### PR TITLE
feat(lint): add max-warnings for cli-plugin-eslint, close #1268

### DIFF
--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -24,7 +24,8 @@ module.exports = (api, { lintOnSave }) => {
     usage: 'vue-cli-service lint [options] [...files]',
     options: {
       '--format [formatter]': 'specify formatter (default: codeframe)',
-      '--no-fix': 'do not fix errors'
+      '--no-fix': 'do not fix errors',
+      '--max-warnings [limit]': 'specify number of warnings to make build failed'
     },
     details: 'For more options, see https://eslint.org/docs/user-guide/command-line-interface#options'
   }, args => {

--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -25,7 +25,8 @@ module.exports = (api, { lintOnSave }) => {
     options: {
       '--format [formatter]': 'specify formatter (default: codeframe)',
       '--no-fix': 'do not fix errors',
-      '--max-warnings [limit]': 'specify number of warnings to make build failed'
+      '--max-errors [limit]': 'specify number of errors to make build failed (default: 0)',
+      '--max-warnings [limit]': 'specify number of warnings to make build failed (default: Infinity)'
     },
     details: 'For more options, see https://eslint.org/docs/user-guide/command-line-interface#options'
   }, args => {

--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -19,11 +19,13 @@ module.exports = function lint (args = {}, api) {
   if (config.fix) {
     CLIEngine.outputFixes(report)
   }
+  
+  const maxErrors = argsConfig.maxErrors || 0
+  const maxWarnings = typeof argsConfig.maxWarnings === 'number' ? argsConfig.maxWarnings : Infinity
+  const isErrorsExceeded = report.errorCount > maxErrors
+  const isWarningsExceeded = report.warningCount > maxWarnings
 
-  const isErrorsExceed = report.errorCount > (argsConfig.maxErrors || 0)
-  const isWarningsExceed = report.warningCount > (
-    argsConfig.hasOwnProperty('maxWarnings') ? argsConfig.maxWarnings : Infinity)
-  if (!isErrorsExceed && !isWarningsExceed) {
+  if (!isErrorsExceeded && !isWarningsExceeded) {
     if (!args.silent) {
       const hasFixed = report.results.some(f => f.output)
       if (hasFixed) {

--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -20,7 +20,10 @@ module.exports = function lint (args = {}, api) {
     CLIEngine.outputFixes(report)
   }
 
-  if (report.errorCount <= (argsConfig.maxWarnings || 0)) {
+  const isErrorsExceed = report.errorCount > (argsConfig.maxErrors || 0)
+  const isWarningsExceed = report.warningCount > (
+    argsConfig.hasOwnProperty('maxWarnings') ? argsConfig.maxWarnings : Infinity)
+  if (!isErrorsExceed && !isWarningsExceed) {
     if (!args.silent) {
       const hasFixed = report.results.some(f => f.output)
       if (hasFixed) {
@@ -41,6 +44,12 @@ module.exports = function lint (args = {}, api) {
     }
   } else {
     console.log(formatter(report.results))
+    if (isErrorsExceed && typeof argsConfig.maxErrors === 'number') {
+      log(`Eslint found too many errors (maximum: ${argsConfig.maxErrors}).`)
+    }
+    if (isWarningsExceed) {
+      log(`Eslint found too many warnings (maximum: ${argsConfig.maxWarnings}).`)
+    }
     process.exit(1)
   }
 }

--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -7,10 +7,11 @@ module.exports = function lint (args = {}, api) {
   const { log, done } = require('@vue/cli-shared-utils')
 
   const files = args._ && args._.length ? args._ : ['src', 'tests', '*.js']
+  const argsConfig = normalizeConfig(args)
   const config = Object.assign({}, options, {
     fix: true,
     cwd
-  }, normalizeConfig(args))
+  }, argsConfig)
   const engine = new CLIEngine(config)
   const report = engine.executeOnFiles(files)
   const formatter = engine.getFormatter(args.format || 'codeframe')
@@ -19,7 +20,7 @@ module.exports = function lint (args = {}, api) {
     CLIEngine.outputFixes(report)
   }
 
-  if (!report.errorCount) {
+  if (!report.errorCount || report.errorCount <= (argsConfig.maxWarnings || 0)) {
     if (!args.silent) {
       const hasFixed = report.results.some(f => f.output)
       if (hasFixed) {

--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -20,7 +20,7 @@ module.exports = function lint (args = {}, api) {
     CLIEngine.outputFixes(report)
   }
 
-  if (!report.errorCount || report.errorCount <= (argsConfig.maxWarnings || 0)) {
+  if (report.errorCount <= (argsConfig.maxWarnings || 0)) {
     if (!args.silent) {
       const hasFixed = report.results.some(f => f.output)
       if (hasFixed) {
@@ -33,7 +33,7 @@ module.exports = function lint (args = {}, api) {
         })
         log()
       }
-      if (report.warningCount) {
+      if (report.warningCount || report.errorCount) {
         console.log(formatter(report.results))
       } else {
         done(hasFixed ? `All lint errors auto-fixed.` : `No lint errors found!`)


### PR DESCRIPTION
add a `--max-warnings` and `--max-errors` option for cli-plugin-eslint to specify number of warnings or errors to trigger build failed. 

usage:
```bash
vue-cli-service lint --max-warnings 10 --max-errors 2
```

#1268 

https://eslint.org/docs/user-guide/command-line-interface#options

