### PR TITLE
feat: Allow git commit message through UI

### DIFF
--- a/packages/@vue/cli-ui/locales/en.json
+++ b/packages/@vue/cli-ui/locales/en.json
@@ -199,7 +199,7 @@
             "options": {
               "label": "Additional options",
               "description": "Overwrite target folder if it exists",
-              "git": "Use custom first initial commit message or skip git initialization",
+              "git": "Initialize git repository (recommended)",
               "gitPlaceholder": "Initial commit message (optional)"
             }
           },

--- a/packages/@vue/cli-ui/locales/en.json
+++ b/packages/@vue/cli-ui/locales/en.json
@@ -198,9 +198,9 @@
             },
             "options": {
               "label": "Additional options",
-              "description": "Overwrite target folder if it exists",
+              "force": "Overwrite target folder if it exists",
               "git": "Initialize git repository (recommended)",
-              "gitPlaceholder": "Initial commit message (optional)"
+              "git-commit-message": "Initial commit message (optional)"
             }
           },
           "buttons": {

--- a/packages/@vue/cli-ui/locales/en.json
+++ b/packages/@vue/cli-ui/locales/en.json
@@ -198,7 +198,9 @@
             },
             "options": {
               "label": "Additional options",
-              "description": "Overwrite target folder if it exists"
+              "description": "Overwrite target folder if it exists",
+              "git": "Use custom first initial commit message or skip git initialization",
+              "gitPlaceholder": "Initial commit message (optional)"
             }
           },
           "buttons": {

--- a/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
+++ b/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
@@ -281,14 +281,12 @@ async function create (input, context) {
       answers.useConfigFiles = 'files'
     }
 
-    const cliOptions = {git: true}
+    const createOptions = {git: true}
     // Git
-    if (!input.enableGit) {
-      if (!input.gitCommit) {
-        cliOptions.git = false
-      } else {
-        cliOptions.git = input.gitCommit
-      }
+    if (input.enableGit && input.gitCommitMessage) {
+      createOptions.git = input.gitCommitMessage
+    } else {
+      createOptions.git = input.enableGit
     }
 
     // Preset
@@ -316,7 +314,7 @@ async function create (input, context) {
     })
 
     // Create
-    await creator.create(cliOptions, preset)
+    await creator.create(createOptions, preset)
     removeCreator()
 
     notify({

--- a/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
+++ b/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
@@ -281,6 +281,16 @@ async function create (input, context) {
       answers.useConfigFiles = 'files'
     }
 
+    const cliOptions = {git: true}
+    // Git
+    if (input.skipGit) {
+      if (!input.gitCommit) {
+        cliOptions.git = 'false'
+      } else {
+        cliOptions.git = input.gitCommit
+      }
+    }
+
     // Preset
     answers.preset = input.preset
     if (input.save) {
@@ -306,7 +316,7 @@ async function create (input, context) {
     })
 
     // Create
-    await creator.create({ git: true }, preset)
+    await creator.create(cliOptions, preset)
     removeCreator()
 
     notify({

--- a/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
+++ b/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
@@ -281,7 +281,7 @@ async function create (input, context) {
       answers.useConfigFiles = 'files'
     }
 
-    const createOptions = {git: true}
+    const createOptions = {}
     // Git
     if (input.enableGit && input.gitCommitMessage) {
       createOptions.git = input.gitCommitMessage

--- a/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
+++ b/packages/@vue/cli-ui/src/graphql-api/connectors/projects.js
@@ -283,9 +283,9 @@ async function create (input, context) {
 
     const cliOptions = {git: true}
     // Git
-    if (input.skipGit) {
+    if (!input.enableGit) {
       if (!input.gitCommit) {
-        cliOptions.git = 'false'
+        cliOptions.git = false
       } else {
         cliOptions.git = input.gitCommit
       }

--- a/packages/@vue/cli-ui/src/graphql-api/schema/project.js
+++ b/packages/@vue/cli-ui/src/graphql-api/schema/project.js
@@ -38,7 +38,7 @@ input ProjectCreateInput {
   clone: Boolean
   save: String
   enableGit: Boolean!
-  gitCommit: String
+  gitCommitMessage: String
 }
 
 input ProjectImportInput {

--- a/packages/@vue/cli-ui/src/graphql-api/schema/project.js
+++ b/packages/@vue/cli-ui/src/graphql-api/schema/project.js
@@ -37,6 +37,8 @@ input ProjectCreateInput {
   remote: Boolean
   clone: Boolean
   save: String
+  skipGit: Boolean!
+  gitCommit: String
 }
 
 input ProjectImportInput {

--- a/packages/@vue/cli-ui/src/graphql-api/schema/project.js
+++ b/packages/@vue/cli-ui/src/graphql-api/schema/project.js
@@ -37,7 +37,7 @@ input ProjectCreateInput {
   remote: Boolean
   clone: Boolean
   save: String
-  skipGit: Boolean!
+  enableGit: Boolean!
   gitCommit: String
 }
 

--- a/packages/@vue/cli-ui/src/views/ProjectCreate.vue
+++ b/packages/@vue/cli-ui/src/views/ProjectCreate.vue
@@ -80,18 +80,21 @@
                     v-model="formData.force"
                     class="extend-left force"
                   >
-                    {{ $t('views.project-create.tabs.details.form.options.description') }}
+                    {{ $t('views.project-create.tabs.details.form.options.force') }}
                   </VueSwitch>
+                </VueFormField>
+
+                <VueFormField>
                   <VueSwitch
-                    v-model="formData.git"
+                    v-model="formData.enableGit"
                     class="extend-left git"
                   >
                     {{ $t('views.project-create.tabs.details.form.options.git') }}
                   </VueSwitch>
                   <VueInput
                     v-model="formData.gitCommitMessage"
-                    v-show="!formData.git"
-                    :placeholder="$t('views.project-create.tabs.details.form.options.gitPlaceholder')"
+                    v-show="formData.enableGit"
+                    :placeholder="$t('views.project-create.tabs.details.form.options.git-commit-message')"
                   />
                 </VueFormField>
               </div>
@@ -399,7 +402,7 @@ function formDataFactory () {
   return {
     folder: '',
     force: false,
-    git: true,
+    enableGit: true,
     gitCommitMessage: '',
     packageManager: undefined,
     selectedPreset: null,
@@ -525,8 +528,8 @@ export default {
             input: {
               folder: this.formData.folder,
               force: this.formData.force,
-              enableGit: this.formData.git,
-              gitCommit: this.formData.gitCommitMessage,
+              enableGit: this.formData.enableGit,
+              gitCommitMessage: this.formData.gitCommitMessage,
               packageManager: this.formData.packageManager,
               preset: this.formData.selectedPreset,
               remote: this.formData.remotePreset.url,

--- a/packages/@vue/cli-ui/src/views/ProjectCreate.vue
+++ b/packages/@vue/cli-ui/src/views/ProjectCreate.vue
@@ -82,6 +82,17 @@
                   >
                     {{ $t('views.project-create.tabs.details.form.options.description') }}
                   </VueSwitch>
+                  <VueSwitch
+                    v-model="formData.git"
+                    class="extend-left git"
+                  >
+                    {{ $t('views.project-create.tabs.details.form.options.git') }}
+                  </VueSwitch>
+                  <VueInput
+                    v-model="formData.gitCommitMessage"
+                    v-show="formData.git"
+                    :placeholder="$t('views.project-create.tabs.details.form.options.gitPlaceholder')"
+                  />
                 </VueFormField>
               </div>
             </div>
@@ -388,6 +399,8 @@ function formDataFactory () {
   return {
     folder: '',
     force: false,
+    git: false,
+    gitCommitMessage: '',
     packageManager: undefined,
     selectedPreset: null,
     remotePreset: {
@@ -512,6 +525,8 @@ export default {
             input: {
               folder: this.formData.folder,
               force: this.formData.force,
+              skipGit: this.formData.git,
+              gitCommit: this.formData.gitCommitMessage,
               packageManager: this.formData.packageManager,
               preset: this.formData.selectedPreset,
               remote: this.formData.remotePreset.url,

--- a/packages/@vue/cli-ui/src/views/ProjectCreate.vue
+++ b/packages/@vue/cli-ui/src/views/ProjectCreate.vue
@@ -90,7 +90,7 @@
                   </VueSwitch>
                   <VueInput
                     v-model="formData.gitCommitMessage"
-                    v-show="formData.git"
+                    v-show="!formData.git"
                     :placeholder="$t('views.project-create.tabs.details.form.options.gitPlaceholder')"
                   />
                 </VueFormField>
@@ -399,7 +399,7 @@ function formDataFactory () {
   return {
     folder: '',
     force: false,
-    git: false,
+    git: true,
     gitCommitMessage: '',
     packageManager: undefined,
     selectedPreset: null,
@@ -525,7 +525,7 @@ export default {
             input: {
               folder: this.formData.folder,
               force: this.formData.force,
-              skipGit: this.formData.git,
+              enableGit: this.formData.git,
               gitCommit: this.formData.gitCommitMessage,
               packageManager: this.formData.packageManager,
               preset: this.formData.selectedPreset,


### PR DESCRIPTION
Implements #1482.

Hi! I went ahead and implemented support on UI to specify a custom initial git commit message and skip git initialization.

I'm not sure if using a single switch for both actions and skip git initialization if the switch is on but no message is specified is the best approach, I can switch to something else like having different switches if it seems a better option.