### PR TITLE
fix: 404 link to vuex intro page

### DIFF
--- a/packages/@vue/cli-service/generator/template/src/components/HelloWorld.vue
+++ b/packages/@vue/cli-service/generator/template/src/components/HelloWorld.vue
@@ -22,7 +22,7 @@
     <h3>Ecosystem</h3>
     <ul>
       <li><a href="https://router.vuejs.org/en/essentials/getting-started.html" target="_blank">vue-router</a></li>
-      <li><a href="https://vuex.vuejs.org/en/intro.html" target="_blank">vuex</a></li>
+      <li><a href="https://vuex.vuejs.org" target="_blank">vuex</a></li>
       <li><a href="https://github.com/vuejs/vue-devtools#vue-devtools" target="_blank">vue-devtools</a></li>
       <li><a href="https://vue-loader.vuejs.org" target="_blank">vue-loader</a></li>
       <li><a href="https://github.com/vuejs/awesome-vue" target="_blank">awesome-vue</a></li>


### PR DESCRIPTION
Fixed the wrong link to vuex page in `HelloWorld.vue`