### PR TITLE
feat(build): honor custom component name for single file wc builds

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -18,6 +18,7 @@ module.exports = (api, { target, entry, name }) => {
 
   // generate dynamic entry based on glob files
   const resolvedFiles = require('globby').sync([entry], { cwd: api.resolve('.') })
+
   if (!resolvedFiles.length) {
     abort(`entry pattern "${entry}" did not match any files.`)
   }
@@ -38,7 +39,7 @@ module.exports = (api, { target, entry, name }) => {
     }
   }
 
-  const dynamicEntry = resolveEntry(prefix, resolvedFiles, isAsync)
+  const dynamicEntry = resolveEntry(prefix, libName, resolvedFiles, isAsync)
 
   function genConfig (minify, genHTML) {
     const config = api.resolveChainableWebpackConfig()
@@ -104,9 +105,12 @@ module.exports = (api, { target, entry, name }) => {
             inject: false,
             filename: 'demo.html',
             libName,
-            components: resolvedFiles.map(file => {
-              return fileToComponentName(prefix, file).kebabName
-            })
+            components:
+              prefix === ''
+                ? [libName]
+                : resolvedFiles.map(file => {
+                  return fileToComponentName(prefix, file).kebabName
+                })
           }])
     }
 


### PR DESCRIPTION
fixes #1146

Fixes issue that prevented single entry wc builds from honoring the `--name` argument.
The build process would just use the entry file name for the component name when registering the component previously