### PR TITLE
docs: remove css.module from default

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,10 +49,6 @@ module.exports = {
     // pass custom options to pre-processor loaders. e.g. to pass options to
     // sass-loader, use { sass: { ... } }
     loaderOptions: {},
-
-    // Enable CSS modules for all css / pre-processor files.
-    // This option does not affect *.vue files.
-    modules: false
   },
 
   // use thread-loader for babel & TS in production build


### PR DESCRIPTION
It is invalid after 1b5bdde1