### PR TITLE
chore: restore --offline option for legacy vue init API

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -121,6 +121,7 @@ program
   .command('init <template> <app-name>')
   .description('generate a project from a remote template (legacy API, requires @vue/cli-init)')
   .option('-c, --clone', 'Use git clone when fetching remote template')
+  .option('--offline', 'Use cached template')
   .action(() => {
     loadCommand('init', '@vue/cli-init')
   })


### PR DESCRIPTION
If the legacy `vue init` API is still necessary to be compatible with, it is also necessary to keep the `--offline` option : )