### PR TITLE
feat(build/serve): export build/serve command and allow them to take config argument (chainable webpack config)

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -69,7 +69,7 @@ const initiateBuild = async (args, api, options, config) => {
     delete process.env.VUE_CLI_MODERN_MODE
     delete process.env.VUE_CLI_MODERN_BUILD
   } else {
-    await build(args, api, options)
+    await build(args, api, options, config)
   }
   delete process.env.VUE_CLI_BUILD_TARGET
 }

--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -33,41 +33,48 @@ module.exports = (api, options) => {
       '--watch': `watch for changes`
     }
   }, async (args) => {
-    for (const key in defaults) {
-      if (args[key] == null) {
-        args[key] = defaults[key]
-      }
-    }
-    args.entry = args.entry || args._[0]
-    if (args.target !== 'app') {
-      args.entry = args.entry || 'src/App.vue'
-    }
-
-    process.env.VUE_CLI_BUILD_TARGET = args.target
-    if (args.modern && args.target === 'app') {
-      process.env.VUE_CLI_MODERN_MODE = true
-      delete process.env.VUE_CLI_MODERN_BUILD
-      await build(Object.assign({}, args, {
-        modernBuild: false,
-        keepAlive: true
-      }), api, options)
-
-      process.env.VUE_CLI_MODERN_BUILD = true
-      await build(Object.assign({}, args, {
-        modernBuild: true,
-        clean: false
-      }), api, options)
-
-      delete process.env.VUE_CLI_MODERN_MODE
-      delete process.env.VUE_CLI_MODERN_BUILD
-    } else {
-      await build(args, api, options)
-    }
-    delete process.env.VUE_CLI_BUILD_TARGET
-  })
+    await initiateBuild(args, api, options)
+    return
+  }
+  )
 }
 
