### PR TITLE
docs: drop support for node 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple CLI for scaffolding Vue.js projects.
 
 ### Installation
 
-Prerequisites: [Node.js](https://nodejs.org/en/) (>=6.x, 4.x preferred), npm version 3+ and [Git](https://git-scm.com/).
+Prerequisites: [Node.js](https://nodejs.org/en/) (>=6.x, 8.x preferred), npm version 3+ and [Git](https://git-scm.com/).
 
 ``` bash
 $ npm install -g vue-cli

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple CLI for scaffolding Vue.js projects.
 
 ### Installation
 
-Prerequisites: [Node.js](https://nodejs.org/en/) (>=4.x, 6.x preferred), npm version 3+ and [Git](https://git-scm.com/).
+Prerequisites: [Node.js](https://nodejs.org/en/) (>=6.x, 4.x preferred), npm version 3+ and [Git](https://git-scm.com/).
 
 ``` bash
 $ npm install -g vue-cli


### PR DESCRIPTION
The codebase is being modernized and the cli no longer works with node 4. 8 being stable, I think it's safe to drop support for version 4