### PR TITLE
Add missing "EOT" (upper case) font extension.

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -79,7 +79,7 @@ module.exports = (api, options) => {
 
     webpackConfig.module
       .rule('fonts')
-        .test(/\.(woff2?|EOT|eot|ttf|otf)(\?.*)?$/)
+        .test(/\.(woff2?|eot|ttf|otf)(\?.*)?$/i)
         .use('url-loader')
           .loader('url-loader')
           .options({

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -79,7 +79,7 @@ module.exports = (api, options) => {
 
     webpackConfig.module
       .rule('fonts')
-        .test(/\.(woff2?|eot|ttf|otf)(\?.*)?$/)
+        .test(/\.(woff2?|EOT|eot|ttf|otf)(\?.*)?$/)
         .use('url-loader')
           .loader('url-loader')
           .options({


### PR DESCRIPTION
I have EOT (upper cased) fonts in my project, which currently cause the compilation process to fail with vue-cli 3 alpha 11. This PR fixes the problem.
