### PR TITLE
Don't swallow vue.config.js errors (fixes #874)

### DIFF
--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -160,7 +160,7 @@ module.exports = class Service {
       process.env.VUE_CLI_SERVICE_CONFIG_PATH ||
       path.resolve(this.context, 'vue.config.js')
     )
-    try {
+    if (fs.existsSync(configPath)) {
       fileConfig = require(configPath)
       if (!fileConfig || typeof fileConfig !== 'object') {
         error(
@@ -168,7 +168,7 @@ module.exports = class Service {
         )
         fileConfig = null
       }
-    } catch (e) {}
+    }
 
     // package.vue
     pkgConfig = this.pkg.vue


### PR DESCRIPTION
I assumed the try/catch was only to avoid an error if `vue.config.js` didn't exist. This should accomplish the same, but still provide useful error output in cases of a syntax or runtime error in this file.