### PR TITLE
Make prompts when support function.

### DIFF
--- a/lib/ask.js
+++ b/lib/ask.js
@@ -32,11 +32,9 @@ module.exports = function ask (prompts, data, done) {
  */
 
 function prompt (data, key, prompt, done) {
-  // skip prompts whose when condition is not met
-  if (prompt.when && !evaluate(prompt.when, data)) {
+  if (prompt.when && !(typeof prompt.when === 'function' ? prompt.when(data) : evaluate(prompt.when, data))) {
     return done()
   }
-
   var promptDefault = prompt.default
   if (typeof prompt.default === 'function') {
     promptDefault = function () {

--- a/test/e2e/mock-metadata-repo-js/meta.js
+++ b/test/e2e/mock-metadata-repo-js/meta.js
@@ -12,6 +12,19 @@ module.exports = {
       validate: function (input) {
         return input === 'custom' ? 'can not input `custom`' : true
       }
+    },
+    q1: {
+      type: 'list',
+      required: true,
+      label: 'Which choice?',
+      choices: ['a1', 'a2']
+    },
+    q2: {
+      when: function (answers) {
+        return answers.q1 === 'a1'
+      },
+      label: 'Which choice',
+      type: 'confirm'
     }
   },
   helpers: {

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -240,7 +240,7 @@ describe('vue-cli', () => {
     monkeyPatchInquirer(collectQa2)
     ask(meta.prompts, data2, function () {
       expect(data2).to.not.have.property('q2')
-      })
+    })
   })
   it('points out the file in the error', done => {
     monkeyPatchInquirer(answers)

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -225,7 +225,7 @@ describe('vue-cli', () => {
     expect(getTemplatePath('../template')).to.equal(path.join(__dirname, '/../../../template'))
   })
 
-  it.only('"when" set function', () => {
+  it('"when" set function', () => {
     var meta = require(path.join(MOCK_METADATA_REPO_JS_PATH, 'meta.js'))
 
     var collectQa1 = extend({}, answers, { q1: 'a1', q2: 'aq2' })

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -11,6 +11,7 @@ const extend = Object.assign || require('util')._extend
 const generate = require('../../lib/generate')
 const metadata = require('../../lib/options')
 const { isLocalPath, getTemplatePath } = require('../../lib/local-path')
+const ask = require('../../lib/ask')
 
 const MOCK_META_JSON_PATH = path.resolve('./test/e2e/mock-meta-json')
 const MOCK_TEMPLATE_REPO_PATH = path.resolve('./test/e2e/mock-template-repo')
@@ -222,5 +223,22 @@ describe('vue-cli', () => {
 
     expect(getTemplatePath('..')).to.equal(path.join(__dirname, '/../../..'))
     expect(getTemplatePath('../template')).to.equal(path.join(__dirname, '/../../../template'))
+  })
+
+  it.only('"when" set function', () => {
+    var meta = require(path.join(MOCK_METADATA_REPO_JS_PATH, 'meta.js'))
+
+    var collectQa1 = extend({}, answers, { q1: 'a1', q2: 'aq2' })
+    monkeyPatchInquirer(collectQa1)
+    var data = {}
+    ask(meta.prompts, data, function () {
+      expect(data).to.have.property('q2')
+    })
+    var data2 = {}
+    var collectQa2 = extend({}, answers, { q1: 'a2', q2: 'aq2' })
+    monkeyPatchInquirer(collectQa2)
+    ask(meta.prompts, data2, function () {
+      expect(data2).to.not.have.property('q2')
+    })
   })
 })


### PR DESCRIPTION
Now  we only set prompts __when__ is an attribute from the other prompts , and the prompt must be a  boolean . but sometimes we want set the __when__ to a special value,  when a prompt choice the value , we return a boolean.  
so I resolve this problem; I through this example to illustrate;

previously , we can only set prompt like this
```js
q1: {
  type: 'confirm',
  require: true,
  message: 'this is a question?',
  default: true
},
q2: {
  when: 'q1',
  type: 'list',
  message: 'Which choice ?',
  choices:[] // some choices
}
```
If __q1__ is not a _confirm_ , it is a _list_, like this 
```js
q1: {
  type: 'list',
  message: 'make choice?',
  choices:['c1','c2'] // some choices
},
q2: {
  when: ????,
  type: 'list',
  message: 'Which choice ?',
  choices:[] // some choices
}
```
now  we want to when __q1__ choice _c1_ , then ask __q2__, otherwise do not ask __q2__;

so  when  should like __inquirer__ to support set _function_ value to __when__

we can set like this:
```js
q1: {
  type: 'list',
  message: 'make choice?',
  choices:['c1','c2'] // some choices
},
q2: {
  when: function(answers){
    return answers.q1 === 'c1';
  },
  type: 'list',
  message: 'Which choice ?',
  choices:[] // some choices
}
```

