### PR TITLE
enforce minimum node version 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple CLI for scaffolding Vue.js projects.
 
 ### Installation
 
-Prerequisites: [Node.js](https://nodejs.org/en/) (>5.x preferred) and [Git](https://git-scm.com/).
+Prerequisites: [Node.js](https://nodejs.org/en/) (>=4.x, 5.x preferred) and [Git](https://git-scm.com/).
 
 ``` bash
 $ npm install -g vue-cli

--- a/lib/check-version.js
+++ b/lib/check-version.js
@@ -1,15 +1,30 @@
 var request = require('request')
 var semver = require('semver')
 var chalk = require('chalk')
+var packageConfig = require('../package.json')
 
 module.exports = function (done) {
+  // Parse version number from strings such as 'v4.2.0' or `>=4.0.0'
+  function parseVersionNumber (versionString) {
+    return parseFloat(versionString.replace(/[^\d\.]/g, ''))
+  }
+
+  // Ensure minimum supported node version is used
+  var minNodeVersion = parseVersionNumber(packageConfig.engines.node)
+  var currentNodeVersion = parseVersionNumber(process.version)
+  if (minNodeVersion > currentNodeVersion) {
+    return console.log(chalk.red(
+      '  You must upgrade node to >=' + minNodeVersion + '.x to use vue-cli'
+    ))
+  }
+
   request({
     url: 'https://registry.npmjs.org/vue-cli',
     timeout: 1000
   }, function (err, res, body) {
     if (!err && res.statusCode === 200) {
       var latestVersion = JSON.parse(body)['dist-tags'].latest
-      var localVersion = require('../package.json').version
+      var localVersion = packageConfig.version
       if (semver.lt(localVersion, latestVersion)) {
         console.log(chalk.yellow('  A newer version of vue-cli is available.'))
         console.log()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A simple CLI for scaffolding Vue.js projects.",
   "preferGlobal": true,
   "bin": {
@@ -55,5 +55,8 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
     "mocha": "^2.4.5"
+  },
+  "engines" : {
+    "node" : ">=4.0.0"
   }
 }


### PR DESCRIPTION
Forces upgrade to a minimum node version that's compatible with metalsmith. Resolves #81.