### PR TITLE
Auto correct default names

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -14,7 +14,7 @@ const validateName = require('validate-npm-package-name')
 module.exports = function options (name, dir) {
   const opts = getMetadata(dir)
 
-  setDefault(opts, 'name', name)
+  setDefault(opts, 'name', name.toLowerCase().replace(/\s/g,''))
   setValidateName(opts)
 
   const author = getGitUser()

--- a/lib/options.js
+++ b/lib/options.js
@@ -14,7 +14,7 @@ const validateName = require('validate-npm-package-name')
 module.exports = function options (name, dir) {
   const opts = getMetadata(dir)
 
-  setDefault(opts, 'name', name.toLowerCase().replace(/\s/g,''))
+  setDefault(opts, 'name', name.toLowerCase().replace(/\s/g, ''))
   setValidateName(opts)
 
   const author = getGitUser()


### PR DESCRIPTION
Names containing spaces and capitals will not pass validation so correct them for default name suggestion. Alternatively this could be changed to convert the name to kebab case.