### PR TITLE
Add default <noscript> content

### DIFF
--- a/packages/@vue/cli-service/generator/template/public/index.html
+++ b/packages/@vue/cli-service/generator/template/public/index.html
@@ -8,6 +8,9 @@
     <title><%= options.projectName %></title>
   </head>
   <body>
+    <noscript>
+      <strong>We're sorry but <%= options.projectName %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>


### PR DESCRIPTION
Add some default content that can be seen by browsers where JavaScript
is disabled. See:
https://developers.google.com/web/tools/lighthouse/audits/no-js

Closes #854