### PR TITLE
fix(ui): correct i18n mistake

### DIFF
--- a/packages/@vue/cli-service/ui.js
+++ b/packages/@vue/cli-service/ui.js
@@ -169,7 +169,7 @@ module.exports = api => {
             value: 'wc-async'
           }
         ],
-        description: 'vue-webpack.tasks.build.description'
+        description: 'vue-webpack.tasks.build.target.description'
       },
       {
         name: 'name',

--- a/packages/@vue/cli-service/ui.js
+++ b/packages/@vue/cli-service/ui.js
@@ -165,7 +165,7 @@ module.exports = api => {
             value: 'wc'
           },
           {
-            name: 'vue-webpack.tasks.build.wc-async',
+            name: 'vue-webpack.tasks.build.target.wc-async',
             value: 'wc-async'
           }
         ],


### PR DESCRIPTION
I was writing locale for vue-cli ui and found this mistake in the parameter-prompt in project's `build` task page.

### Addition
Well, then another one.
![image](https://user-images.githubusercontent.com/8225666/40883910-99655fd4-673a-11e8-9b5a-aa7c24a8fc8d.png)
