### PR TITLE
Add example of baseUrl in vue.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ module.exports = {
   configureWebpack: {
     // ...
   }
+  
+  // extra webpack parameters
+  baseUrl: '/' // default value
 }
 ```
 


### PR DESCRIPTION
It took me time until I found https://github.com/vuejs/vue-cli/issues/787
So probably add the extra params in the readme could be and easy way.
I perfectly understand if you don't want to included. It's just a suggestion.
If you find a better way I will be happy to contribute.

Thanks for the hard work.