### PR TITLE
Pass all parameters to onProxyReq in proxy configuration

### DIFF
--- a/packages/@vue/cli-service/lib/util/prepareProxy.js
+++ b/packages/@vue/cli-service/lib/util/prepareProxy.js
@@ -79,7 +79,7 @@ module.exports = function prepareProxy (proxy, appPublicFolder) {
           )
         }
       },
-      onProxyReq(proxyReq, req, res) {
+      onProxyReq (proxyReq, req, res) {
         if (usersOnProxyReq) {
           usersOnProxyReq(proxyReq, req, res)
         }

--- a/packages/@vue/cli-service/lib/util/prepareProxy.js
+++ b/packages/@vue/cli-service/lib/util/prepareProxy.js
@@ -79,9 +79,9 @@ module.exports = function prepareProxy (proxy, appPublicFolder) {
           )
         }
       },
-      onProxyReq (proxyReq) {
+      onProxyReq(proxyReq, req, res) {
         if (usersOnProxyReq) {
-          usersOnProxyReq(proxyReq)
+          usersOnProxyReq(proxyReq, req, res)
         }
         // Browsers may send Origin headers even with same-origin
         // requests. To prevent CORS issues, we have to change


### PR DESCRIPTION
In the current version of vue-cli, one is able to use the `onProxyReq` callback to modify the request. This is useful for adding things such as client IDs and secrets for OAuth when one can't keep them secure client-side.

```js
module.exports = {
  target: process.env.PROXY_URL,
  onProxyReq(proxyReq, req, res) {
    console.log(proxyReq, req, res)
    if (req.path == '/oauth/token') {
      req.body.client_id = process.env.CLIENT_ID
      req.body.client_secret = process.env.CLIENT_SECRET
    }
  },
}
```

The currently tagged beta 6 doesn't use a user-provided `onProxyReq` callback. The dev branch does, but it does not pass all the parameters to it: 

```js
onProxyReq (proxyReq) {
  if (usersOnProxyReq) {
    usersOnProxyReq(proxyReq)
  }
  // ...
},
```

It would be ideal if we could keep this functionality. :-)