### PR TITLE
feat(test): warn developers when they re-use a test project name

### DIFF
--- a/packages/@vue/cli-test-utils/createTestProject.js
+++ b/packages/@vue/cli-test-utils/createTestProject.js
@@ -15,6 +15,10 @@ module.exports = function createTestProject (name, preset, cwd, initGit) {
     return fs.existsSync(path.resolve(projectRoot, file))
   }
 
+  if (has(projectRoot)) {
+    console.warn(`An existing test project already exists for ${name}. May get unexpected test results due to project re-use`)
+  }
+
   const write = (file, content) => {
     const targetPath = path.resolve(projectRoot, file)
     const dir = path.dirname(targetPath)


### PR DESCRIPTION
This warning would have saved me a fair bit of time during testing because test projects are not cleaned up between individual tests and I kept stepping on previous tests. If this is a dumb idea then you can just reject and ignore