### PR TITLE
update inquirer to 3.1.1 for node 8+

### DIFF
--- a/lib/ask.js
+++ b/lib/ask.js
@@ -51,7 +51,7 @@ function prompt (data, key, prompt, done) {
     default: promptDefault,
     choices: prompt.choices || [],
     validate: prompt.validate || function () { return true }
-  }], function (answers) {
+  }]).then(function (answers) {
     if (Array.isArray(answers[key])) {
       data[key] = {}
       answers[key].forEach(function (multiChoiceAnswer) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "handlebars": "^4.0.5",
     "html-webpack-plugin": "^2.26.0",
     "http-proxy-middleware": "^0.17.3",
-    "inquirer": "^0.12.0",
+    "inquirer": "^3.1.1",
     "installed-by-yarn-globally": "^0.1.1",
     "metalsmith": "^2.1.0",
     "minimatch": "^3.0.0",


### PR DESCRIPTION
inquirer@0.12.0 inquirer.prompt is not work in node v8.1.0;
With node v8.1.0 run `vue init pwa pwa`, enter the name after the stuck, and then no response