### PR TITLE
Fix TypeScript ESLint warning

### DIFF
--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -28,7 +28,7 @@
     "globby": "^8.0.1",
     "ts-loader": "^4.3.1",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^2.9.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7 || ^7.0.0-beta || ^7.0.0-rc",

--- a/packages/@vue/eslint-config-typescript/package.json
+++ b/packages/@vue/eslint-config-typescript/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/vuejs/vue-cli/packages/@vue/eslint-config-typescript#readme",
   "dependencies": {
     "eslint-plugin-typescript": "^0.12.0",
-    "typescript-eslint-parser": "^15.0.0"
+    "typescript-eslint-parser": "^16.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11642,14 +11642,14 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-15.0.0.tgz#882fd3d7aabffbab0a7f98d2a59fb9a989c2b37f"
+typescript-eslint-parser@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.0.tgz#14a9ab75932b15af919602faef553c6f0487f352"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^2.8.3:
+typescript@^2.9.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 


### PR DESCRIPTION
When generating a TypeScript project with linting enabled, the current set of dependencies resolves to `typescript: 2.9.1` and `typescript-eslint-parser: 15.0.1`, which are not fully compatible with each other and lead to the following warning message when linting: 

```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: ~2.8.1

YOUR TYPESCRIPT VERSION: 2.9.1

Please only submit bug reports when using the officially supported version.

=============
```
This PR upgrades `typescript-eslint-parser` to `^16.0.0` and explicitly upgrades `typescript` to `^2.9.1` to fix the warning.