### PR TITLE
Add filter support for optional questions

### DIFF
--- a/lib/ask.js
+++ b/lib/ask.js
@@ -34,6 +34,8 @@ module.exports = function ask (prompts, data, done) {
 function prompt (data, key, prompt, done) {
   // skip prompts whose when condition is not met
   if (prompt.when && !evaluate(prompt.when, data)) {
+    // set undefined value to avoid failure on filter evaluations
+    data[key] = undefined
     return done()
   }
 


### PR DESCRIPTION
undefined value is now defined in metalsmith metadata when meta.js "when" property returns false. This makes the filter evaluation works for filters using data that have been skipped in the prompt workflow by using the default value of the field.

Close #408