### PR TITLE
Upgrade cypress and properly set base url (resolve #847)

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/generator/template/test/e2e/specs/test.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/generator/template/test/e2e/specs/test.js
@@ -2,7 +2,7 @@
 
 describe('My First Test', () => {
   it('Visits the Kitchen Sink', () => {
-    cy.visit(Cypress.env('VUE_DEV_SERVER_URL'))
+    cy.visit('/')
     cy.contains('h1', 'Welcome to Your Vue.js <%- hasTS ? '+ TypeScript ' : '' %>App')
   })
 })

--- a/packages/@vue/cli-plugin-e2e-cypress/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/index.js
@@ -24,7 +24,7 @@ module.exports = (api, options) => {
 
       const cyArgs = [
         command, // open or run
-        '--env', `VUE_DEV_SERVER_URL=${url}`,
+        '--config', `baseUrl=${url}`,
         ...rawArgs
       ]
 

--- a/packages/@vue/cli-plugin-e2e-cypress/package.json
+++ b/packages/@vue/cli-plugin-e2e-cypress/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "cypress": "^1.4.1",
+    "cypress": "^2.0.3",
     "eslint-plugin-cypress": "^2.0.1"
   }
 }


### PR DESCRIPTION
The major version bump in Cypress doesn't include any configuration-related breaking changes. [See here](https://docs.cypress.io/guides/references/changelog.html#2-0-0) for details.