### PR TITLE
Use same Puppeteer like in main package.json

### DIFF
--- a/packages/@vue/cli-test-utils/launchPuppeteer.js
+++ b/packages/@vue/cli-test-utils/launchPuppeteer.js
@@ -9,7 +9,7 @@ module.exports = async function launchPuppeteer (url) {
   const page = await browser.newPage()
 
   const logs = []
-  page.on('console', msg => logs.push(msg.text))
+  page.on('console', msg => logs.push(msg.text()))
 
   await page.goto(url)
 

--- a/packages/@vue/cli-test-utils/package.json
+++ b/packages/@vue/cli-test-utils/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "execa": "^0.8.0",
-    "puppeteer": "^0.13.0"
+    "puppeteer": "^1.0.0"
   }
 }


### PR DESCRIPTION
This prevent download two version of Puppeteer. I can not run test properly even without this change, so I do not know if this can break anything.