### PR TITLE
fix: fix vue-cli-service build

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -18,7 +18,8 @@ module.exports = (api, options) => {
       '--mode': `specify env mode (default: ${defaults.mode})`,
       '--dest': `specify output directory (default: ${options.outputDir})`,
       '--target': `app | lib | wc | wc-async (default: ${defaults.target})`,
-      '--name': `name for lib or web-component mode (default: "name" in package.json or entry filename)`
+      '--name': `name for lib or web-component mode (default: "name" in package.json or entry filename)`,
+      '--silent': `run without printing status log`
     }
   }, args => {
     args.entry = args.entry || args._[0]


### PR DESCRIPTION
add --silent option for ignore printing status log