### PR TITLE
Update coffeescript package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "uid": "0.0.2",
     "user-home": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
-    "coffee-script": "1.12.7"
+    "coffeescript": "1.12.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
```
npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
```
