### PR TITLE
feat(xdg-compliance): rc file location hierarchy

### DIFF
--- a/packages/@vue/cli/lib/options.js
+++ b/packages/@vue/cli/lib/options.js
@@ -6,8 +6,22 @@ const { error } = require('@vue/cli-shared-utils/lib/logger')
 const { createSchema, validate } = require('@vue/cli-shared-utils/lib/validate')
 const { exit } = require('@vue/cli-shared-utils/lib/exit')
 
+const xdgConfigPath = () => {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME
+  if (xdgConfigHome) {
+    const rcDir = path.join(xdgConfigHome, 'vue')
+    if (!fs.existsSync(rcDir)) {
+      fs.mkdirSync(rcDir, 0o700)
+    }
+    return path.join(rcDir, '.vuerc')
+  }
+
+  return undefined
+}
+
 const rcPath = exports.rcPath = (
   process.env.VUE_CLI_CONFIG_PATH ||
+  xdgConfigPath() ||
   path.join(os.homedir(), '.vuerc')
 )
 


### PR DESCRIPTION
`vue-cli` now uses the following hierarchy for hosting its rc file:

* `VUE_CLI_CONFIG_PATH`
* `XDG_CONFIG_HOME/vue/.vuerc`
* `HOME/.config/vue/.vuerc`
* `HOME/.vuerc`

Let me know if you need something changed

I would like to point out that the middle 2 paths probably shouldn't be hidden files. Left that up to the devs though.

closes #1325