### PR TITLE
Add a --copy option to the serve command

### DIFF
--- a/docs/cli-service.md
+++ b/docs/cli-service.md
@@ -32,6 +32,7 @@ Usage: vue-cli-service serve [options]
 Options:
 
   --open    open browser on server start
+  --copy    copy url to clipboard on server start
   --mode    specify env mode (default: development)
   --host    specify host (default: 0.0.0.0)
   --port    specify port (default: 8080)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -174,6 +174,7 @@ serve a .js or .vue file in development mode with zero config
 Options:
 
   -o, --open  Open browser
+  -c, --copy  Copy local url to clipboard
   -h, --help  output usage information
 ```
 

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -162,7 +162,7 @@ module.exports = (api, options) => {
         let copied = ''
         if (isFirstCompile && args.copy) {
           require('clipboardy').write(urls.localUrlForBrowser)
-          copied = chalk.dim('(copied!)')
+          copied = chalk.dim('(copied to clipboard)')
         }
 
         console.log()

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -159,10 +159,16 @@ module.exports = (api, options) => {
           return
         }
 
+        let copied = ''
+        if (isFirstCompile && (args.copy || projectDevServerOptions.copy)) {
+          clipboardy.write(urls.localUrlForBrowser)
+          copied = chalk.dim('(copied!)')
+        }
+
         console.log()
         console.log([
           `  App running at:`,
-          `  - Local:   ${chalk.cyan(urls.localUrlForTerminal)}`,
+          `  - Local:   ${chalk.cyan(urls.localUrlForTerminal)} ${copied}`,
           `  - Network: ${chalk.cyan(urls.lanUrlForTerminal)}`
         ].join('\n'))
         console.log()

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -160,8 +160,8 @@ module.exports = (api, options) => {
         }
 
         let copied = ''
-        if (isFirstCompile && (args.copy || projectDevServerOptions.copy)) {
-          clipboardy.write(urls.localUrlForBrowser)
+        if (isFirstCompile && args.copy) {
+          require('clipboardy').write(urls.localUrlForBrowser)
           copied = chalk.dim('(copied!)')
         }
 

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -84,7 +84,6 @@ exports.defaults = () => ({
   devServer: {
   /*
     open: process.platform === 'darwin',
-    copy: false,
     host: '0.0.0.0',
     port: 8080,
     https: false,

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -84,6 +84,7 @@ exports.defaults = () => ({
   devServer: {
   /*
     open: process.platform === 'darwin',
+    copy: false,
     host: '0.0.0.0',
     port: 8080,
     https: false,

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -31,6 +31,7 @@
     "cache-loader": "^1.2.2",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.4.1",
+    "clipboardy": "^1.2.3",
     "cliui": "^4.1.0",
     "copy-webpack-plugin": "^4.5.1",
     "css-loader": "^0.28.11",

--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -82,6 +82,7 @@ program
   .command('serve [entry]')
   .description('serve a .js or .vue file in development mode with zero config')
   .option('-o, --open', 'Open browser')
+  .option('-c, --copy', 'Copy local url to clipboard')
   .action((entry, cmd) => {
     loadCommand('serve', '@vue/cli-service-global').serve(entry, cleanArgs(cmd))
   })


### PR DESCRIPTION
This feature will copy the local url to the clipboard. 

I use this feature of https://poi.js.org/ quite a lot.

It's not as aggressive as `--open` but just as convenient :)