### PR TITLE
Update Node.js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple CLI for scaffolding Vue.js projects.
 
 ### Installation
 
-Prerequisites: [Node.js](https://nodejs.org/en/) (>=4.x, 6.x preferred), npm version 3+ and [Git](https://git-scm.com/).
+Prerequisites: [Node.js](https://nodejs.org/en/) (>=6.x), npm version 3+ and [Git](https://git-scm.com/).
 
 ``` bash
 $ npm install -g vue-cli


### PR DESCRIPTION
There is a 'let' expression outside of the strict mode in the bin/vue-init file, which makes Node.js(4.x) unsupported.