### PR TITLE
Add robots.txt

### DIFF
--- a/packages/@vue/cli-plugin-pwa/generator/template/public/robots.txt
+++ b/packages/@vue/cli-plugin-pwa/generator/template/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
Lighthouse 3.0 issue while passing a new audit:

"Ensure that your site's robots.txt file is properly formed so that search bots can crawl your site."

Ref: https://developers.google.com/web/updates/2018/05/lighthouse3