### PR TITLE
fix(request): dev server behind NAT network

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -58,7 +58,7 @@ module.exports = (api, options) => {
       if (!isProduction) {
         const devClients = [
           // dev server client
-          require.resolve(`webpack-dev-server/client`) + `?${urls.localUrlForBrowser}`,
+          require.resolve(`webpack-dev-server/client`),
           // hmr client
           require.resolve(projectDevServerOptions.hotOnly
             ? 'webpack/hot/only-dev-server'


### PR DESCRIPTION
(#828)Webpack dev client could not work when server is behind NAT network.
This is because localUrlForBrowser is not equal to server's public url.

Now, without passing localUrlForBrowser to dev client, the dev client tries to connect to browser's window.location.