### PR TITLE
Document themeColor and msTileColor in @vue/cli-plugin-pwa

### DIFF
--- a/packages/@vue/cli-plugin-pwa/README.md
+++ b/packages/@vue/cli-plugin-pwa/README.md
@@ -42,6 +42,8 @@ module.exports = {
       swSrc: 'dev/sw.js',
       // ...other Workbox options...
     },
+    themeColor: '#4DBA87',
+    msTileColor: '#000000',
   },
 };
 ```

--- a/packages/@vue/cli-plugin-pwa/README.md
+++ b/packages/@vue/cli-plugin-pwa/README.md
@@ -36,16 +36,17 @@ file, or the `"vue"` field in `package.json`.
 module.exports = {
   // ...other vue-cli plugin options...
   pwa: {
+    name: 'My App', // used for apple-mobile-web-app-title
+    themeColor: '#4DBA87',
+    msTileColor: '#000000',
     workboxPluginMode: 'InjectManifest',
     workboxOptions: {
       // swSrc is required in InjectManifest mode.
       swSrc: 'dev/sw.js',
       // ...other Workbox options...
-    },
-    themeColor: '#4DBA87',
-    msTileColor: '#000000',
-  },
-};
+    }
+  }
+}
 ```
 
 ## Installing in an Already Created Project


### PR DESCRIPTION
If these options aren't set, HtmlPwaPlugin will use the default Vue colors for populating index.html, which wasn't otherwise obvious to me as I had already set them in manifest.json. Thanks!