### PR TITLE
chore(UI): use computedKeywords to filter the search

### DIFF
--- a/packages/@vue/cli-ui/src/views/ProjectPluginsAdd.vue
+++ b/packages/@vue/cli-ui/src/views/ProjectPluginsAdd.vue
@@ -33,7 +33,7 @@
                     'name',
                     'description'
                   ],
-                  filters: `keywords:vue-cli-plugin`
+                  filters: `computedKeywords:vue-cli-plugin`
                 }"
               >
                 <InstantSearchInput


### PR DESCRIPTION
Both `keywords` and `computedKeywords` work, but `computedKeywords` will make sure this only matches for those with the correct name, not all with that keyword. 

Thanks!

cc @Akryum 