### PR TITLE
Make experimentalCompileTsWithBabel compatible with vue.config.js

### DIFF
--- a/packages/@vue/cli-plugin-typescript/__tests__/tsPluginExpDecorators.spec.js
+++ b/packages/@vue/cli-plugin-typescript/__tests__/tsPluginExpDecorators.spec.js
@@ -1,0 +1,14 @@
+jest.setTimeout(30000)
+
+const { assertServe, assertBuild } = require('./tsPlugin.helper')
+
+const options = {
+  plugins: {
+    '@vue/cli-plugin-typescript': {
+      experimentalCompileTsWithBabel: true
+    }
+  }
+}
+
+assertServe('ts-default-serve', options)
+assertBuild('ts-default-build', options)

--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -23,7 +23,9 @@ module.exports = (api, {
         '@babel/preset-typescript': '7 || ^7.0.0-beta || ^7.0.0-rc'
       },
       vue: {
-        experimentalCompileTsWithBabel: true
+        pluginOptions: {
+          experimentalCompileTsWithBabel
+        }
       },
       babel: {
         presets: ['@babel/typescript', '@vue/app']

--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -1,7 +1,7 @@
 module.exports = (api, {
   parallel,
   lintOnSave,
-  experimentalCompileTsWithBabel
+  pluginOptions
 }) => {
   const fs = require('fs')
   const useThreads = process.env.NODE_ENV === 'production' && parallel
@@ -54,7 +54,7 @@ module.exports = (api, {
       })
     }
 
-    if (!experimentalCompileTsWithBabel) {
+    if (!(pluginOptions && pluginOptions.experimentalCompileTsWithBabel)) {
       if (api.hasPlugin('babel')) {
         addLoader({
           loader: 'babel-loader'


### PR DESCRIPTION
The schema of `vue.config.js` is very specific in what it can accept.
For instance, it can accept custom options only in the `pluginOptions` param.
I put the `experimentalCompileTsWithBabel` back in it's place