### PR TITLE
fix: when script has no attributes

### DIFF
--- a/packages/@vue/cli-service/lib/webpack/ModernModePlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/ModernModePlugin.js
@@ -37,7 +37,7 @@ class ModernModePlugin {
     compiler.hooks.compilation.tap(ID, compilation => {
       compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync(ID, async (data, cb) => {
         // use <script type="module"> for modern assets
-        const modernAssets = data.body.filter(a => a.tagName === 'script')
+        const modernAssets = data.body.filter(a => a.tagName === 'script' && a.attributes)
         modernAssets.forEach(a => { a.attributes.type = 'module' })
 
         // inject Safari 10 nomdoule fix
@@ -51,7 +51,7 @@ class ModernModePlugin {
         const htmlName = data.plugin.options.filename
         const tempFilename = path.join(this.targetDir, `legacy-assets-${htmlName}.json`)
         const legacyAssets = JSON.parse(await fs.readFile(tempFilename, 'utf-8'))
-          .filter(a => a.tagName === 'script')
+          .filter(a => a.tagName === 'script' && a.attributes)
         legacyAssets.forEach(a => { a.attributes.nomodule = '' })
         data.body.push(...legacyAssets)
         await fs.remove(tempFilename)


### PR DESCRIPTION
when use webpack `htmlWebpackIncludeAssetsPlugin` include script. the script has no attributes, and build throw error.

![image](https://user-images.githubusercontent.com/1269858/41634619-276b0574-7477-11e8-97ed-de4c89bb60f5.png)
