### PR TITLE
Use `esnext` targets for downleveling and modules.

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "<%- options.useTsWithBabel ? 'es2015' : 'es5' %>",
-    "module": "es2015",
+    "target": "<%- options.useTsWithBabel ? 'esnext' : 'es5' %>",
+    "module": "esnext",
     "strict": true,
     "jsx": "preserve",
     "moduleResolution": "node",


### PR DESCRIPTION
This gives you

1. Babel's downleveling for ESNext-style constructs if enabled.
2. The ability to use `import()` expressions.