### PR TITLE
CSS Pre-processors "More info" link leads to 404

### DIFF
--- a/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
+++ b/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
@@ -3,7 +3,7 @@ module.exports = cli => {
     name: 'CSS Pre-processors',
     value: 'css-preprocessor',
     description: 'Add support for CSS pre-processors like SASS, Less or Stylus',
-    link: 'https://github.com/vuejs/vue-cli/blob/dev/docs/css.md'
+    link: 'https://cli.vuejs.org/guide/css.html'
   })
 
   cli.injectPrompt({


### PR DESCRIPTION
Don't quite know if redirecting to GitHub instead of cli.vuejs.or is an expected behaviour, please feel free to update by this one if you want to link to GitHub https://github.com/vuejs/vue-cli/blob/dev/docs/guide/css.md

Thanks!