### PR TITLE
FIXES #230: `npm install` after `vue init` fails if git user name has "-s

### DIFF
--- a/lib/git-user.js
+++ b/lib/git-user.js
@@ -9,7 +9,7 @@ module.exports = function () {
     email = exec('git config --get user.email')
   } catch (e) {}
 
-  name = name && name.toString().trim()
+  name = name && name.toString().trim().replace(/"/g,'\\"')
   email = email && (' <' + email.toString().trim() + '>')
   return (name || '') + (email || '')
 }


### PR DESCRIPTION
FIXES #230: `npm install` after `vue init` fails if git user name has double quotes in it

Issue URL : https://github.com/vuejs/vue-cli/issues/230