### PR TITLE
Add lib gracefulFs

### DIFF
--- a/bin/vue-build
+++ b/bin/vue-build
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 var fs = require('fs')
+var gracefulFs = require('graceful-fs')
+gracefulFs.gracefulify(fs)
 var path = require('path')
 var program = require('commander')
 var chalk = require('chalk')

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
     "execa": "^0.5.0",
+    "graceful-fs": "^4.1.11",
     "mocha": "^2.4.5"
   },
   "engines": {


### PR DESCRIPTION
**Issue:** EMFILE: too many open files" on Windows while running build on large project

graceful-fs functions as a drop-in replacement for the fs module, making various improvements.

The improvements are meant to normalize behavior across different platforms and environments, and to make filesystem access more resilient to errors.

See [this issue](https://github.com/kevlened/copy-webpack-plugin/issues/59#issuecomment-228563990) for more details
