### PR TITLE
Add docs build mode env

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -37,6 +37,12 @@ Note that a mode is different from `NODE_ENV`, as a mode can contain multiple en
 
 You can set environment variables only available to a certain mode by postfixing the `.env` file. For example, if you create a file named `.env.development` in your project root, then the variables declared in that file will only be loaded in development mode.
 
+Passing the `--mode` option flag with [build command](https://github.com/vuejs/vue-cli/blob/dev/docs/cli-service.md#build) will use that mode's environment variables in the build. For example, if you want to use development variables in the build command, add this to your package.json scripts:
+
+```
+"dev-build": "vue-cli-service build --mode development",
+```
+
 ### Using Env Variables in Client-side Code
 
 Only variables that start with `VUE_APP_` will be statically embedded into the client bundle with `webpack.DefinePlugin`. You can access them in your application code:

--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -46,11 +46,11 @@ module.exports = (api, options) => {
 
     log()
     if (args.target === 'app') {
-      logWithSpinner(`Building for production...`)
+      logWithSpinner(`Building for ${args.mode}...`)
     } else {
       const buildMode = buildModes[args.target]
       if (buildMode) {
-        logWithSpinner(`Building for production as ${buildMode}...`)
+        logWithSpinner(`Building for ${args.mode} as ${buildMode}...`)
       } else {
         throw new Error(`Unknown build target: ${args.target}`)
       }


### PR DESCRIPTION
Hiyya!

I ran into a need to use development environment variables in a build (specifically, needing to use a development API server on our development app server). Eventually I connected the dots, but thought it would be useful to add to the docs.

Additionally, even when running in development mode, the "Building for.." message was hard coded to display "production", added in the `arg.mode` variable.

Let me know if you have any questions! First PR really with an open source project :)