### PR TITLE
Master

### DIFF
--- a/bin/vue-init
+++ b/bin/vue-init
@@ -65,7 +65,7 @@ const name = inPlace ? path.relative('../', process.cwd()) : rawName
 const to = path.resolve(rawName || '.')
 const clone = program.clone || false
 
-const tmp = path.join(home, '.vue-templates', template.replace(/\//g, '-'))
+const tmp = path.join(home, '.vue-templates', template.replace(/\/:/g, '-'))
 if (program.offline) {
   console.log(`> Use cached template at ${chalk.yellow(tildify(tmp))}`)
   template = tmp

--- a/bin/vue-init
+++ b/bin/vue-init
@@ -65,7 +65,7 @@ const name = inPlace ? path.relative('../', process.cwd()) : rawName
 const to = path.resolve(rawName || '.')
 const clone = program.clone || false
 
-const tmp = path.join(home, '.vue-templates', template.replace(/\/:/g, '-'))
+const tmp = path.join(home, '.vue-templates', template.replace(/[\/:]/g, '-'))
 if (program.offline) {
   console.log(`> Use cached template at ${chalk.yellow(tildify(tmp))}`)
   template = tmp


### PR DESCRIPTION
This bug appear in the Windows.

When i type such as `vue init gitlab:http://192.168.116.62:10080:vues/simple-cli demo --clone`， it try to  create a folder named `C:\\Users\\Administrator\\.vue-templates\\gitlab:http:--192.168.116.62:10080:vues-simple-cli` or a template cache.

The colon is not allowd in the Windows System，so the child_process `git clone` return 'status 128' for this input.
