### PR TITLE
feat: Remove unnecessary .vue extensions when importing

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/template/src/App.vue
+++ b/packages/@vue/cli-plugin-typescript/generator/template/src/App.vue
@@ -13,7 +13,7 @@ Welcome to Your Vue.js + TypeScript App
 <script lang="ts">
 <%_ if (!options.classComponent) { _%>
 import Vue from 'vue';
-import HelloWorld from './components/HelloWorld.vue';
+import HelloWorld from '@/components/HelloWorld';
 
 export default Vue.extend({
   name: 'app',
@@ -23,7 +23,7 @@ export default Vue.extend({
 });
 <%_ } else { _%>
 import { Component, Vue } from 'vue-property-decorator';
-import HelloWorld from './components/HelloWorld.vue';
+import HelloWorld from '@/components/HelloWorld';
 
 @Component({
   components: {

--- a/packages/@vue/cli-plugin-typescript/generator/template/src/views/Home.vue
+++ b/packages/@vue/cli-plugin-typescript/generator/template/src/views/Home.vue
@@ -14,7 +14,7 @@ Welcome to Your Vue.js + TypeScript App
 <script lang="ts">
 <%_ if (!options.classComponent) { _%>
 import Vue from 'vue';
-import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
+import HelloWorld from '@/components/HelloWorld';
 
 export default Vue.extend({
   name: 'home',
@@ -24,7 +24,7 @@ export default Vue.extend({
 });
 <%_ } else { _%>
 import { Component, Vue } from 'vue-property-decorator';
-import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
+import HelloWorld from '@/components/HelloWorld';
 
 @Component({
   components: {

--- a/packages/@vue/cli-plugin-unit-jest/generator/template/tests/unit/HelloWorld.spec.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/template/tests/unit/HelloWorld.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
-import HelloWorld from '@/components/HelloWorld.vue'
+import HelloWorld from '@/components/HelloWorld'
 
 describe('HelloWorld.vue', () => {
   it('renders props.msg when passed', () => {

--- a/packages/@vue/cli-plugin-unit-mocha/generator/template/tests/unit/HelloWorld.spec.js
+++ b/packages/@vue/cli-plugin-unit-mocha/generator/template/tests/unit/HelloWorld.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { shallowMount } from '@vue/test-utils'
-import HelloWorld from '@/components/HelloWorld.vue'
+import HelloWorld from '@/components/HelloWorld'
 
 describe('HelloWorld.vue', () => {
   it('renders props.msg when passed', () => {

--- a/packages/@vue/cli-service/generator/router/index.js
+++ b/packages/@vue/cli-service/generator/router/index.js
@@ -1,5 +1,5 @@
 module.exports = (api, options) => {
-  api.injectImports(api.entryFile, `import router from './router'`)
+  api.injectImports(api.entryFile, `import router from '@/router'`)
   api.injectRootOptions(api.entryFile, `router`)
   api.extendPackage({
     dependencies: {

--- a/packages/@vue/cli-service/generator/router/template/src/router.js
+++ b/packages/@vue/cli-service/generator/router/template/src/router.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import Router from 'vue-router'
-import Home from './views/Home.vue'
-import About from './views/About.vue'
+import Home from '@/views/Home'
+import About from '@/views/About'
 
 Vue.use(Router)
 

--- a/packages/@vue/cli-service/generator/router/template/src/views/Home.vue
+++ b/packages/@vue/cli-service/generator/router/template/src/views/Home.vue
@@ -6,8 +6,7 @@
 </template>
 
 <script>
-// @ is an alias to /src
-import HelloWorld from '@/components/HelloWorld.vue'
+import HelloWorld from '@/components/HelloWorld'
 
 export default {
   name: 'home',

--- a/packages/@vue/cli-service/generator/template/src/App.vue
+++ b/packages/@vue/cli-service/generator/template/src/App.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
+import HelloWorld from '@/components/HelloWorld'
 
 export default {
   name: 'app',

--- a/packages/@vue/cli-service/generator/template/src/main.js
+++ b/packages/@vue/cli-service/generator/template/src/main.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import App from './App.vue'
+import App from '@/App'
 
 Vue.config.productionTip = false
 

--- a/packages/@vue/cli-service/generator/vuex/index.js
+++ b/packages/@vue/cli-service/generator/vuex/index.js
@@ -1,5 +1,5 @@
 module.exports = (api, options) => {
-  api.injectImports(api.entryFile, `import store from './store'`)
+  api.injectImports(api.entryFile, `import store from '@/store'`)
   api.injectRootOptions(api.entryFile, `store`)
   api.extendPackage({
     dependencies: {


### PR DESCRIPTION
Also use the `@` alias everywhere to keep things consistent