### PR TITLE
Fixed update info's formatting.

### DIFF
--- a/packages/@vue/cli/lib/util/clearConsole.js
+++ b/packages/@vue/cli/lib/util/clearConsole.js
@@ -16,9 +16,9 @@ module.exports = async function clearConsoleWithTitle (checkUpdate) {
   }
   if (checkUpdate && semver.gt(latest, current)) {
     title += chalk.green(`
-┌─────────────────────────${`─`.repeat(latest.length)}─┐
+┌─────────────────────────${`─`.repeat(latest.length + 2)}─┐
 │ ✨  Update available: ${latest} ✨  │
-└─────────────────────────${`─`.repeat(latest.length)}─┘`)
+└─────────────────────────${`─`.repeat(latest.length + 2)}─┘`)
   }
 
   clearConsole(title)


### PR DESCRIPTION
Before the prompt for new available update looked like this

┌─────────────────┐
│ ✨  Update available: 3.0.0-alpha.13 ✨  │
└─────────────────┘

After 

┌──────────────────┐
│ ✨  Update available: 3.0.0-alpha.13 ✨  │
└──────────────────┘