### PR TITLE
Update Cypress test.js test it block description

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/specs/test.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/specs/test.js
@@ -1,7 +1,7 @@
 // https://docs.cypress.io/api/introduction/api.html
 
 describe('My First Test', () => {
-  it('Visits the Kitchen Sink', () => {
+  it('Visits the app root url', () => {
     cy.visit('/')
     cy.contains('h1', 'Welcome to Your Vue.js <%- hasTS ? '+ TypeScript ' : '' %>App')
   })


### PR DESCRIPTION
The Cypress initial test visits Cypress's sample app, Kitchen Sink.  It seems for the initial Vue app, it should visit the app root url (or home/main/first page?).