### PR TITLE
clean cached template in downloadandgenerate

### DIFF
--- a/bin/vue-init
+++ b/bin/vue-init
@@ -142,7 +142,7 @@ function run () {
 function downloadAndGenerate (template) {
   var spinner = ora('downloading template')
   spinner.start()
-  // check if template is local
+  // Remove if local template exists
   if (exists(tmp)) rm(tmp)
   download(template, tmp, { clone: clone }, function (err) {
     spinner.stop()

--- a/bin/vue-init
+++ b/bin/vue-init
@@ -9,6 +9,7 @@ var home = require('user-home')
 var tildify = require('tildify')
 var chalk = require('chalk')
 var inquirer = require('inquirer')
+var rm = require('rimraf').sync
 var logger = require('../lib/logger')
 var generate = require('../lib/generate')
 var checkVersion = require('../lib/check-version')
@@ -141,6 +142,8 @@ function run () {
 function downloadAndGenerate (template) {
   var spinner = ora('downloading template')
   spinner.start()
+  // check if template is local
+  if (exists(tmp)) rm(tmp)
   download(template, tmp, { clone: clone }, function (err) {
     spinner.stop()
     if (err) logger.fatal('Failed to download repo ' + template + ': ' + err.message.trim())

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postcss-loader": "^1.2.1",
     "read-metadata": "^1.0.0",
     "request": "^2.67.0",
-    "rimraf": "^2.5.0",
+    "rimraf": "^2.6.1",
     "semver": "^5.1.0",
     "tildify": "^1.2.0",
     "url-loader": "^0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,7 +4610,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.0:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.0, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:


### PR DESCRIPTION
Remove the currently cached template when we are doing a download and generate.  

This helps to resolve #403 where using the --clone flag with private repos fails when the cached template directory already exists.

It also helps resolve #409 where init results in a template that is outdated.