### PR TITLE
Make it work with vue-play

### DIFF
--- a/bin/vue-build
+++ b/bin/vue-build
@@ -287,18 +287,6 @@ if (production) {
     }))
   }
 } else {
-  if (!options.watch) {
-    webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin())
-    var hmrEntries = options.hmrEntries || ['client']
-    var hmrClient = require.resolve('webpack-hot-middleware/client') + `?reload=true&path=http://${options.host}:${options.port}/__webpack_hmr`
-    hmrEntries.forEach(name => {
-      if (Array.isArray(webpackConfig.entry[name])) {
-        webpackConfig.entry[name].unshift(hmrClient)
-      } else {
-        webpackConfig.entry[name] = [hmrClient, webpackConfig.entry[name]]
-      }
-    })
-  }
   webpackConfig.devtool = 'eval-source-map'
   webpackConfig.plugins.push(
     new FriendlyErrorsPlugin(),
@@ -327,6 +315,19 @@ if (!options.disableWebpackConfig) {
       webpackConfig = webpackMerge.smart(webpackConfig, require(localWebpackConfigPath))
     }
   }
+}
+
+if (!options.watch && !options.production) {
+  webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin())
+  var hmrEntries = options.hmrEntries || ['client']
+  var hmrClient = require.resolve('webpack-hot-middleware/client') + `?reload=true&path=http://${options.host}:${options.port}/__webpack_hmr`
+  hmrEntries.forEach(name => {
+    if (Array.isArray(webpackConfig.entry[name])) {
+      webpackConfig.entry[name].unshift(hmrClient)
+    } else {
+      webpackConfig.entry[name] = [hmrClient, webpackConfig.entry[name]]
+    }
+  })
 }
 
 // only check entry when there's no custom config

--- a/bin/vue-build
+++ b/bin/vue-build
@@ -66,6 +66,7 @@ var options = merge({
   host: 'localhost'
 }, localConfig, {
   entry: args[0],
+  config: program.config,
   port: program.port,
   host: program.host,
   open: program.open,

--- a/bin/vue-build
+++ b/bin/vue-build
@@ -219,6 +219,10 @@ if (options.mount === undefined && !options.lib && /\.vue$/.test(options.entry))
 if (options.mount) {
   webpackConfig.entry.client.push(ownDir('lib/default-entry.es6'))
   webpackConfig.resolve.alias['your-tasteful-component'] = cwd(options.entry)
+} else if (Array.isArray(options.entry)) {
+  webpackConfig.entry.client = options.client
+} else if (typeof options.entry === 'object') {
+  webpackConfig.entry = options.entry
 } else {
   webpackConfig.entry.client.push(options.entry)
 }

--- a/bin/vue-build
+++ b/bin/vue-build
@@ -81,7 +81,7 @@ var options = merge({
 })
 
 function help () {
-  if (!options.run && !options.entry) {
+  if (!options.config && !options.entry) {
     return program.help()
   }
 }
@@ -232,12 +232,16 @@ if (options.lib) {
   webpackConfig.output.libraryTarget = 'umd'
 } else {
   // only output index.html in non-lib mode
-  webpackConfig.plugins.unshift(
-    new HtmlWebpackPlugin(Object.assign({
-      title: 'Vue App',
-      template: ownDir('lib/template.html')
-    }, options.html))
-  )
+  var html = Array.isArray(options.html) ? options.html : [options.html || {}]
+
+  html.forEach(item => {
+    webpackConfig.plugins.unshift(
+      new HtmlWebpackPlugin(Object.assign({
+        title: 'Vue App',
+        template: ownDir('lib/template.html')
+      }, item))
+    )
+  })
 }
 
 // installed by `yarn global add`
@@ -284,7 +288,15 @@ if (production) {
 } else {
   if (!options.watch) {
     webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin())
-    webpackConfig.entry.client.unshift(require.resolve('webpack-hot-middleware/client') + `?reload=true&path=http://${options.host}:${options.port}/__webpack_hmr`)
+    var hmrEntries = options.hmrEntries || ['client']
+    var hmrClient = require.resolve('webpack-hot-middleware/client') + `?reload=true&path=http://${options.host}:${options.port}/__webpack_hmr`
+    hmrEntries.forEach(name => {
+      if (Array.isArray(webpackConfig.entry[name])) {
+        webpackConfig.entry[name].unshift(hmrClient)
+      } else {
+        webpackConfig.entry[name] = [hmrClient, webpackConfig.entry[name]]
+      }
+    })
   }
   webpackConfig.devtool = 'eval-source-map'
   webpackConfig.plugins.push(
@@ -316,8 +328,8 @@ if (!options.disableWebpackConfig) {
   }
 }
 
-// only check entry when there's no custom `run` process
-if (!options.run && !fs.existsSync(options.entry)) {
+// only check entry when there's no custom config
+if (!options.config && !fs.existsSync(options.entry)) {
   logger.fatal(`${chalk.yellow(options.entry)} does not exist, did you forget to create one?`)
 }
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -143,7 +143,7 @@ PostCSS options, if it's an `Array` or `Function`, the default value will be ove
 
 #### html
 
-Type: `Object`
+Type: `Object` `Array`
 
 [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) options, use this option to customize `index.html` output, default value:
 
@@ -175,6 +175,13 @@ Set custom filename for `js` `css` `static` files:
 Type: `boolean`
 
 In production mode, all generated files will be compressed and produce sourcemaps file. You can use `--disableCompress` to disable this behavior.
+
+#### hmrEntries
+
+Type: `Array`<br>
+Default: `['client']`
+
+Add `webpack-hot-middleware` HMR client to specific webpack entries. By default your app is loaded in `client` entry, so we insert it here.
 
 #### proxy
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -80,9 +80,15 @@ You can define CLI options in this file.
 
 #### entry
 
-Type: `string`
+Type: `string` `Array` `Object`
 
 It's the first argument of `vue build` command, eg: `vue build entry.js`. You can set it here to omit it in CLI arguments.
+
+The single-component mode (`--mount`) will not work if you set `entry` to an `Array` or `Object`.
+
+- `Array`: Override `webpackConfig.entry.client`
+- `Object`: Override `webpackConfig.entry`
+- `string`: Added to `webpackConfig.entry.client` or used as `webpackConfig.resolve.alias['your-tasteful-component']` in single-component mode.
 
 #### port
 


### PR DESCRIPTION
To make it work with vue-play, we need to change the webpack config in config.js to something like:

```js
module.exports = {
  entry: {
    app: './play/app.js',
    preview: './play/preview.js'
  },
  // add hmr client to these entries
  hmrEntries: ['app', 'preview'],
  // produce html files for these entries
  html: [
    {title: 'Vue-Play Panel', chunks: ['app']},
    {title: 'Vue-Play Preview', chunks: ['preview'], filename: 'preview.html'}
  ]
}
```

And this PR allows:

- `options.entry` to be undefined if using `--config`
- `options.html` can be an array
- use `options.hmrEntries` to add hmr client