-async function build (args, api, options) {
+const initiateBuild = async (args, api, options, config) => {
+  for (const key in defaults) {
+    if (args[key] == null) {
+      args[key] = defaults[key]
+    }
+  }
+  args.entry = args.entry || args._[0]
+  if (args.target !== 'app') {
+    args.entry = args.entry || 'src/App.vue'
+  }
+
+  process.env.VUE_CLI_BUILD_TARGET = args.target
+  if (args.modern && args.target === 'app') {
+    process.env.VUE_CLI_MODERN_MODE = true
+    delete process.env.VUE_CLI_MODERN_BUILD
+    await build(
+      Object.assign({}, args, {
+        modernBuild: false,
+        keepAlive: true
+      }), api, options, config)
+
+    process.env.VUE_CLI_MODERN_BUILD = true
+    await build(Object.assign({}, args, {
+      modernBuild: true,
+      clean: false
+    }), api, options, config)
+
+    delete process.env.VUE_CLI_MODERN_MODE
+    delete process.env.VUE_CLI_MODERN_BUILD
+  } else {
+    await build(args, api, options)
+  }
+  delete process.env.VUE_CLI_BUILD_TARGET
+}
+
+async function build (args, api, options, config) {
   const fs = require('fs-extra')
   const path = require('path')
   const chalk = require('chalk')
@@ -105,14 +112,14 @@ async function build (args, api, options) {
   // resolve raw webpack config
   let webpackConfig
   if (args.target === 'lib') {
-    webpackConfig = require('./resolveLibConfig')(api, args, options)
+    webpackConfig = require('./resolveLibConfig')(api, args, options, config)
   } else if (
     args.target === 'wc' ||
     args.target === 'wc-async'
   ) {
-    webpackConfig = require('./resolveWcConfig')(api, args, options)
+    webpackConfig = require('./resolveWcConfig')(api, args, options, config)
   } else {
-    webpackConfig = require('./resolveAppConfig')(api, args, options)
+    webpackConfig = require('./resolveAppConfig')(api, args, options, config)
   }
 
   // apply inline dest path after user configureWebpack hooks
@@ -136,15 +143,15 @@ async function build (args, api, options) {
     // plugin the correct value this way.
     throw new Error(
       `\n\nConfiguration Error: ` +
-      `Avoid modifying webpack output.path directly. ` +
-      `Use the "outputDir" option instead.\n`
+        `Avoid modifying webpack output.path directly. ` +
+        `Use the "outputDir" option instead.\n`
     )
   }
 
   if (actualTargetDir === api.service.context) {
     throw new Error(
       `\n\nConfiguration Error: ` +
-      `Do not set output directory to project root.\n`
+        `Do not set output directory to project root.\n`
     )
   }
 
@@ -235,3 +242,4 @@ async function build (args, api, options) {
 module.exports.defaultModes = {
   build: 'production'
 }
+module.exports.build = initiateBuild

--- a/packages/@vue/cli-service/lib/commands/build/resolveAppConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveAppConfig.js
@@ -1,5 +1,5 @@
-module.exports = (api, args, options) => {
-  const config = api.resolveChainableWebpackConfig()
+module.exports = (api, args, options, config) => {
+  if (!config) config = api.resolveChainableWebpackConfig()
   const targetDir = api.resolve(args.dest || options.outputDir)
 
   // respect inline build destination in copy plugin

--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
-module.exports = (api, { entry, name }, options) => {
+module.exports = (api, { entry, name }, options, config) => {
   // inline all static asset files since there is no publicPath handling
   process.env.VUE_CLI_INLINE_LIMIT = Infinity
 
@@ -27,7 +27,7 @@ module.exports = (api, { entry, name }, options) => {
   )
 
   function genConfig (format, postfix = format, genHTML) {
-    const config = api.resolveChainableWebpackConfig()
+    if (!config) config = api.resolveChainableWebpackConfig()
 
     // adjust css output name so they write to the same file
     if (config.plugins.has('extract-css')) {

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const { resolveEntry, fileToComponentName } = require('./resolveWcEntry')
 
-module.exports = (api, { target, entry, name }) => {
+module.exports = (api, { target, entry, name }, config) => {
   // Disable CSS extraction and turn on CSS shadow mode for vue-style-loader
   process.env.VUE_CLI_CSS_SHADOW_MODE = true
 
@@ -40,7 +40,7 @@ module.exports = (api, { target, entry, name }) => {
   const dynamicEntry = resolveEntry(prefix, libName, resolvedFiles, isAsync)
 
   function genConfig (minify, genHTML) {
-    const config = api.resolveChainableWebpackConfig()
+    if (!config) config = api.resolveChainableWebpackConfig()
 
     // make sure not to transpile wc-wrapper
     config.module

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const { resolveEntry, fileToComponentName } = require('./resolveWcEntry')
 
-module.exports = (api, { target, entry, name }, config) => {
+module.exports = (api, { target, entry, name }, options, config) => {
   // Disable CSS extraction and turn on CSS shadow mode for vue-style-loader
   process.env.VUE_CLI_CSS_SHADOW_MODE = true
 
@@ -41,7 +41,6 @@ module.exports = (api, { target, entry, name }, config) => {
 
   function genConfig (minify, genHTML) {
     if (!config) config = api.resolveChainableWebpackConfig()
-
     // make sure not to transpile wc-wrapper
     config.module
       .rule('js')

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -23,9 +23,8 @@ module.exports = (api, options) => {
       '--port': `specify port (default: ${defaults.port})`,
       '--https': `use https (default: ${defaults.https})`
     }
-  }, async function (args) {
-    await serve(args, api, options)
-    return
+  }, function (args) {
+    return serve(args, api, options)
   })
 }
 

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -12,25 +12,21 @@ const defaults = {
 }
 
 module.exports = (api, options) => {
-  api.registerCommand(
-    'serve',
-    {
-      description: 'start development server',
-      usage: 'vue-cli-service serve [options] [entry]',
-      options: {
-        '--open': `open browser on server start`,
-        '--copy': `copy url to clipboard on server start`,
-        '--mode': `specify env mode (default: development)`,
-        '--host': `specify host (default: ${defaults.host})`,
-        '--port': `specify port (default: ${defaults.port})`,
-        '--https': `use https (default: ${defaults.https})`
-      }
-    },
-    async function (args) {
-      await serve(args, api, options)
-      return
+  api.registerCommand('serve', {
+    description: 'start development server',
+    usage: 'vue-cli-service serve [options] [entry]',
+    options: {
+      '--open': `open browser on server start`,
+      '--copy': `copy url to clipboard on server start`,
+      '--mode': `specify env mode (default: development)`,
+      '--host': `specify host (default: ${defaults.host})`,
+      '--port': `specify port (default: ${defaults.port})`,
+      '--https': `use https (default: ${defaults.https})`
     }
-  )
+  }, async function (args) {
+    await serve(args, api, options)
+    return
+  })
 }
 
 async function serve (args, api, options, config) {
@@ -59,11 +55,9 @@ async function serve (args, api, options, config) {
   // expose advanced stats
   if (args.dashboard) {
     const DashboardPlugin = require('../webpack/DashboardPlugin')
-    ;(webpackConfig.plugins = webpackConfig.plugins || []).push(
-      new DashboardPlugin({
-        type: 'serve'
-      })
-    )
+            ;(webpackConfig.plugins = webpackConfig.plugins || []).push(new DashboardPlugin({
+      type: 'serve'
+    }))
   }
 
   // entry arg
@@ -77,19 +71,16 @@ async function serve (args, api, options, config) {
   // resolve server options
   const useHttps = args.https || projectDevServerOptions.https || defaults.https
   const protocol = useHttps ? 'https' : 'http'
-  const host =
-    args.host ||
-    process.env.HOST ||
-    projectDevServerOptions.host ||
-    defaults.host
-  portfinder.basePort =
-    args.port ||
-    process.env.PORT ||
-    projectDevServerOptions.port ||
-    defaults.port
+  const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
+  portfinder.basePort = args.port || process.env.PORT || projectDevServerOptions.port || defaults.port
   const port = await portfinder.getPortPromise()
 
-  const urls = prepareURLs(protocol, host, port, options.baseUrl)
+  const urls = prepareURLs(
+    protocol,
+    host,
+    port,
+    options.baseUrl
+  )
 
   const proxySettings = prepareProxy(
     projectDevServerOptions.proxy,
@@ -99,24 +90,20 @@ async function serve (args, api, options, config) {
   // inject dev & hot-reload middleware entries
   if (!isProduction) {
     const publicOpt = projectDevServerOptions.public
-    const sockjsUrl = publicOpt
-      ? `//${publicOpt}/sockjs-node`
-      : url.format({
-        protocol,
-        port,
-        hostname: urls.lanUrlForConfig || 'localhost',
-        pathname: '/sockjs-node'
-      })
+    const sockjsUrl = publicOpt ? `//${publicOpt}/sockjs-node` : url.format({
+      protocol,
+      port,
+      hostname: urls.lanUrlForConfig || 'localhost',
+      pathname: '/sockjs-node'
+    })
 
     const devClients = [
       // dev server client
       require.resolve(`webpack-dev-server/client`) + `?${sockjsUrl}`,
       // hmr client
-      require.resolve(
-        projectDevServerOptions.hotOnly
-          ? 'webpack/hot/only-dev-server'
-          : 'webpack/hot/dev-server'
-      )
+      require.resolve(projectDevServerOptions.hotOnly
+        ? 'webpack/hot/only-dev-server'
+        : 'webpack/hot/dev-server')
       // TODO custom overlay client
       // `@vue/cli-overlay/dist/client`
     ]
@@ -131,52 +118,41 @@ async function serve (args, api, options, config) {
   const compiler = webpack(webpackConfig)
 
   // create server
-  const server = new WebpackDevServer(
-    compiler,
-    Object.assign(
-      {
-        clientLogLevel: 'none',
-        historyApiFallback: {
-          disableDotRule: true,
-          rewrites: [
-            { from: /./, to: path.posix.join(options.baseUrl, 'index.html') }
-          ]
-        },
-        contentBase: api.resolve('public'),
-        watchContentBase: !isProduction,
-        hot: !isProduction,
-        quiet: true,
-        compress: isProduction,
-        publicPath: options.baseUrl,
-        overlay: isProduction // TODO disable this
-          ? false
-          : { warnings: false, errors: true }
-      },
-      projectDevServerOptions,
-      {
-        https: useHttps,
-        proxy: proxySettings,
-        before (app) {
-          // launch editor support.
-          // this works with vue-devtools & @vue/cli-overlay
-          app.use(
-            '/__open-in-editor',
-            launchEditorMiddleware(() =>
-              console.log(
-                `To specify an editor, sepcify the EDITOR env variable or ` +
-                  `add "editor" field to your Vue project config.\n`
-              )
-            )
-          )
-          // allow other plugins to register middlewares, e.g. PWA
-          api.service.devServerConfigFns.forEach(fn => fn(app))
-          // apply in project middlewares
-          projectDevServerOptions.before && projectDevServerOptions.before(app)
-        }
-      }
-    )
-  )
-  ;['SIGINT', 'SIGTERM'].forEach(signal => {
+  const server = new WebpackDevServer(compiler, Object.assign({
+    clientLogLevel: 'none',
+    historyApiFallback: {
+      disableDotRule: true,
+      rewrites: [
+        { from: /./, to: path.posix.join(options.baseUrl, 'index.html') }
+      ]
+    },
+    contentBase: api.resolve('public'),
+    watchContentBase: !isProduction,
+    hot: !isProduction,
+    quiet: true,
+    compress: isProduction,
+    publicPath: options.baseUrl,
+    overlay: isProduction // TODO disable this
+      ? false
+      : { warnings: false, errors: true }
+  }, projectDevServerOptions, {
+    https: useHttps,
+    proxy: proxySettings,
+    before (app) {
+      // launch editor support.
+      // this works with vue-devtools & @vue/cli-overlay
+      app.use('/__open-in-editor', launchEditorMiddleware(() => console.log(
+        `To specify an editor, sepcify the EDITOR env variable or ` +
+                    `add "editor" field to your Vue project config.\n`
+      )))
+      // allow other plugins to register middlewares, e.g. PWA
+      api.service.devServerConfigFns.forEach(fn => fn(app))
+      // apply in project middlewares
+      projectDevServerOptions.before && projectDevServerOptions.before(app)
+    }
+  }))
+
+        ;['SIGINT', 'SIGTERM'].forEach(signal => {
     process.on(signal, () => {
       server.close(() => {
         process.exit(0)
@@ -212,13 +188,11 @@ async function serve (args, api, options, config) {
       }
 
       console.log()
-      console.log(
-        [
-          `  App running at:`,
-          `  - Local:   ${chalk.cyan(urls.localUrlForTerminal)} ${copied}`,
-          `  - Network: ${chalk.cyan(urls.lanUrlForTerminal)}`
-        ].join('\n')
-      )
+      console.log([
+        `  App running at:`,
+        `  - Local:   ${chalk.cyan(urls.localUrlForTerminal)} ${copied}`,
+        `  - Network: ${chalk.cyan(urls.lanUrlForTerminal)}`
+      ].join('\n'))
       console.log()
 
       if (isFirstCompile) {
@@ -227,9 +201,7 @@ async function serve (args, api, options, config) {
         if (!isProduction) {
           const buildCommand = hasYarn() ? `yarn build` : `npm run build`
           console.log(`  Note that the development build is not optimized.`)
-          console.log(
-            `  To create a production build, run ${chalk.cyan(buildCommand)}.`
-          )
+          console.log(`  To create a production build, run ${chalk.cyan(buildCommand)}.`)
         } else {
           console.log(`  App is served in production mode.`)
           console.log(`  Note this is for preview or E2E testing only.`)
@@ -274,7 +246,7 @@ async function serve (args, api, options, config) {
 function addDevClientToEntry (config, devClient) {
   const { entry } = config
   if (typeof entry === 'object' && !Array.isArray(entry)) {
-    Object.keys(entry).forEach(key => {
+    Object.keys(entry).forEach((key) => {
       entry[key] = devClient.concat(entry[key])
     })
   } else if (typeof entry === 'function') {


### PR DESCRIPTION
Solves #1551 by changing the build command to export itself. It can then be imported and ran with a custom config that will be used instead of `api.resolveChainableWebpackConfig()`. This allows plugins to modify the webpack config only if their build command is run, not for normal builds. 

Edit: Now does same process for the serve command.