### PR TITLE
Wrong directory name

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,9 @@
 {
   "extends": "standard",
+  "env": {
+    "mocha": true,
+    "node": true
+  },
   "rules": {
     "arrow-parens": [2, "as-needed"]
   }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -34,7 +34,7 @@ module.exports = function generate (name, src, dest, done) {
   var opts = getOptions(name, src)
   var metalsmith = Metalsmith(path.join(src, 'template'))
   // extract all gathered data from user and override project name with destination directory name
-  var data = extend({}, metalsmith.metadata(), { name: name })
+  var data = extend({}, metalsmith.metadata(), { destDirName: name })
   // avoid handlebars escaping HTML
   data.noEscape = true
   metalsmith

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -6,6 +6,7 @@ var path = require('path')
 var getOptions = require('./options')
 var ask = require('./ask')
 var filter = require('./filter')
+var extend = Object.assign || require('util')._extend
 
 // register hendlebars helper
 Handlebars.registerHelper('if_eq', function (a, b, opts) {
@@ -32,7 +33,8 @@ Handlebars.registerHelper('unless_eq', function (a, b, opts) {
 module.exports = function generate (name, src, dest, done) {
   var opts = getOptions(name, src)
   var metalsmith = Metalsmith(path.join(src, 'template'))
-  var data = metalsmith.metadata()
+  // extract all gathered data from user and override project name with destination directory name
+  var data = extend({}, metalsmith.metadata(), { name: name })
   // avoid handlebars escaping HTML
   data.noEscape = true
   metalsmith

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -13,7 +13,7 @@ const generate = require('../../lib/generate')
 const MOCK_TEMPLATE_REPO_PATH = './test/e2e/mock-template-repo'
 const MOCK_TEMPLATE_BUILD_PATH = path.resolve('./test/e2e/mock-template-build')
 
-function monkeyPatchInquirer(answers) {
+function monkeyPatchInquirer (answers) {
   // monkey patch inquirer
   inquirer.prompt = (questions, cb) => {
     const key = questions[0].name
@@ -25,7 +25,7 @@ function monkeyPatchInquirer(answers) {
     }
     _answers[key] = answers[key]
     cb(_answers)
-  };
+  }
 }
 
 describe('vue-cli', () => {
@@ -95,7 +95,7 @@ describe('vue-cli', () => {
     var invalidName = extend({}, answers, {name: 'INVALID-NAME'})
     monkeyPatchInquirer(invalidName)
     generate('INVALID-NAME', MOCK_TEMPLATE_REPO_PATH, MOCK_TEMPLATE_BUILD_PATH, err => {
-      expect(err).to.be.an('error');
+      expect(err).to.be.an('error')
       done()
     })
   })


### PR DESCRIPTION
Fixes #86.

Although I was thinking we might rather do this

```js
var data = extend({}, metalsmith.metadata(), { destDirName: name })
```

and also update https://github.com/vuejs-templates/webpack/blob/dist/meta.json to use `destDirName` inside `completeMessage`.