### PR TITLE
feat(cli): add ability to `add` vuex and vue-router internal plugins (#1202)

### DIFF
--- a/packages/@vue/cli/lib/add.js
+++ b/packages/@vue/cli/lib/add.js
@@ -6,20 +6,30 @@ const { resolveModule } = require('./util/module')
 const {
   log,
   error,
+  warn,
   hasYarn,
   stopSpinner,
   resolvePluginId
 } = require('@vue/cli-shared-utils')
 
+// vuex and vue-router are internally added via cli-service so they need to be handled differently
+const internalPluginRE = /^(vuex|router)$/
+
 async function add (pluginName, options = {}, context = process.cwd()) {
-  const packageName = resolvePluginId(pluginName)
+  let packageName
+  const internalPlugin = internalPluginRE.test(pluginName)
+  if (internalPlugin) {
+    packageName = pluginName.replace(/router/, 'vue-router')
+  } else {
+    packageName = resolvePluginId(pluginName)
+  }
 
   log()
   log(`📦  Installing ${chalk.cyan(packageName)}...`)
   log()
 
   const packageManager = loadOptions().packageManager || (hasYarn() ? 'yarn' : 'npm')
-  await installPackage(context, packageManager, null, packageName)
+  await installPackage(context, packageManager, null, packageName, !internalPlugin)
 
   stopSpinner()
 
@@ -30,6 +40,10 @@ async function add (pluginName, options = {}, context = process.cwd()) {
   const generatorPath = resolveModule(`${packageName}/generator`, context)
   if (generatorPath) {
     invoke(pluginName, options, context)
+  } else if (internalPlugin) {
+    log()
+    warn(`Internal Plugin: ${packageName} cannot modify files post creation. See https://${pluginName}.vuejs.org for instructions to add ${packageName} to your code`)
+    log()
   } else {
     log(`Plugin ${packageName} does not have a generator to invoke`)
   }


### PR DESCRIPTION
custom handling for `vuex` and `router` when invoking `vue add` to simply add the dependencies to `package.json` and point the user to documentation about integrating the libraries into their app