### PR TITLE
Fixing "The new decorators proposal is not supported yet."

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -37,7 +37,8 @@ module.exports = (context, options = {}) => {
   // stage 2. This includes some important transforms, e.g. dynamic import
   // and rest object spread.
   presets.push([require('@babel/preset-stage-2'), {
-    useBuiltIns: true
+    useBuiltIns: true,
+    decoratorsLegacy: true
   }])
 
   // transform runtime, but only for helpers

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -17,8 +17,7 @@ module.exports = (context, options = {}) => {
   const envOptions = {
     modules: options.modules || false,
     targets: options.targets,
-    useBuiltIns: typeof options.useBuiltIns === 'undefined' ? 'usage' : options.useBuiltIns,
-    decoratorsLegacy: options.decoratorsLegacy || false
+    useBuiltIns: typeof options.useBuiltIns === 'undefined' ? 'usage' : options.useBuiltIns
   }
   delete envOptions.jsx
   // target running node version (this is set by unit testing plugins)
@@ -39,7 +38,7 @@ module.exports = (context, options = {}) => {
   // and rest object spread.
   presets.push([require('@babel/preset-stage-2'), {
     useBuiltIns: true,
-    decoratorsLegacy: envOptions.decoratorsLegacy
+    decoratorsLegacy: options.decoratorsLegacy || false
   }])
 
   // transform runtime, but only for helpers

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -17,7 +17,8 @@ module.exports = (context, options = {}) => {
   const envOptions = {
     modules: options.modules || false,
     targets: options.targets,
-    useBuiltIns: typeof options.useBuiltIns === 'undefined' ? 'usage' : options.useBuiltIns
+    useBuiltIns: typeof options.useBuiltIns === 'undefined' ? 'usage' : options.useBuiltIns,
+    decoratorsLegacy: options.decoratorsLegacy || false
   }
   delete envOptions.jsx
   // target running node version (this is set by unit testing plugins)
@@ -38,7 +39,7 @@ module.exports = (context, options = {}) => {
   // and rest object spread.
   presets.push([require('@babel/preset-stage-2'), {
     useBuiltIns: true,
-    decoratorsLegacy: true
+    decoratorsLegacy: envOptions.decoratorsLegacy
   }])
 
   // transform runtime, but only for helpers


### PR DESCRIPTION
Adding option `decoratorsLegacy: true` in `@babel/preset-stage-2` for fixing this error :
```
Module build failed: Error: [BABEL] /path/to/project/src/main.js: The new decorators proposal is not supported yet. You must pass the `"decoratorsLegacy": true` option to @babel/preset-stage-2 (While processing: "/path/to/node_modules/@vue/babel-preset-app/index.js$1")
```