### PR TITLE
fix(cli-service): make devBaseUrl work properly in serve command

### DIFF
--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -29,7 +29,7 @@ module.exports = (api, options) => {
             files: assets,
             options: pluginOptions
           }
-        }, resolveClientEnv(options.baseUrl, true /* raw */))
+        }, resolveClientEnv(options, true /* raw */))
       }
     }
 

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -146,7 +146,7 @@ module.exports = (api, options) => {
     webpackConfig
       .plugin('define')
         .use(require('webpack/lib/DefinePlugin'), [
-          resolveClientEnv(options.baseUrl)
+          resolveClientEnv(options)
         ])
 
     webpackConfig

--- a/packages/@vue/cli-service/lib/config/dev.js
+++ b/packages/@vue/cli-service/lib/config/dev.js
@@ -7,7 +7,7 @@ module.exports = (api, options) => {
       webpackConfig
         .devtool('cheap-module-eval-source-map')
         .output
-          .publicPath(options.devBaseUrl || '/')
+          .publicPath(options.devBaseUrl)
 
       webpackConfig
         .plugin('hmr')

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -48,6 +48,9 @@ exports.defaults = () => ({
   // project deployment base
   baseUrl: '/',
 
+  // baseUrl, but for the dev server.
+  devBaseUrl: '/',
+
   // where to output built files
   outputDir: 'dist',
 

--- a/packages/@vue/cli-service/lib/util/resolveClientEnv.js
+++ b/packages/@vue/cli-service/lib/util/resolveClientEnv.js
@@ -1,13 +1,14 @@
 const prefixRE = /^VUE_APP_/
 
-module.exports = function resolveClientEnv (publicPath, raw) {
+module.exports = function resolveClientEnv (options, raw) {
+  const isProd = process.env.NODE_ENV === 'production'
   const env = {}
   Object.keys(process.env).forEach(key => {
     if (prefixRE.test(key) || key === 'NODE_ENV') {
       env[key] = process.env[key]
     }
   })
-  env.BASE_URL = publicPath
+  env.BASE_URL = isProd ? options.baseUrl : options.devBaseUrl
 
   if (raw) {
     return env


### PR DESCRIPTION
This PR includes:

1. Use `devBaseUrl` as `process.env.BASE_URL` in development mode. 

  Previously  favicon url would be incorrect with:
```html
<link rel="icon" href="<%= BASE_URL %>favicon.ico">
```

2. Make `webpack-dev-server` use `devBaseUrl` as publicPath

Previously `devBaseUrl` only changes `publicPath` in webpack config, which is not enough because the dev server is not serving files in that way...

There is a known issue here, that if we have a `vue.config.js` like:
```js
module.exports = {
  devBaseUrl: '/foo/'
}
```

When accessing `localhost:8080` without any additional path, `historyApiFallback` won't be triggered. So that dev server will act like been accessing `localhost:8080/index.html`, which is the original file (`public/index.html`) because dev server is serving `public` folder with `contentBase` ...