### PR TITLE
Use devServer.public to build sockjsUrl, if defined.

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -82,7 +82,8 @@ module.exports = (api, options) => {
 
     // inject dev & hot-reload middleware entries
     if (!isProduction) {
-      const sockjsUrl = url.format({
+      const public = projectDevServerOptions.public
+      const sockjsUrl = public ? `//${public}/sockjs-node` : url.format({
         protocol,
         port,
         hostname: urls.lanUrlForConfig || 'localhost',

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -82,8 +82,8 @@ module.exports = (api, options) => {
 
     // inject dev & hot-reload middleware entries
     if (!isProduction) {
-      const public = projectDevServerOptions.public
-      const sockjsUrl = public ? `//${public}/sockjs-node` : url.format({
+      const publicOpt = projectDevServerOptions.public
+      const sockjsUrl = publicOpt ? `//${publicOpt}/sockjs-node` : url.format({
         protocol,
         port,
         hostname: urls.lanUrlForConfig || 'localhost',


### PR DESCRIPTION
See: https://github.com/vuejs/vue-cli/issues/1525
