### PR TITLE
Add filename when in handlebars errors

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -115,7 +115,10 @@ function renderTemplateFiles (skipInterpolation) {
         return next()
       }
       render(str, metalsmithMetadata, function (err, res) {
-        if (err) return next(err)
+        if (err) {
+          err.message = `[${file}] ${err.message}`
+          return next(err)
+        }
         files[file].contents = new Buffer(res)
         next()
       })

--- a/test/e2e/mock-error/meta.js
+++ b/test/e2e/mock-error/meta.js
@@ -1,0 +1,9 @@
+module.exports = {
+  prompts: {
+    name: {
+      type: 'string',
+      required: true,
+      message: 'Name'
+    }
+  }
+}

--- a/test/e2e/mock-error/template/readme.md
+++ b/test/e2e/mock-error/template/readme.md
@@ -1,0 +1,1 @@
+{{error,name}}

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -17,6 +17,7 @@ const MOCK_TEMPLATE_REPO_PATH = path.resolve('./test/e2e/mock-template-repo')
 const MOCK_TEMPLATE_BUILD_PATH = path.resolve('./test/e2e/mock-template-build')
 const MOCK_METADATA_REPO_JS_PATH = path.resolve('./test/e2e/mock-metadata-repo-js')
 const MOCK_SKIP_GLOB = path.resolve('./test/e2e/mock-skip-glob')
+const MOCK_ERROR = path.resolve('./test/e2e/mock-error')
 
 function monkeyPatchInquirer (answers) {
   // monkey patch inquirer
@@ -222,5 +223,13 @@ describe('vue-cli', () => {
 
     expect(getTemplatePath('..')).to.equal(path.join(__dirname, '/../../..'))
     expect(getTemplatePath('../template')).to.equal(path.join(__dirname, '/../../../template'))
+  })
+
+  it.only('points out the file in the error', done => {
+    monkeyPatchInquirer(answers)
+    generate('test', MOCK_ERROR, MOCK_TEMPLATE_BUILD_PATH, err => {
+      expect(err.message).to.match(/^\[readme\.md\] Parse error/)
+      done()
+    })
   })
 })


### PR DESCRIPTION
When handlebars gives an error, it doesn't contain the filename that is actually producing the error.
Should help solve problems like #401 

Instead of 

```
Parse error on line 21
```

We now have

```
[readme.md] Parse error on line 21
```

@egoist @zigomir Feel free to modify how the filename is included in the error message