### PR TITLE
fix: version check ignores cached version. fixes #1613

### DIFF
--- a/packages/@vue/cli/lib/util/getVersions.js
+++ b/packages/@vue/cli/lib/util/getVersions.js
@@ -18,7 +18,8 @@ module.exports = async function getVersions () {
     const lastChecked = (await fs.stat(fsCachePath)).mtimeMs
     const daysPassed = (Date.now() - lastChecked) / (60 * 60 * 1000 * 24)
     if (daysPassed > 7) {
-      await getAndCacheLatestVersion(current)
+      const cachedCurrent = await fs.readFile(fsCachePath, 'utf-8')
+      await getAndCacheLatestVersion(cachedCurrent)
     }
     latest = await fs.readFile(fsCachePath, 'utf-8')
   } else {


### PR DESCRIPTION
I'm not entirely sure this fix is completely necessary, as I _suspect_ the `.version` file in the latest package (.rc3) simply contains the wrong version (i.e. `3.0.0-beta.15`).

related issue #1613 