### PR TITLE
fix(ui): add end of string to build regex to prevent unwanted matches

### DIFF
--- a/packages/@vue/cli-ui/ui-defaults/tasks.js
+++ b/packages/@vue/cli-ui/ui-defaults/tasks.js
@@ -96,7 +96,7 @@ module.exports = api => {
     defaultView: 'vue-webpack-dashboard'
   }
   api.describeTask({
-    match: /vue-cli-service serve/,
+    match: /vue-cli-service serve$/,
     description: 'vue-webpack.tasks.serve.description',
     link: 'https://cli.vuejs.org/guide/cli-service.html#vue-cli-service-serve',
     icon: '/public/webpack-logo.png',
@@ -171,7 +171,7 @@ module.exports = api => {
     ...views
   })
   api.describeTask({
-    match: /vue-cli-service build/,
+    match: /vue-cli-service build$/,
     description: 'vue-webpack.tasks.build.description',
     link: 'https://cli.vuejs.org/guide/cli-service.html#vue-cli-service-build',
     icon: '/public/webpack-logo.png',


### PR DESCRIPTION
Fixes issue #1629, pasted below:

### What problem does this feature solve?
The match regex in `@vue/cli-ui/ui-defaults/tasks.js` doesn't have an end of string modifier at the end of it ($). This means it matches `vue-cli-service build:electron` or something else similar. Since these defaults overwrite plugin ui config, this prevents developers like me for making their plugin work with the ui.

### What does the proposed API look like?
Add `$` to the end of the match regex for the build/serve commands. Created pr #1630 which does exactly this.