### PR TITLE
Fix typo in plugin name

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -122,7 +122,7 @@ module.exports = (api, options) => {
     // fails to resolve a loader, so we provide custom handlers to improve it
     const { transformer, formatter } = require('../webpack/resolveLoaderError')
     webpackConfig
-      .plugin('firendly-errors')
+      .plugin('friendly-errors')
         .use(require('friendly-errors-webpack-plugin'), [{
           additionalTransformers: [transformer],
           additionalFormatters: [formatter]


### PR DESCRIPTION
Just a small typo in the naming of a webpack-chain plugin option:

`firendly-errors` => `friendly-errors`