### PR TITLE
fix(tslint): don't change working directory

### DIFF
--- a/packages/@vue/cli-plugin-typescript/lib/tslint.js
+++ b/packages/@vue/cli-plugin-typescript/lib/tslint.js
@@ -1,6 +1,5 @@
 module.exports = function lint (args = {}, api, silent) {
-  process.chdir(api.resolve('.'))
-
+  const cwd = api.resolve('.')
   const fs = require('fs')
   const path = require('path')
   const globby = require('globby')
@@ -79,7 +78,7 @@ module.exports = function lint (args = {}, api, silent) {
 
   const stripTsExtension = str => str.replace(/\.vue\.ts\b/g, '.vue')
 
-  return globby(files).then(files => {
+  return globby(files, { cwd }).then(files => {
     return Promise.all(files.map(lint))
   }).then(() => {
     if (silent) return


### PR DESCRIPTION
I ran `vue create test-app` and selected TypeScript and TSLint.
At the end I got the following output:
```
🎉  Successfully created project test-app.
👉  Get started with the following commands:

 $ yarn serve
```
The command `$ cd test-app` was missing, because tslint changed the working directory.