### PR TITLE
docs: add entry argument to serve command

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -32,7 +32,7 @@ npx vue-cli-service serve
 ## vue-cli-service serve
 
 ```
-Usage: vue-cli-service serve [options]
+Usage: vue-cli-service serve [options] [entry]
 
 Options:
 


### PR DESCRIPTION
This argument is present in the help text but not in the docs.