### PR TITLE
Might be useful

### DIFF
--- a/docs/cli-service.md
+++ b/docs/cli-service.md
@@ -83,7 +83,8 @@ module.exports = {
     proxy: {
       '/api': {
         target: '<url>',
-        ws: true
+        ws: true,
+        changeOrigin: true
       },
       '/foo': {
         target: '<other_url>'


### PR DESCRIPTION
Certainly not required, but knowing the `changeOrigin` option is available straight from your docs (as opposed to http-proxy-middleware's docs) might save devs some time.