### PR TITLE
feat(build): add 'watch' option

### DIFF
--- a/docs/cli-service.md
+++ b/docs/cli-service.md
@@ -104,6 +104,7 @@ Options:
   --dest    specify output directory (default: dist)
   --target  app | lib | wc | wc-async (default: app)
   --name    name for lib or web-component mode (default: "name" in package.json or entry filename)
+  --watch   watch for changes
 ```
 
 `vue-cli-service build` produces a production-ready bundle in the `dist/` directory, with minification for JS/CSS/HTML and auto vendor chunk splitting for better caching. The chunk manifest is inlined into the HTML.

--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -17,7 +17,8 @@ module.exports = (api, options) => {
       '--mode': `specify env mode (default: production)`,
       '--dest': `specify output directory (default: ${options.outputDir})`,
       '--target': `app | lib | wc | wc-async (default: ${defaults.target})`,
-      '--name': `name for lib or web-component mode (default: "name" in package.json or entry filename)`
+      '--name': `name for lib or web-component mode (default: "name" in package.json or entry filename)`,
+      '--watch': `watch for changes`
     }
   }, async function build (args) {
     args.entry = args.entry || args._[0]
@@ -100,8 +101,12 @@ module.exports = (api, options) => {
         : webpackConfig
     ).output.path
 
+    if (args.watch) {
+      webpackConfig.watch = true
+    }
+
     if (!args.dest && actualTargetDir !== api.resolve(options.outputDir)) {
-      // user directly modifys output.path in configureWebpack or chainWebpack.
+      // user directly modifies output.path in configureWebpack or chainWebpack.
       // this is not supported because there's no way for us to give copy
       // plugin the correct value this way.
       console.error(chalk.red(


### PR DESCRIPTION
Closes #1317 

Not sure if `--watch` can be an option or do we need to add it as switch / flag. Documentation is intentionally minimal, open for suggestions.