### PR TITLE
Output help information on unknown CLI commands

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -87,6 +87,15 @@ program
     loadCommand('init', '@vue/cli-init')
   })
 
+// output help information on unknown commands
+program
+  .arguments('<command>')
+  .action((cmd) => {
+    program.outputHelp()
+    console.log(`  ` + chalk.red(`Unknown command ${chalk.yellow(cmd)}.`))
+    console.log()
+  })
+
 // add some useful info on help
 program.on('--help', () => {
   console.log()


### PR DESCRIPTION
resolves #849.
I read quick through the dependency `commander.js`'s README and source code, finding that it hasn't implemented this yet. Here is a workaround, but I am not sure if it has a side effect.