### PR TITLE
Change to test that checks if template is local

### DIFF
--- a/bin/vue-init
+++ b/bin/vue-init
@@ -91,7 +91,7 @@ if (exists(to)) {
 
 function run () {
   // check if template is local
-  if (/^[./]|(\w:)/.test(template)) {
+  if (/^\.{1,2}\/|^\w:|^\//.test(template)) {
     var templatePath = template.charAt(0) === '/' || /^\w:/.test(template)
       ? template
       : path.normalize(path.join(process.cwd(), template))


### PR DESCRIPTION
I'm having issues similar to those raised here [https://github.com/vuejs/vue-cli/issues/283](url)

When using a local gitlab repo, I am seeing the following error:

> vue-cli · Local template "gitlab:git.company.com:User/webpack-simple" not found.

The fix suggested in the issue that was raised was to change the test that checks if the template is local to:

`/^\.{1,2}\/|^\w:|^\//.test(template) ` 

I have tested this and it appears to fix the problem, since there doesn't appear to be a PR for this, I thought I would raise one.

Hope this is ok.