### PR TITLE
Escape double quotes in string prompts

### DIFF
--- a/lib/ask.js
+++ b/lib/ask.js
@@ -57,6 +57,8 @@ function prompt (data, key, prompt, done) {
       answers[key].forEach(function (multiChoiceAnswer) {
         data[key][multiChoiceAnswer] = true
       })
+    } else if (typeof answers[key] == "string"){
+      data[key] = answers[key].replace(/"/g, '\\"')
     } else {
       data[key] = answers[key]
     }

--- a/lib/ask.js
+++ b/lib/ask.js
@@ -57,7 +57,7 @@ function prompt (data, key, prompt, done) {
       answers[key].forEach(function (multiChoiceAnswer) {
         data[key][multiChoiceAnswer] = true
       })
-    } else if (typeof answers[key] == "string"){
+    } else if (typeof answers[key] === 'string') {
       data[key] = answers[key].replace(/"/g, '\\"')
     } else {
       data[key] = answers[key]

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -34,9 +34,6 @@ function monkeyPatchInquirer (answers) {
 }
 
 describe('vue-cli', () => {
-  /* eslint-disable quotes */
-  const escapedAuthor = "John \"The Tester\" Doe <john@doe.com>"
-
   const escapedAnswers = {
     name: 'vue-cli-test',
     author: 'John "The Tester" Doe <john@doe.com>',
@@ -130,7 +127,7 @@ describe('vue-cli', () => {
       const pkg = fs.readFileSync(`${MOCK_TEMPLATE_BUILD_PATH}/package.json`, 'utf8')
       try {
         var validData = JSON.parse(pkg)
-        expect(validData.author).to.equal(escapedAuthor)
+        expect(validData.author).to.equal(escapedAnswers.author)
         done()
       } catch (err) {
         done(err)

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -34,6 +34,22 @@ function monkeyPatchInquirer (answers) {
 }
 
 describe('vue-cli', () => {
+  /* eslint-disable quotes */
+  const escapedAuthor = "John \"The Tester\" Doe <john@doe.com>"
+
+  const escapedAnswers = {
+    name: 'vue-cli-test',
+    author: 'John "The Tester" Doe <john@doe.com>',
+    description: 'vue-cli e2e test',
+    preprocessor: {
+      less: true,
+      sass: true
+    },
+    pick: 'no',
+    noEscape: true
+
+  }
+
   const answers = {
     name: 'vue-cli-test',
     author: 'John Doe <john@doe.com>',
@@ -103,6 +119,22 @@ describe('vue-cli', () => {
           next()
         })
       }, done)
+    })
+  })
+
+  it('generate a vaild package.json with escaped author', done => {
+    monkeyPatchInquirer(escapedAnswers)
+    generate('test', MOCK_TEMPLATE_REPO_PATH, MOCK_TEMPLATE_BUILD_PATH, err => {
+      if (err) done(err)
+
+      const pkg = fs.readFileSync(`${MOCK_TEMPLATE_BUILD_PATH}/package.json`, 'utf8')
+      try {
+        var validData = JSON.parse(pkg)
+        expect(validData.author).to.equal(escapedAuthor)
+        done()
+      } catch (err) {
+        done(err)
+      }
     })
   })
 


### PR DESCRIPTION
This fixes #382.
It checks if the answer type is `string`, and if it is, `replace`s `"` with `\"`, so it can be parsed as valid JSON.