### PR TITLE
Fix link to NightwatchJS site in README

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/README.md
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/README.md
@@ -6,7 +6,7 @@
 
 - **`vue-cli-service test:e2e`**
 
-  run e2e tests with [NightwatchJS](nightwatchjs.org).
+  run e2e tests with [NightwatchJS](http://nightwatchjs.org).
 
   Options:
 


### PR DESCRIPTION
README for `cli-plugin-e2e-cypress` had a broken link to the NightwatchJS site.