### PR TITLE
Wording change in the cli-service guide

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -23,7 +23,7 @@ npm run serve
 yarn serve
 ```
 
-If you have [npx](https://github.com/zkat/npx) available (should be bundled with an update-to-date version of npm), you can also invoke the binary directly with:
+If you have [npx](https://github.com/zkat/npx) available (should be bundled with an up-to-date version of npm), you can also invoke the binary directly with:
 
 ``` bash
 npx vue-cli-service serve


### PR DESCRIPTION
Change `update-to-date` to `up-to-date`. It sounded weird and doesn't appear in the dictionary: https://www.merriam-webster.com/dictionary/update-to-date