### PR TITLE
fix: increase Node memory limit to workaround webpack crash, fix #1453

### DIFF
--- a/packages/@vue/cli-service/bin/vue-cli-service.js
+++ b/packages/@vue/cli-service/bin/vue-cli-service.js
@@ -1,4 +1,11 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max_old_space_size=4096
+
+/**
+ * --max_old_space_size to increase V8 default heap size.
+ * Temporary workaround for memory leaks in webpack and high memory usage
+ * from file watching & sourcemap generation.
+ * https://github.com/vuejs/vue-cli/issues/1453
+ */
 
 const semver = require('semver')
 const { error } = require('@vue/cli-shared-utils')


### PR DESCRIPTION
https://github.com/vuejs/vue-cli/issues/1453#issuecomment-396811585

@yyx990803 I've been running with this setting for a while and haven't encountered crashes any more.