### PR TITLE
Fix issue with Jest configuration regex not matching template.

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -31,7 +31,7 @@ module.exports = api => {
       'jest-serializer-vue'
     ],
     'testMatch': [
-      '<rootDir>/(tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx))'
+      '<rootDir>/(tests/unit/*.spec.(js|jsx|ts|tsx)|**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx))'
     ]
   }
 


### PR DESCRIPTION
This PR fixes the bug in generated configuration of Jest testing framework. Issue was that when you create project using vue-cli and select to use jest configuration regex would be setup to look under a folder within tests/unit directory. This change makes it look for files also directly in tests/unit directory.
Without this change template test `HelloWorld.spec.js` would also fail.
Closes #1686 