### PR TITLE
Better local template handling with Windows compatability

### DIFF
--- a/bin/vue-init
+++ b/bin/vue-init
@@ -64,7 +64,7 @@ process.on('exit', function () {
 var template = program.args[0]
 var hasSlash = template.indexOf('/') > -1
 var rawName = program.args[1]
-var templatePath = path.normalize(path.join(process.cwd(), template))
+var templatePath = exists(template) ? template : path.normalize(path.join(process.cwd(), template))
 var inPlace = !rawName || rawName === '.'
 var name = inPlace ? path.relative('../', process.cwd()) : rawName
 var to = path.resolve(rawName || '.')

--- a/bin/vue-init
+++ b/bin/vue-init
@@ -64,6 +64,7 @@ process.on('exit', function () {
 var template = program.args[0]
 var hasSlash = template.indexOf('/') > -1
 var rawName = program.args[1]
+var templatePath = path.normalize(path.join(process.cwd(), template))
 var inPlace = !rawName || rawName === '.'
 var name = inPlace ? path.relative('../', process.cwd()) : rawName
 var to = path.resolve(rawName || '.')
@@ -91,8 +92,8 @@ if (exists(to)) {
 
 function run () {
   // check if template is local
-  if (hasSlash && exists(template)) {
-    generate(name, template, to, function (err) {
+  if (exists(templatePath)) {
+    generate(name, templatePath, to, function (err) {
       if (err) logger.fatal(err)
       console.log()
       logger.success('Generated "%s".', name)


### PR DESCRIPTION
Windows users have trouble using local templates when the the previous solution only checked for slash and not backslash or `path.sep`. With this new approach mac, linux and windows users can also use relative paths to the template:

``` shell
   vue init ./myTemplate projectName
```

or

``` shell
   vue init ../myTemplatesFolder/myTemplate projectName
```

Tested on Mac osx with node 6.2.2 both from local build and globally installed build, as well as Windows 8 with node 6.7.0 from local build.
