### PR TITLE
fix(cli-plugin-pwa): Set cacheid in GenerateSW mode only

### DIFF
--- a/packages/@vue/cli-plugin-pwa/index.js
+++ b/packages/@vue/cli-plugin-pwa/index.js
@@ -24,15 +24,20 @@ module.exports = (api, options) => {
         )
       }
 
-      const workBoxConfig = Object.assign({
-        cacheId: name,
+      const defaultOptions = {
         exclude: [
           /\.map$/,
           /img\/icons\//,
           /favicon\.ico$/,
           /manifest\.json$/
         ]
-      }, userOptions.workboxOptions)
+      }
+
+      const defaultGenerateSWOptions = workboxPluginMode === 'GenerateSW' ? {
+        cacheId: name
+      } : {}
+
+      const workBoxConfig = Object.assign(defaultOptions, defaultGenerateSWOptions, userOptions.workboxOptions)
 
       webpackConfig
         .plugin('workbox')


### PR DESCRIPTION
This PR fixes https://github.com/vuejs/vue-cli/issues/891. 