### PR TITLE
Fixes: cloning with colons

### DIFF
--- a/bin/vue-init
+++ b/bin/vue-init
@@ -14,6 +14,7 @@ var generate = require('../lib/generate')
 var checkVersion = require('../lib/check-version')
 var warnings = require('../lib/warnings')
 var { isLocalPath, getTemplatePath } = require('../lib/local-path')
+var rm = require("rimraf").sync
 
 /**
  * Usage.
@@ -61,11 +62,13 @@ var name = inPlace ? path.relative('../', process.cwd()) : rawName
 var to = path.resolve(rawName || '.')
 var clone = program.clone || false
 
-var tmp = path.join(home, '.vue-templates', template.replace(/\//g, '-'))
+var tmp = path.join(home, '.vue-templates', template.replace(/\/|:/g, '-'))
 if (program.offline) {
   console.log(`> Use cached template at ${chalk.yellow(tildify(tmp))}`)
   template = tmp
 }
+
+console.log(tmp)
 
 /**
  * Padding.
@@ -148,6 +151,7 @@ function downloadAndGenerate (template) {
       if (err) logger.fatal(err)
       console.log()
       logger.success('Generated "%s".', name)
+      rm(tmp)
     })
   })
 }

--- a/bin/vue-init
+++ b/bin/vue-init
@@ -14,7 +14,7 @@ var generate = require('../lib/generate')
 var checkVersion = require('../lib/check-version')
 var warnings = require('../lib/warnings')
 var { isLocalPath, getTemplatePath } = require('../lib/local-path')
-var rm = require("rimraf").sync
+var rm = require('rimraf').sync
 
 /**
  * Usage.

--- a/bin/vue-init
+++ b/bin/vue-init
@@ -68,8 +68,6 @@ if (program.offline) {
   template = tmp
 }
 
-console.log(tmp)
-
 /**
  * Padding.
  */

--- a/bin/vue-init
+++ b/bin/vue-init
@@ -14,7 +14,6 @@ var generate = require('../lib/generate')
 var checkVersion = require('../lib/check-version')
 var warnings = require('../lib/warnings')
 var { isLocalPath, getTemplatePath } = require('../lib/local-path')
-var rm = require('rimraf').sync
 
 /**
  * Usage.
@@ -149,7 +148,6 @@ function downloadAndGenerate (template) {
       if (err) logger.fatal(err)
       console.log()
       logger.success('Generated "%s".', name)
-      rm(tmp)
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "consolidate": "^0.14.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",
-    "download-git-repo": "^1.0.0",
+    "download-git-repo": "^0.2.1",
     "express": "^4.14.0",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "consolidate": "^0.14.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",
-    "download-git-repo": "^0.2.1",
+    "download-git-repo": "^1.0.0",
     "express": "^4.14.0",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",


### PR DESCRIPTION
This fixes two issues:

- When using a repo like _bitbucket:local.url.com:org/name_ in vue init, the temp directory made would have multiple colons in it, this caused git to fatal.