### PR TITLE
feat: ask for whether to use taobao when get versions

### DIFF
--- a/packages/@vue/cli/lib/util/getVersions.js
+++ b/packages/@vue/cli/lib/util/getVersions.js
@@ -9,8 +9,7 @@ module.exports = async function getVersions () {
     latest = process.env.VUE_CLI_LATEST_VERSION = current
   } else {
     const request = require('./request')
-    const options = require('../options').loadOptions()
-    const registry = options.useTaobaoRegistry
+    const registry = (await require('./shouldUseTaobao')())
       ? `https://registry.npm.taobao.org`
       : `https://registry.npmjs.org`
 

--- a/packages/@vue/cli/lib/util/installDeps.js
+++ b/packages/@vue/cli/lib/util/installDeps.js
@@ -1,77 +1,12 @@
-const request = require('./request')
 const chalk = require('chalk')
 const execa = require('execa')
 const readline = require('readline')
-const inquirer = require('inquirer')
-const { loadOptions, saveOptions } = require('../options')
-const { pauseSpinner, resumeSpinner } = require('@vue/cli-shared-utils')
+const registries = require('./registries')
+const shouldUseTaobao = require('./shouldUseTaobao')
 
 const debug = require('debug')('vue-cli:install')
 
-const registries = {
-  npm: 'https://registry.npmjs.org',
-  yarn: 'https://registry.yarnpkg.com',
-  taobao: 'https://registry.npm.taobao.org'
-}
 const taobaoDistURL = 'https://npm.taobao.org/dist'
-
-async function ping (registry) {
-  await request.get(`${registry}/vue-cli-version-marker/latest`)
-  return registry
-}
-
-function removeSlash (url) {
-  return url.replace(/\/$/, '')
-}
-
-let checked
-let result
-async function shouldUseTaobao () {
-  // ensure this only gets called once.
-  if (checked) return result
-  checked = true
-
-  // previously saved preference
-  const saved = loadOptions().useTaobaoRegistry
-  if (typeof saved === 'boolean') {
-    return (result = saved)
-  }
-
-  const save = val => {
-    result = val
-    saveOptions({ useTaobaoRegistry: val })
-    return val
-  }
-
-  const userCurrent = (await execa(`npm`, ['config', 'get', 'registry'])).stdout
-  const defaultRegistry = registries.npm
-  if (removeSlash(userCurrent) !== removeSlash(defaultRegistry)) {
-    // user has configured custom regsitry, respect that
-    return save(false)
-  }
-  const faster = await Promise.race([
-    ping(defaultRegistry),
-    ping(registries.taobao)
-  ])
-
-  if (faster !== registries.taobao) {
-    // default is already faster
-    return save(false)
-  }
-
-  // ask and save preference
-  pauseSpinner()
-  const { useTaobaoRegistry } = await inquirer.prompt([{
-    name: 'useTaobaoRegistry',
-    type: 'confirm',
-    message: chalk.yellow(
-      ` Your connection to the the default npm registry seems to be slow.\n` +
-      `   Use ${chalk.cyan(registries.taobao)} for faster installation?`
-    )
-  }])
-  resumeSpinner()
-  return save(useTaobaoRegistry)
-}
 
 function toStartOfLine (stream) {
   if (!chalk.supportsColor) {

--- a/packages/@vue/cli/lib/util/registries.js
+++ b/packages/@vue/cli/lib/util/registries.js
@@ -1,0 +1,7 @@
+const registries = {
+  npm: 'https://registry.npmjs.org',
+  yarn: 'https://registry.yarnpkg.com',
+  taobao: 'https://registry.npm.taobao.org'
+}
+
+module.exports = registries

--- a/packages/@vue/cli/lib/util/shouldUseTaobao.js
+++ b/packages/@vue/cli/lib/util/shouldUseTaobao.js
@@ -1,0 +1,65 @@
+const chalk = require('chalk')
+const execa = require('execa')
+const request = require('./request')
+const inquirer = require('inquirer')
+const registries = require('./registries')
+const { loadOptions, saveOptions } = require('../options')
+
+async function ping (registry) {
+  await request.get(`${registry}/vue-cli-version-marker/latest`)
+  return registry
+}
+
+function removeSlash (url) {
+  return url.replace(/\/$/, '')
+}
+
+let checked
+let result
+
+module.exports = async function shouldUseTaobao () {
+  // ensure this only gets called once.
+  if (checked) return result
+  checked = true
+
+  // previously saved preference
+  const saved = loadOptions().useTaobaoRegistry
+  if (typeof saved === 'boolean') {
+    return (result = saved)
+  }
+
+  const save = val => {
+    result = val
+    saveOptions({ useTaobaoRegistry: val })
+    return val
+  }
+
+  const userCurrent = (await execa(`npm`, ['config', 'get', 'registry'])).stdout
+  const defaultRegistry = registries.npm
+  if (removeSlash(userCurrent) !== removeSlash(defaultRegistry)) {
+    // user has configured custom regsitry, respect that
+    return save(false)
+  }
+  const faster = await Promise.race([
+    ping(defaultRegistry),
+    ping(registries.taobao)
+  ])
+
+  if (faster !== registries.taobao) {
+    // default is already faster
+    return save(false)
+  }
+
+  // ask and save preference
+  const { useTaobaoRegistry } = await inquirer.prompt([
+    {
+      name: 'useTaobaoRegistry',
+      type: 'confirm',
+      message: chalk.yellow(
+        ` Your connection to the the default npm registry seems to be slow.\n` +
+          `   Use ${chalk.cyan(registries.taobao)} for faster installation?`
+      )
+    }
+  ])
+  return save(useTaobaoRegistry)
+}


### PR DESCRIPTION
If a developer from China first use vue-cli, `useTaobaoRegistry` will be undefined. Then [getVersions](https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli/lib/util/getVersions.js#L13) will not use the right registry.