### PR TITLE
add a --verbose flag to inspect command

### DIFF
--- a/packages/@vue/cli-service/lib/commands/inspect.js
+++ b/packages/@vue/cli-service/lib/commands/inspect.js
@@ -3,7 +3,8 @@ module.exports = (api, options) => {
     description: 'inspect internal webpack config',
     usage: 'vue-cli-service inspect [options] [...paths]',
     options: {
-      '--mode': 'specify env mode (default: development)'
+      '--mode': 'specify env mode (default: development)',
+      '--verbose': 'show full function definitions in output'
     }
   }, args => {
     api.setMode(args.mode || 'development')
@@ -27,13 +28,15 @@ module.exports = (api, options) => {
 
     const pluginRE = /(?:function|class) (\w+Plugin)/
     console.log(stringify(res, (value, indent, stringify) => {
-      if (typeof value === 'function' && value.toString().length > 100) {
-        return `function () { /* omitted long function */ }`
-      }
-      if (value && typeof value.constructor === 'function') {
-        const match = value.constructor.toString().match(pluginRE)
-        if (match) {
-          return `/* ${match[1]} */ ` + stringify(value)
+      if (!args.verbose) {
+        if (typeof value === 'function' && value.toString().length > 100) {
+          return `function () { /* omitted long function */ }`
+        }
+        if (value && typeof value.constructor === 'function') {
+          const match = value.constructor.toString().match(pluginRE)
+          if (match) {
+            return `/* ${match[1]} */ ` + stringify(value)
+          }
         }
       }
       return stringify(value)

--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -66,9 +66,10 @@ program
 program
   .command('inspect [paths...]')
   .option('--mode <mode>')
+  .option('-v --verbose', 'Show full function definitions in output')
   .description('inspect the webpack config in a project with vue-cli-service')
   .action((paths, cmd) => {
-    require('../lib/inspect')(paths, cmd.mode)
+    require('../lib/inspect')(paths, cleanArgs(cmd))
   })
 
 program

--- a/packages/@vue/cli/lib/inspect.js
+++ b/packages/@vue/cli/lib/inspect.js
@@ -3,7 +3,7 @@ const path = require('path')
 const execa = require('execa')
 const resolve = require('resolve')
 
-module.exports = function inspect (paths, mode) {
+module.exports = function inspect (paths, args) {
   const cwd = process.cwd()
   let servicePath
   try {
@@ -18,7 +18,8 @@ module.exports = function inspect (paths, mode) {
     execa('node', [
       binPath,
       'inspect',
-      ...(mode ? ['--mode', mode] : []),
+      ...(args.mode ? ['--mode', args.mode] : []),
+      ...(args.verbose ? ['--verbose'] : []),
       ...paths
     ], { cwd, stdio: 'inherit' })
   }


### PR DESCRIPTION
-v or --verbose can be used to output full function definitions. fixes #1157 