### PR TITLE
Changing tabs to tab for vue/html-indent

### DIFF
--- a/packages/@vue/cli-plugin-eslint/ui.js
+++ b/packages/@vue/cli-plugin-eslint/ui.js
@@ -64,7 +64,7 @@ module.exports = api => {
             },
             {
               name: 'Tabs',
-              value: JSON.stringify(['error', 'tabs'])
+              value: JSON.stringify(['error', 'tab'])
             },
             {
               name: '2 spaces',


### PR DESCRIPTION
See #1440 changing 'vue/html-indent': ['error', 'tab']` to match the vue/html-indent specs

I hope this is where the fix is. If not no harm in closing this.

Thanks for the great work!