### PR TITLE
docs: bump vuepress

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "rimraf": "^2.6.2",
-    "vuepress": "^0.10.0",
+    "vuepress": "^0.10.1",
     "vuepress-theme-vue": "^1.0.3",
     "yorkie": "^1.0.2"
   },


### PR DESCRIPTION
# Summary

Update to `0.10.1` to get some very small UI enhancement (mainly for `lastUpdated`).

And I also want to **sell** two features here.

## 1. free to use relative path

From now on, we can be free to use `relative path` for markdown file reference:

**e.g.**

``` md
[`transpileDependencies`](../config/#transpiledependencies)
```

Can be replaced by:

``` md
[`transpileDependencies`](../config/README.md#transpiledependencies)
```

The first convention assumes that the user uses the VuePress, and as a source file, it uses the runtime path, so I personally prefer the second one, mainly that it keeps the `jump-to-definition` in editor.

> Complete use case test [here](https://github.com/vuejs/vuepress/blob/master/test/markdown/link.spec.js).

## 2. Header badge

Now we can easily add a `version`/`status`  to a new feature at docs.

**e.g.**

- Input

``` md
## Import Code Snippets <Badge text="Experimental" type="warn"/> <Badge text="0.11.0+" type="tip"/>
```

- Output

![image](https://user-images.githubusercontent.com/23133919/41191422-d70f0678-6c21-11e8-8823-92e7d5a2b1fb.png)






