### PR TITLE
fix: Add name to chunk file output (#1167)

### DIFF
--- a/packages/@vue/cli-service/lib/config/prod.js
+++ b/packages/@vue/cli-service/lib/config/prod.js
@@ -5,7 +5,7 @@ module.exports = (api, options) => {
         .devtool('source-map')
         .output
           .filename(`js/[name].[chunkhash:8].js`)
-          .chunkFilename(`js/[id].[chunkhash:8].js`)
+          .chunkFilename(`js/[name].[id].[chunkhash:8].js`)
 
       // keep module.id stable when vendor modules does not change
       webpackConfig


### PR DESCRIPTION
Add [name] to file name build output. This makes chunk name configurable with 
`/* webpackChunkName: "xyz" */`