### PR TITLE
Fix bin not exist when installed via yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A simple CLI for scaffolding Vue.js projects.",
   "preferGlobal": true,
   "bin": {
-    "vue": "bin/vue"
+    "vue": "bin/vue",
+    "vue-init": "bin/vue-init",
+    "vue-list": "bin/vue-list"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A simple CLI for scaffolding Vue.js projects.",
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
`yarn` will link bin files in `package.json`.

This should fix #205 and #193.

Besides, due to `yarn` cached installed packages, if you have installed `vue-cli` before, please remove them from `.yarn-cache` and re-install it again.