### PR TITLE
feat(e2e nightwatch): allow setting cli `config` option.

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/index.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/index.js
@@ -31,17 +31,20 @@ module.exports = (api, options) => {
     return serverPromise.then(({ server, url }) => {
       // expose dev server url to tests
       process.env.VUE_DEV_SERVER_URL = url
-      // expose user options to config file
-      const fs = require('fs')
-      let userOptionsPath, userOptions
-      if (fs.existsSync(userOptionsPath = api.resolve('nightwatch.config.js'))) {
-        userOptions = require(userOptionsPath)
-      } else if (fs.existsSync(userOptionsPath = api.resolve('nightwatch.json'))) {
-        userOptions = require(userOptionsPath)
+      if (rawArgs.indexOf('--config') === -1) {
+        // expose user options to config file
+        const fs = require('fs')
+        let userOptionsPath, userOptions
+        if (fs.existsSync(userOptionsPath = api.resolve('nightwatch.config.js'))) {
+          userOptions = require(userOptionsPath)
+        } else if (fs.existsSync(userOptionsPath = api.resolve('nightwatch.json'))) {
+          userOptions = require(userOptionsPath)
+        }
+        process.env.VUE_NIGHTWATCH_USER_OPTIONS = JSON.stringify(userOptions || {})
+  
+        rawArgs.push('--config', require.resolve('./nightwatch.config.js'))
       }
-      process.env.VUE_NIGHTWATCH_USER_OPTIONS = JSON.stringify(userOptions || {})
 
-      rawArgs.push('--config', require.resolve('./nightwatch.config.js'))
       if (rawArgs.indexOf('--env') === -1) {
         rawArgs.push('--env', 'chrome')
       }


### PR DESCRIPTION
Hi,
This allow to run e2e with a custom config file `vue-cli-service e2e --config nightwatch.config.js` instead of using the internal Nightwatch config.

My use-cases is using e2e nightwatch with a custom integration like [nightwatch-cucumber](https://github.com/mucsi96/nightwatch-cucumber) which seems not working with the default behavior.

```js
// nightwatch.config.js
require('nightwatch-cucumber')({}) // is ignored when using the internal Nightwatch config.
module.exports = {
  ...
}
```

Thanks!