### PR TITLE
Use github personal access token if provided in env

### DIFF
--- a/bin/vue-list
+++ b/bin/vue-list
@@ -18,8 +18,8 @@ process.on('exit', function () {
  */
 var auth
 
-if (process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
-  auth = { bearer: process.env.GITHUB_PERSONAL_ACCESS_TOKEN }
+if (process.env.GITHUB_TOKEN) {
+  auth = { bearer: process.env.GITHUB_TOKEN }
 }
 
 request({

--- a/bin/vue-list
+++ b/bin/vue-list
@@ -16,12 +16,18 @@ process.on('exit', function () {
 /**
  * List repos.
  */
+var auth
+
+if (process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
+  auth = { bearer: process.env.GITHUB_PERSONAL_ACCESS_TOKEN }
+}
 
 request({
   url: 'https://api.github.com/users/vuejs-templates/repos',
   headers: {
     'User-Agent': 'vue-cli'
-  }
+  },
+  auth: auth
 }, function (err, res, body) {
   if (err) logger.fatal(err)
   var requestBody = JSON.parse(body)


### PR DESCRIPTION
This PR includes
- Use `GITHUB_PERSONAL_ACCESS_TOKEN` if defined in `env`

Fixes #368 