### PR TITLE
compatible with safari 10

### DIFF
--- a/packages/@vue/cli-service/lib/config/uglifyOptions.js
+++ b/packages/@vue/cli-service/lib/config/uglifyOptions.js
@@ -30,6 +30,9 @@ module.exports = options => ({
       conditionals: true,
       dead_code: true,
       evaluate: true
+    },
+    mangle: {
+      safari10: true
     }
   },
   sourceMap: options.productionSourceMap,


### PR DESCRIPTION
According to [this issue](https://github.com/mishoo/UglifyJS2/issues/1753), if we do not add the line of `mangle safari 10`, it will cause vue pages become blank page on iOS 10.