### PR TITLE
feat(plugin-api): allow non-semver versioned dependencies (#1177)

### DIFF
--- a/packages/@vue/cli/lib/util/mergeDeps.js
+++ b/packages/@vue/cli/lib/util/mergeDeps.js
@@ -7,8 +7,13 @@ module.exports = function resolveDeps (generatorId, to, from, sources) {
     const r1 = to[name]
     const r2 = from[name]
     const sourceGeneratorId = sources[name]
+    const isValidURI = r2.match(/^(?:file|git|git\+ssh|git\+http|git\+https|git\+file|https?):/) != null
+    const isValidGitHub = r2.match(/^[^/]+\/[^/]+/) != null
 
-    if (!semver.validRange(r2)) {
+    // if they are the same, do nothing. Helps when non semver type deps are used
+    if (r1 === r2) continue
+
+    if (!isValidGitHub && !isValidURI && !semver.validRange(r2)) {
       warn(
         `invalid version range for dependency "${name}":\n\n` +
         `- ${r2} injected by generator "${generatorId}"`
@@ -20,17 +25,19 @@ module.exports = function resolveDeps (generatorId, to, from, sources) {
       res[name] = r2
       sources[name] = generatorId
     } else {
-      const r = tryGetNewerRange(r1, r2)
+      const r1semver = extractSemver(r1)
+      const r2semver = extractSemver(r2)
+      const r = tryGetNewerRange(r1semver, r2semver)
       const didGetNewer = !!r
       // if failed to infer newer version, use existing one because it's likely
       // built-in
-      res[name] = didGetNewer ? r : r1
+      res[name] = didGetNewer ? injectSemver(r2, r) : r1
       // if changed, update source
       if (res[name] === r2) {
         sources[name] = generatorId
       }
       // warn incompatible version requirements
-      if (!semver.intersects(r1, r2)) {
+      if (!semver.validRange(r1semver) || !semver.validRange(r2semver) || !semver.intersects(r1semver, r2semver)) {
         warn(
           `conflicting versions for project dependency "${name}":\n\n` +
           `- ${r1} injected by generator "${sourceGeneratorId}"\n` +
@@ -45,6 +52,8 @@ module.exports = function resolveDeps (generatorId, to, from, sources) {
 
 const leadRE = /^(~|\^|>=?)/
 const rangeToVersion = r => r.replace(leadRE, '').replace(/x/g, '0')
+const extractSemver = r => r.replace(/^.+#semver:/, '')
+const injectSemver = (r, v) => semver.validRange(r) ? v : r.replace(/#semver:.+$/, `#semver:${v}`)
 
 function tryGetNewerRange (r1, r2) {
   const v1 = rangeToVersion(r1)


### PR DESCRIPTION
npm supports multiple "version" strings when declaring deps in your
`package.json`. This PR is an attempt to support some of these other
formats in a plugin specification, while retaining the smart version
merging. If a semver range can be extracted, it will be used for
version conflict resolution. If not, a warning will be displayed to
the developer