### PR TITLE
feat: allow access to dev server through reverse proxy

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -129,6 +129,7 @@ module.exports = (api, options) => {
 
       const server = new WebpackDevServer(compiler, Object.assign({
         clientLogLevel: 'none',
+        disableHostCheck: true,
         historyApiFallback: {
           disableDotRule: true
         },


### PR DESCRIPTION
`disableHostCheck` should be set to `true` to allow access to dev server through a reverse proxy.