### PR TITLE
Minor doc change:  Show example in Advanced Webpack config section

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -93,7 +93,9 @@ module.exports = {
 }
 ```
 
-For example say you want to change the default location of index.html from */Users/username/proj/public/index.html* to */Users/username/proj/app/templates/index.html*.  By referencing [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin#options) you can see a list of options you can pass in. To change our template path we simply pass in a new template path like:
+You will need to familiarize yourself with [webpack-chain's API](https://github.com/mozilla-neutrino/webpack-chain#getting-started) and [read some source code](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-service/lib/config) in order to understand how to leverage the full power of this option, but it gives you a more expressive and safer way to modify the webpack config than directly mutation values.
+
+For example, say you want to change the default location of index.html from */Users/username/proj/public/index.html* to */Users/username/proj/app/templates/index.html*.  By referencing [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin#options) you can see a list of options you can pass in. To change our template path we can pass in a new template path with the following config:
 
 ``` js
 // vue.config.js
@@ -109,12 +111,7 @@ module.exports = {
 }
 ```
 
-You can confirm that this change has taken place by examining the vue webpack config with the **vue inspect** utility.
-
-```vue inspect > output.js```
-
-
-You will need to familiarize yourself with [webpack-chain's API](https://github.com/mozilla-neutrino/webpack-chain#getting-started) and [read some source code](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-service/lib/config) in order to understand how to leverage the full power of this option, but it gives you a more expressive and safer way to modify the webpack config than directly mutation values.
+You can confirm that this change has taken place by examining the vue webpack config with the **vue inspect** utility, which we will discuss next.
 
 ### Inspecting the Project's Webpack Config
 

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -102,9 +102,8 @@ module.exports = {
     config
       .plugin('html')
       .tap(args => {
-        return [{
-          template: '/Users/username/proj/app/templates/index.html'
-        }]
+        args[0].template = '/Users/username/proj/app/templates/index.html'
+        return args
       })
   }
 }

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -93,6 +93,28 @@ module.exports = {
 }
 ```
 
+For example say you want to change the default location of index.html from */Users/username/proj/public/index.html* to */Users/username/proj/app/templates/index.html*.  By referencing [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin#options) you can see a list of options you can pass in. To change our template path we simply pass in a new template path like:
+
+``` js
+// vue.config.js
+module.exports = {
+  chainWebpack: config => {
+    config
+      .plugin('html')
+      .tap(args => {
+        return [{
+          template: '/Users/username/proj/app/templates/index.html'
+        }]
+      })
+  }
+}
+```
+
+You can confirm that this change has taken place by examining the vue webpack config with the **vue inspect** utility.
+
+```vue inspect > output.js```
+
+
 You will need to familiarize yourself with [webpack-chain's API](https://github.com/mozilla-neutrino/webpack-chain#getting-started) and [read some source code](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-service/lib/config) in order to understand how to leverage the full power of this option, but it gives you a more expressive and safer way to modify the webpack config than directly mutation values.
 
 ### Inspecting the Project's Webpack Config


### PR DESCRIPTION
Even though this should have been obvious I had a bit of trouble figuring this out today so I figured I'd update the docs to help others.  

I wasn't sure if it made sense to leave the original generic example in place or remove it... so I left it in place and added example below.   I'm more than happy to update as necessary based on feedback.

Thanks