### PR TITLE
docs: update docs for assetsDir, --max-errors and --max-warnings

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -16,6 +16,9 @@ module.exports = {
   // where to output built files
   outputDir: 'dist',
 
+  // where to put static assets (js/css/img/font/...)
+  assetsDir: '',
+
   // whether to use eslint-loader for lint on save.
   // valid values: true | false | 'error'
   // when set to 'error', lint errors will cause compilation to fail.

--- a/packages/@vue/cli-plugin-eslint/README.md
+++ b/packages/@vue/cli-plugin-eslint/README.md
@@ -13,6 +13,8 @@
 
     --format [formatter] specify formatter (default: codeframe)
     --no-fix             do not fix errors
+    --max-errors         specify number of errors to make build failed (default: 0)
+    --max-warnings       specify number of warnings to make build failed (default: Infinity)
   ```
 
   Lints and fixes files. If no specific files are given, it lints all files in `src` and `test`.


### PR DESCRIPTION
Catch up docs that were forgotten in pervious PR (#1289, #1322).