### PR TITLE
Fix #1735

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
+++ b/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
@@ -1,7 +1,7 @@
 // This file is imported into lib/wc client bundles.
 
 if (typeof window !== 'undefined') {
-  let i
+  var i
   if ((i = window.document.currentScript) && (i = i.src.match(/(.+\/)[^/]+\.js$/))) {
     __webpack_public_path__ = i[1] // eslint-disable-line
   }


### PR DESCRIPTION
Don't use ES6 in code that we inject into --lib builds
closes #1735 