### PR TITLE
fix:misspell

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -56,7 +56,7 @@ program
 
 program
   .command('serve [entry]')
-  .description('serve a .js or vue file in development mode with zero config')
+  .description('serve a .js or .vue file in development mode with zero config')
   .option('-o, --open', 'Open browser')
   .action((entry, cmd) => {
     loadCommand('serve', '@vue/cli-service-global').serve(entry, cleanArgs(cmd))


### PR DESCRIPTION
vue -h 
```
serve a .js or vue file in development mode with zero config
```
to
```
serve a .js or .vue file in development mode with zero config
```
Added a point, same to description of build command.
