### PR TITLE
Windows fix for local templates.

### DIFF
--- a/bin/vue-init
+++ b/bin/vue-init
@@ -90,7 +90,7 @@ if (exists(to)) {
 
 function run () {
   // check if template is local
-  if (hasSlash && exists(template)) {
+  if (exists(template)) {
     generate(name, template, to, function (err) {
       if (err) logger.fatal(err)
       console.log()


### PR DESCRIPTION
No need to check for forward slash when checking if path is local.

Fixes #104.