### PR TITLE
Only provide baseUrl fix if baseUrl provided

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -64,7 +64,7 @@ module.exports = (api, options) => {
     if (!isProduction) {
       const devClients = [
         // dev server client
-        require.resolve(`webpack-dev-server/client`) + '?/sockjs-node',
+        require.resolve(`webpack-dev-server/client`) + (options.baseUrl !== '/' ? '?/sockjs-node' : ''),
         // hmr client
         require.resolve(projectDevServerOptions.hotOnly
           ? 'webpack/hot/only-dev-server'


### PR DESCRIPTION
In my scenario, the page is being served by PHP and the URL to the bundle is pointed directly to the webpack dev server. 

So, the website is being served at `http://my-project.test` and the script is pointing to `http://localhost:8080/app.js`. 

By specifying `?/sockjs-node` when including the webpack dev server client, it is forcing the sockjs server to be on the same domain as the page. Because of https://github.com/webpack/webpack-dev-server/blob/ab4eeb007283fdf3e8950ff1f3ff8150a4812061/client-src/default/index.js#L30

I need the __resourceQuery to be empty so that it gets the URL for the sockjs server from the `getCurrentScriptSource`

This PR shouldn't break for anyone already using `baseUrl`. 

Or if there is another way to achieve what I need, please let me know!

Also required by #1390 which I am working on!

