### PR TITLE
docs: correct vue add command in readme

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/README.md
+++ b/packages/@vue/cli-plugin-unit-jest/README.md
@@ -22,5 +22,5 @@ Jest can be configured via `jest.config.js` in your project root, or the `jest` 
 ## Installing in an Already Created Project
 
 ``` sh
-vue add unit-jest
+vue add @vue/unit-jest
 ```


### PR DESCRIPTION
`vue add unit-jest` fails with following output

```
> vue add unit-jest

📦  Installing vue-cli-plugin-unit-jest...

yarn add v1.6.0
info No lockfile found.
[1/4] Resolving packages...
error Couldn't find package "vue-cli-plugin-unit-jest" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```