### PR TITLE
fix(env): preserve existing env vars so load in reverse order.

### DIFF
--- a/packages/@vue/cli-service/__tests__/Service.spec.js
+++ b/packages/@vue/cli-service/__tests__/Service.spec.js
@@ -26,10 +26,11 @@ beforeEach(() => {
 })
 
 test('env loading', () => {
-  fs.writeFileSync('/.env', `FOO=1\nBAR=2`)
-  fs.writeFileSync('/.env.local', `FOO=3\nBAZ=4`)
+  process.env.FOO = 0
+  fs.writeFileSync('/.env.local', `FOO=1\nBAR=2`)
+  fs.writeFileSync('/.env', `BAR=3\nBAZ=4`)
   createMockService()
-  expect(process.env.FOO).toBe('3')
+  expect(process.env.FOO).toBe('0')
   expect(process.env.BAR).toBe('2')
   expect(process.env.BAZ).toBe('4')
 })

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -53,12 +53,12 @@ module.exports = class Service {
     this.initialized = true
     this.mode = mode
 
-    // load base .env
-    this.loadEnv()
     // load mode .env
     if (mode) {
       this.loadEnv(mode)
     }
+    // load base .env
+    this.loadEnv()
 
     // load user config
     const userOptions = this.loadUserOptions()
@@ -106,8 +106,8 @@ module.exports = class Service {
       }
     }
 
-    load(basePath)
     load(localPath)
+    load(basePath)
   }
 
   resolvePlugins (inlinePlugins, useBuiltIn) {

--- a/packages/@vue/cli-service/lib/util/loadEnv.js
+++ b/packages/@vue/cli-service/lib/util/loadEnv.js
@@ -3,7 +3,9 @@ const fs = require('fs')
 module.exports = function loadEnv (path = '.env') {
   const config = parse(fs.readFileSync(path, 'utf-8'))
   Object.keys(config).forEach(key => {
-    process.env[key] = config[key]
+    if (typeof process.env[key] === 'undefined') {
+      process.env[key] = config[key]
+    }
   })
   return config
 }


### PR DESCRIPTION
Fixes  #1499