### PR TITLE
feature: Generating README.md

### DIFF
--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -15,6 +15,7 @@ const PromptModuleAPI = require('./PromptModuleAPI')
 const writeFileTree = require('./util/writeFileTree')
 const { formatFeatures } = require('./util/features')
 const fetchRemotePreset = require('./util/fetchRemotePreset')
+const generateReadme = require('./util/generateReadme')
 
 const {
   defaults,
@@ -183,6 +184,13 @@ module.exports = class Creator extends EventEmitter {
         gitCommitFailed = true
       }
     }
+
+    log()
+    logWithSpinner('📄', 'Generating README.md...')
+    await writeFileTree(context, {
+      'README.md': generateReadme(generator.pkg, packageManager)
+    })
+    stopSpinner()
 
     // log instructions
     stopSpinner()

--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -185,12 +185,13 @@ module.exports = class Creator extends EventEmitter {
       }
     }
 
+    // generate README.md
+    stopSpinner()
     log()
     logWithSpinner('📄', 'Generating README.md...')
     await writeFileTree(context, {
       'README.md': generateReadme(generator.pkg, packageManager)
     })
-    stopSpinner()
 
     // log instructions
     stopSpinner()

--- a/packages/@vue/cli/lib/util/generateReadme.js
+++ b/packages/@vue/cli/lib/util/generateReadme.js
@@ -1,0 +1,35 @@
+const textsForScripts = {
+  build: {
+    command: 'run build',
+    description: 'Build for production'
+  },
+  serve: {
+    command: 'run serve',
+    description: 'Start local server with hot reload'
+  },
+  test: {
+    command: 'run test',
+    description: 'Start local server with hot reload'
+  }
+}
+
+function getScripts (pkg, packageManager) {
+  return Object.keys(pkg.scripts).map(key => {
+    const text = textsForScripts[key]
+
+    if (text) {
+      return `
+### ${text.description}
+${packageManager} ${text.command}
+`
+    }
+  }).join('')
+}
+
+module.exports = function generateReadme (pkg, packageManager) {
+  return `# ${pkg.name}
+
+## Build setup
+${packageManager} install
+${getScripts(pkg, packageManager)}`
+}

--- a/packages/@vue/cli/lib/util/generateReadme.js
+++ b/packages/@vue/cli/lib/util/generateReadme.js
@@ -3,7 +3,7 @@ const descriptions = {
   serve: 'Compiles and hot-reloads for development',
   lint: 'Lints and fixes files',
   test: 'Run your tests',
-  'test:e2e': 'Run your tests end-to-end',
+  'test:e2e': 'Run your end-to-end tests',
   'test:unit': 'Run your unit tests'
 }
 

--- a/packages/@vue/cli/lib/util/generateReadme.js
+++ b/packages/@vue/cli/lib/util/generateReadme.js
@@ -1,35 +1,30 @@
-const textsForScripts = {
-  build: {
-    command: 'run build',
-    description: 'Build for production'
-  },
-  serve: {
-    command: 'run serve',
-    description: 'Start local server with hot reload'
-  },
-  test: {
-    command: 'run test',
-    description: 'Start local server with hot reload'
-  }
+const descriptions = {
+  build: 'Compiles and minifies for production',
+  serve: 'Compiles and hot-reloads for development',
+  lint: 'Lints and fixes files',
+  test: 'Run your tests',
+  'test:e2e': 'Run your tests end-to-end',
+  'test:unit': 'Run your unit tests'
 }
 
-function getScripts (pkg, packageManager) {
+function printScripts (pkg, packageManager) {
   return Object.keys(pkg.scripts).map(key => {
-    const text = textsForScripts[key]
+    const text = descriptions[key]
 
     if (text) {
-      return `
-### ${text.description}
-${packageManager} ${text.command}
-`
+      return [
+        `\n### ${text}`,
+        `${packageManager} run ${key}\n`
+      ].join('\n')
     }
   }).join('')
 }
 
 module.exports = function generateReadme (pkg, packageManager) {
-  return `# ${pkg.name}
-
-## Build setup
-${packageManager} install
-${getScripts(pkg, packageManager)}`
+  return [
+    `# ${pkg.name}\n`,
+    '## Project setup',
+    `${packageManager} install`,
+    printScripts(pkg, packageManager)
+  ].join('\n')
 }

--- a/packages/@vue/cli/lib/util/generateReadme.js
+++ b/packages/@vue/cli/lib/util/generateReadme.js
@@ -9,14 +9,10 @@ const descriptions = {
 
 function printScripts (pkg, packageManager) {
   return Object.keys(pkg.scripts).map(key => {
-    const text = descriptions[key]
-
-    if (text) {
-      return [
-        `\n### ${text}`,
-        `${packageManager} run ${key}\n`
-      ].join('\n')
-    }
+    return [
+      `\n### ${descriptions[key]}`,
+      `${packageManager} run ${key}\n`
+    ].join('\n')
   }).join('')
 }
 


### PR DESCRIPTION
Closes #1675.

As suggested in the issue, this PR adds a step to the `vue create` process to create a `README.md` based on the project's `package.json`.

I got some descriptions from the `cli-ui` package and created generic ones to the others. Please let me know if I missed any script/description.

Regarding the code, I used `Array.join`s to try to keep the code as clean as possible. I'm not sure if it's the best solution, but using only template strings in this situation is really messy in my opinion.

PS: If tests are necessary to this feature, let me know as well.