### PR TITLE
Multi choice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can also create your own template from scratch:
 
 - All template files will be piped through Handlebars for simple templating - `vue-cli` will automatically infer the prompts based on `{{}}` interpolations found in the files.
 
-- A template repo **may** have a `meta.json` file that provides a schema for the prompts. The schema will be passed to [inquirer](https://github.com/SBoudrias/Inquirer.js). See [example](https://github.com/vuejs-templates/webpack/blob/master/meta.json). We only support `string` and `boolean` types at the moment.
+- A template repo **may** have a `meta.json` file that provides a schema for the prompts. The schema will be passed to [inquirer](https://github.com/SBoudrias/Inquirer.js). See [example](https://github.com/vuejs-templates/webpack/blob/master/meta.json). We support `string`, `boolean` and `checkbox` (for multi choice) types.
 
 While developing your template you can test via `vue-cli` with:
 

--- a/bin/vue-init
+++ b/bin/vue-init
@@ -142,12 +142,21 @@ function ask (files, metalsmith, done) {
     var prompt = opts.schema[key]
 
     inquirer.prompt([{
-      type: promptInquirerTypeMapping[prompt.type],
+      type: promptInquirerTypeMapping[prompt.type] || prompt.type,
       name: key,
       message: prompt.label || key,
-      default: prompt.default
+      default: prompt.default,
+      choices: prompt.choices || []
     }], function (answers) {
-      metalsmithMetadata[key] = answers[key]
+      if (Array.isArray(answers[key])) {
+        metalsmithMetadata[key] = {}
+        answers[key].forEach(function (multiChoiceAnswer) {
+          metalsmithMetadata[key][multiChoiceAnswer] = true
+        })
+      } else {
+        metalsmithMetadata[key] = answers[key]
+      }
+
       done()
     })
   }


### PR DESCRIPTION
Fixes #5. 

Example `meta.json`

```json
{
  "schema": {
    "name": {
      "type": "string",
      "required": true,
      "label": "Project name"
    },
    "description": {
      "type": "string",
      "required": true,
      "label": "Project description",
      "default": "A Vue.js project"
    },
    "author": {
      "type": "string",
      "label": "Author"
    },
    "private": {
      "type": "boolean",
      "default": true
    },
    "preprocessor": {
      "label": "CSS Preprocessor",
      "type": "checkbox",
      "choices": [
        "less",
        "sass"
      ]
    }
  }
}
```

example `package.json`

```json
{
  "name": "{{ name }}",
  "description": "{{ description }}",
  "author": "{{ author }}",
  {{#private}}
  "private": true,
  {{/private}}
  "scripts": {
    "watchify": "watchify -vd -p browserify-hmr -e src/main.js -o dist/build.js",
    "serve": "http-server -c 1 -a localhost",
    "dev": "npm-run-all --parallel watchify serve",
    "build": "cross-env NODE_ENV=production browserify src/main.js | uglifyjs -c warnings=false -m > dist/build.js"
  },
  "dependencies": {
    "vue": "^1.0.0"
  },
  "devDependencies": {
    {{#preprocessor.less}}
    "less": "^2.6.1",
    {{/preprocessor.less}}
    {{#preprocessor.sass}}
    "node-sass": "^3.4.2",
    {{/preprocessor.sass}}
    "babel-core": "^6.0.0",
    "babel-plugin-transform-runtime": "^6.0.0",
    "babel-preset-es2015": "^6.0.0",
    "babel-preset-stage-2": "^6.0.0",
    "babel-runtime": "^5.8.0",
    "cross-env": "^1.0.6",
    "babelify": "^7.2.0",
    "browserify": "^12.0.1",
    "browserify-hmr": "^0.3.1",
    "http-server": "^0.9.0",
    "npm-run-all": "^1.6.0",
    "uglify-js": "^2.5.0",
    "vue-hot-reload-api": "^1.2.2",
    "vueify": "^8.0.0",
    "vueify-insert-css": "^1.0.0",
    "watchify": "^3.4.0"
  },
  "browserify": {
    "transform": [
      "vueify",
      "babelify"
    ]
  }
}
```

It would probably make sense to document this feature a bit more in readme.