### PR TITLE
Update eslint webpack-chain documentation

### DIFF
--- a/packages/@vue/cli-plugin-eslint/README.md
+++ b/packages/@vue/cli-plugin-eslint/README.md
@@ -39,5 +39,5 @@ vue add @vue/eslint
 
 ## Injected webpack-chain Rules
 
-- `config.rule('eslint')`
-- `config.rule('eslint').use('eslint-loader')`
+- `config.module.rule('eslint')`
+- `config.module.rule('eslint').use('eslint-loader')`


### PR DESCRIPTION
Minor fix: it's `config.module.rule('eslint')` not `config.rule('eslint')`