### PR TITLE
Add .swp files to default .gitignore

### DIFF
--- a/packages/@vue/cli-service/generator/template/_gitignore
+++ b/packages/@vue/cli-service/generator/template/_gitignore
@@ -28,3 +28,4 @@ yarn-error.log*
 *.ntvs*
 *.njsproj
 *.sln
+*.swp


### PR DESCRIPTION
.swp files are temporary files generated when a file is open in VIM.
Let's ignore them like the other editors :)