### PR TITLE
don't set header origin if using an agent

### DIFF
--- a/packages/@vue/cli-service/lib/util/prepareProxy.js
+++ b/packages/@vue/cli-service/lib/util/prepareProxy.js
@@ -86,7 +86,7 @@ module.exports = function prepareProxy (proxy, appPublicFolder) {
         // Browsers may send Origin headers even with same-origin
         // requests. To prevent CORS issues, we have to change
         // the Origin to match the target URL.
-        if (proxyReq.getHeader('origin')) {
+        if (!proxyReq.agent && proxyReq.getHeader('origin')) {
           proxyReq.setHeader('origin', target)
         }
       },


### PR DESCRIPTION
Sample vue.config.json

```
const HttpsProxyAgent = require('https-proxy-agent');


let agent
const proxyServer = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
if (proxyServer) {
  agent = new HttpsProxyAgent(proxyServer)
}

module.exports = {
  devServer: {
    proxy: {
      '/api': {
        target:"https://www.example.com",
        agent: agent,
        logLevel: process.env.DEBUG
      }
    }
  }
}
```

Was running into error 
```
_http_outgoing.js:491
    throw new Error('Can\'t set headers after they are sent.');
    ^

Error: Can't set headers after they are sent.
    at validateHeader (_http_outgoing.js:491:11)
    at ClientRequest.setHeader (_http_outgoing.js:498:3)
    at ProxyServer.onProxyReq (MY_PROJECT_PATH/node_modules/@vue/cli-service/lib/util/prepareProxy.js:90:20)
    at ProxyServer.emit (MY_PROJECT_PATH/node_modules/eventemitter3/index.js:119:35)
    at ClientRequest.<anonymous> (MY_PROJECT_PATH/node_modules/http-proxy/lib/http-proxy/passes/web-incoming.js:125:27)
    at emitOne (events.js:121:20)
    at ClientRequest.emit (events.js:211:7)
    at tickOnSocket (_http_client.js:657:7)
    at onSocketNT (_http_client.js:673:5)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

So adding the line fixed the issue