### PR TITLE
Allow setting `useBuiltIns` to be `false`.

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -17,7 +17,7 @@ module.exports = (context, options = {}) => {
   const envOptions = {
     modules: options.modules || false,
     targets: options.targets,
-    useBuiltIns: options.useBuiltIns || 'usage'
+    useBuiltIns: typeof options.useBuiltIns === 'undefined' ? 'usage' : options.useBuiltIns
   }
   delete envOptions.jsx
   // target running node version (this is set by unit testing plugins)


### PR DESCRIPTION
Because if you set `useBuiltIns` to false we'll always fallback to `'usage'`.