### PR TITLE
Rename coffee-script to coffeescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -474,6 +474,11 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
+    "coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
+    },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "uid": "0.0.2",
     "user-home": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
-    "coffee-script": "1.12.7"
+    "coffeescript": "1.12.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
More information about this rename in here:
https://github.com/jashkenas/coffeescript/issues/4714

This will remove the warning that appears upon installation to rename coffee-script to coffeescript