### PR TITLE
feat(invoke): allow invoke to replace/rename/delete files

### DIFF
--- a/packages/@vue/cli/__tests__/invoke.spec.js
+++ b/packages/@vue/cli/__tests__/invoke.spec.js
@@ -128,3 +128,12 @@ extends:
   - '@vue/airbnb'
 `.trim())
 })
+
+test('invoking a plugin that renames files', async () => {
+  const project = await create(`invoke-rename`, { plugins: {}})
+  const pkg = JSON.parse(await project.read('package.json'))
+  pkg.devDependencies['@vue/cli-plugin-typescript'] = '*'
+  await project.write('package.json', JSON.stringify(pkg, null, 2))
+  await project.run(`${require.resolve('../bin/vue')} invoke typescript -d`)
+  expect(project.has('src/main.js')).toBe(false)
+})

--- a/packages/@vue/cli/lib/Generator.js
+++ b/packages/@vue/cli/lib/Generator.js
@@ -51,6 +51,8 @@ module.exports = class Generator {
     extractConfigFiles = false,
     checkExisting = false
   } = {}) {
+    // save the file system before applying plugin for comparison
+    const initialFiles = Object.assign({}, this.files)
     // extract configs from package.json into dedicated files.
     this.extractConfigFiles(extractConfigFiles, checkExisting)
     // wait for file resolve
@@ -58,8 +60,8 @@ module.exports = class Generator {
     // set package.json
     this.sortPkg()
     this.files['package.json'] = JSON.stringify(this.pkg, null, 2)
-    // write file tree to disk
-    await writeFileTree(this.context, this.files)
+    // write/update file tree to disk
+    await writeFileTree(this.context, this.files, initialFiles)
   }
 
   extractConfigFiles (extractAll, checkExisting) {

--- a/packages/@vue/cli/lib/util/writeFileTree.js
+++ b/packages/@vue/cli/lib/util/writeFileTree.js
@@ -1,12 +1,26 @@
 const fs = require('fs')
 const path = require('path')
 const { promisify } = require('util')
+const unlink = promisify(fs.unlink)
 const mkdirp = promisify(require('mkdirp'))
 const write = promisify(fs.writeFile)
 
-module.exports = function writeFileTree (dir, files) {
+async function deleteRemovedFiles (directory, newFiles, previousFiles) {
+  // get all files that are not in the new filesystem and are still existing
+  const filesToDelete = Object.keys(previousFiles)
+    .filter(filename => !newFiles[filename])
+
+  // delete each of these files
+  const unlinkPromises = filesToDelete.map(filename => unlink(path.join(directory, filename)))
+  return Promise.all(unlinkPromises)
+}
+
+module.exports = async function writeFileTree (dir, files, previousFiles) {
   if (process.env.VUE_CLI_SKIP_WRITE) {
     return
+  }
+  if (previousFiles) {
+    await deleteRemovedFiles(dir, files, previousFiles)
   }
   return Promise.all(Object.keys(files).map(async (name) => {
     const filePath = path.join(dir, name)


### PR DESCRIPTION
If a plugin is used within the vue create command,
It will be able to delete and rename files.
This is enabling the same tools for invoking 3rd party plugins.

#1048 is solved in this PR