### PR TITLE
feat(lint): default to lint tsx files 

### DIFF
--- a/packages/@vue/cli-plugin-typescript/lib/tslint.js
+++ b/packages/@vue/cli-plugin-typescript/lib/tslint.js
@@ -75,7 +75,7 @@ module.exports = function lint (args = {}, api, silent) {
 
   const files = args._ && args._.length
     ? args._
-    : ['src/**/*.ts', 'src/**/*.vue', 'src/**/*.tsx', 'tests/**/*.ts']
+    : ['src/**/*.ts', 'src/**/*.vue', 'src/**/*.tsx', 'tests/**/*.ts', 'tests/**/*.tsx']
 
   const stripTsExtension = str => str.replace(/\.vue\.ts\b/g, '.vue')
 

--- a/packages/@vue/cli-plugin-typescript/lib/tslint.js
+++ b/packages/@vue/cli-plugin-typescript/lib/tslint.js
@@ -75,7 +75,7 @@ module.exports = function lint (args = {}, api, silent) {
 
   const files = args._ && args._.length
     ? args._
-    : ['src/**/*.ts', 'src/**/*.vue', 'tests/**/*.ts']
+    : ['src/**/*.ts', 'src/**/*.vue', 'src/**/*.tsx', 'tests/**/*.ts']
 
   const stripTsExtension = str => str.replace(/\.vue\.ts\b/g, '.vue')
 


### PR DESCRIPTION
LInt tsx files on default as `cli-plugin-typescript` supports `.tsx`.

PS: Do we have a chance to support tslint `--project` option here?