### PR TITLE
fix(TypeScript e2e): end to end test(s) folder

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -112,7 +112,7 @@ module.exports = (api, {
   // delete all js files that have a ts file of the same name
   // and simply rename other js files to ts
   const jsRE = /\.js$/
-  const excludeRE = /^test\/e2e\/|\.config\.js$/
+  const excludeRE = /^tests\/e2e\/|\.config\.js$/
   const convertLintFlags = require('../lib/convertLintFlags')
   api.postProcessFiles(files => {
     for (const file in files) {


### PR DESCRIPTION
There was one more typo with the "test" folder regarding
e2e. It was preventing cypress from running properly.