### PR TITLE
fix(request): Change axios lib for request

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     ]
   },
   "devDependencies": {
-    "axios": "^0.17.1",
     "babel-core": "^7.0.0-0",
     "debug": "^3.1.0",
     "eslint": "^4.16.0",
@@ -54,6 +53,8 @@
     "lint-staged": "^6.0.1",
     "memfs": "^2.6.0",
     "puppeteer": "^1.0.0",
+    "request": "^2.83.0",
+    "request-promise-native": "^1.0.5",
     "yorkie": "^1.0.2"
   }
 }

--- a/packages/@vue/cli/lib/util/getVersions.js
+++ b/packages/@vue/cli/lib/util/getVersions.js
@@ -8,15 +8,15 @@ module.exports = async function getVersions () {
     // test/debug, use local version
     latest = process.env.VUE_CLI_LATEST_VERSION = current
   } else {
-    const axios = require('axios')
+    const request = require('./request')
     const options = require('../options').loadOptions()
     const registry = options.useTaobaoRegistry
       ? `https://registry.npm.taobao.org`
       : `https://registry.npmjs.org`
 
-    const res = await axios.get(`${registry}/vue-cli-version-marker/latest`)
-    if (res.status === 200) {
-      latest = process.env.VUE_CLI_LATEST_VERSION = res.data.version
+    const res = await request.get(`${registry}/vue-cli-version-marker/latest`)
+    if (res.statusCode === 200) {
+      latest = process.env.VUE_CLI_LATEST_VERSION = res.body.version
     } else {
       // fallback to local version
       latest = process.env.VUE_CLI_LATEST_VERSION = current

--- a/packages/@vue/cli/lib/util/installDeps.js
+++ b/packages/@vue/cli/lib/util/installDeps.js
@@ -1,4 +1,4 @@
-const axios = require('axios')
+const request = require('./request')
 const chalk = require('chalk')
 const execa = require('execa')
 const readline = require('readline')
@@ -16,7 +16,7 @@ const registries = {
 const taobaoDistURL = 'https://npm.taobao.org/dist'
 
 async function ping (registry) {
-  await axios.get(`${registry}/vue-cli-version-marker/latest`)
+  await request.get(`${registry}/vue-cli-version-marker/latest`)
   return registry
 }
 

--- a/packages/@vue/cli/lib/util/request.js
+++ b/packages/@vue/cli/lib/util/request.js
@@ -1,0 +1,14 @@
+const request = require('request-promise-native')
+
+module.exports = {
+  async get (uri) {
+    const reqOpts = {
+      method: 'GET',
+      resolveWithFullResponse: true,
+      json: true,
+      uri
+    }
+
+    return request(reqOpts)
+  }
+}

--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@vue/cli-shared-utils": "^3.0.0-alpha.11",
-    "axios": "^0.17.1",
     "chalk": "^2.3.0",
     "commander": "^2.12.2",
     "ejs": "^2.5.7",
@@ -44,6 +43,8 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "recast": "^0.13.0",
+    "request": "^2.83.0",
+    "request-promise-native": "^1.0.5",
     "resolve": "^1.5.0",
     "rimraf": "^2.6.2",
     "semver": "^5.4.1",

--- a/scripts/syncDeps.js
+++ b/scripts/syncDeps.js
@@ -18,27 +18,18 @@ const localPackageRE = /'(@vue\/(?:cli|eslint|babel)[\w-]+)': '\^([\w-.]+)'/g
 
 const versionCache = {}
 
-const getRequest = uri => {
-  request({
-    method: 'GET',
-    resolveWithFullResponse: true,
-    uri
-  })
-}
-
 const getRemoteVersion = async (pkg) => {
   if (versionCache[pkg]) {
     return versionCache[pkg]
   }
   let res
   try {
-    res = await getRequest(`http://registry.npmjs.org/${pkg}/latest`)
+    res = await request(`http://registry.npmjs.org/${pkg}/latest`)
   } catch (e) {
     return
   }
-  const version = res.data.version
-  versionCache[pkg] = version
-  return version
+  versionCache[pkg] = res.version
+  return res.version
 }
 
 const getRemoteVersionSync = pkg => {

--- a/scripts/syncDeps.js
+++ b/scripts/syncDeps.js
@@ -4,7 +4,7 @@
 const fs = require('fs')
 const path = require('path')
 const chalk = require('chalk')
-const axios = require('axios')
+const request = require('request-promise-native')
 const semver = require('semver')
 const globby = require('globby')
 const { execSync } = require('child_process')
@@ -18,13 +18,21 @@ const localPackageRE = /'(@vue\/(?:cli|eslint|babel)[\w-]+)': '\^([\w-.]+)'/g
 
 const versionCache = {}
 
+const getRequest = uri => {
+  request({
+    method: 'GET',
+    resolveWithFullResponse: true,
+    uri
+  })
+}
+
 const getRemoteVersion = async (pkg) => {
   if (versionCache[pkg]) {
     return versionCache[pkg]
   }
   let res
   try {
-    res = await axios.get(`http://registry.npmjs.org/${pkg}/latest`)
+    res = await getRequest(`http://registry.npmjs.org/${pkg}/latest`)
   } catch (e) {
     return
   }


### PR DESCRIPTION
Closes #785

Axios has a [known issue](https://github.com/axios/axios/issues/658)
that causes requests to hang when accessing an HTTPS resource via a
proxy served over HTTP.  This changes out the axios dependency for the
[request](https://github.com/request/request) library. In order to keep
`async/await` conventions easy, I also dropped in the
[request-promise-native](https://github.com/request/request-promise-native)
dependency.