### PR TITLE
Changed coffee-script to coffeescript in the package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,9 +469,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "coffee-script": {
+    "coffeescript": {
       "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
     "color-convert": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "uid": "0.0.2",
     "user-home": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
-    "coffee-script": "1.12.7"
+    "coffeescript": "1.12.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
I recently installed vue-cli on a new machine and noticed a warning about the `coffee-script` package name being deprecated in favor of `coffeescript`.

(It's also in `gray-matter` but I left that one alone).

