### PR TITLE
Adds basic deployment instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,12 @@ TypeScript can be configured via `tsconfig.json`.
 
 See [@vue/cli-plugin-typescript](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-typescript) for more details.
 
+
+### Deployment
+
+Run ```yarn run build```.
+Upload the `dist` folder to whatever hosting service you are using. 
+
 ### Unit Testing
 
 - #### Jest


### PR DESCRIPTION
A simple addition to the docs README.md to explain how to serve the bundle. For beginners. 

Fixes #1127 