### PR TITLE
Minor improvements for 2.x warning

### DIFF
--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -12,7 +12,7 @@ module.exports = {
   v2BranchIsNowDefault: function (template, name) {
     var vue1InitCommand = 'vue init ' + template + '#1.0' + ' ' + name
 
-    console.log(chalk.red('  This will install Vue 2.x version of template.'))
+    console.log(chalk.green('  This will install Vue 2.x version of the template.'))
     console.log()
     console.log(chalk.yellow('  For Vue 1.x use: ') + chalk.green(vue1InitCommand))
     console.log()


### PR DESCRIPTION
There are two problems (IMHO at least) with the current 2.x "warning":

* It's not an error per se, more like an information, so I changed the color to green instead of red.
* Grammar.

Since both happen in one line, I decided to merge them into one commit.