### PR TITLE
fix typo {mdoule => module}

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -26,7 +26,7 @@ module.exports = (context, options = {}) => {
   }
   // cli-plugin-jest sets this to true because Jest runs without bundling
   if (process.env.VUE_CLI_BABEL_TRANSPILE_MODULES) {
-    envOptions.mdoules = true
+    envOptions.modules = true
   }
 
   // pass options along to babel-preset-env

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -33,7 +33,7 @@ exports.defaults = {
   // boolean, use full build?
   compiler: false,
 
-  // apply css modules to CSS files that doesn't end with .mdoule.css?
+  // apply css modules to CSS files that doesn't end with .module.css?
   cssModules: false,
 
   // vue-loader options


### PR DESCRIPTION
This fixes a typo in setting babel env options and in a comment.