### PR TITLE
Fix(typescript, babel) - Fix tests path for babel and typescript plugins

### DIFF
--- a/packages/@vue/cli-plugin-babel/README.md
+++ b/packages/@vue/cli-plugin-babel/README.md
@@ -6,7 +6,7 @@
 
 Uses Babel 7 + `babel-loader` + [@vue/babel-preset-app](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app) by default, but can be configured via `.babelrc` to use any other Babel presets or plugins.
 
-By default, `babel-loader` is only applied to files inside `src` and `test` directories. If you wish to explicitly transpile a dependency module, you will need to configure webpack in `vue.config.js`:
+By default, `babel-loader` is only applied to files inside `src` and `tests` directories. If you wish to explicitly transpile a dependency module, you will need to configure webpack in `vue.config.js`:
 
 ``` js
 module.exports = {

--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -8,7 +8,7 @@ module.exports = (api, options) => {
         .test(/\.jsx?$/)
         .include
           .add(api.resolve('src'))
-          .add(api.resolve('test'))
+          .add(api.resolve('tests'))
           .end()
         .use('cache-loader')
           .loader('cache-loader')

--- a/packages/@vue/cli-plugin-typescript/README.md
+++ b/packages/@vue/cli-plugin-typescript/README.md
@@ -10,7 +10,7 @@ TypeScript can be configured via `tsconfig.json`.
 
 This plugin can be used alongside `@vue/cli-plugin-babel`. When used with Babel, this plugin will output ES2015 and delegate the rest to Babel for auto polyfill based on browser targets.
 
-By default, `ts-loader` is only applied to files inside `src` and `test` directories. If you wish to explicitly transpile a dependency module, you will need to configure webpack in `vue.config.js`:
+By default, `ts-loader` is only applied to files inside `src` and `tests` directories. If you wish to explicitly transpile a dependency module, you will need to configure webpack in `vue.config.js`:
 
 ``` js
 module.exports = {

--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -21,7 +21,7 @@ module.exports = (api, {
         .test(/\.tsx?$/)
         .include
           .add(api.resolve('src'))
-          .add(api.resolve('test'))
+          .add(api.resolve('tests'))
           .end()
 
     const vueLoader = config.module


### PR DESCRIPTION
Commit 64b45157 changed the test directory but this change was not applied to the babel and typescript plugins.