### PR TITLE
added correct hostname for webpack-dev-server which will be provided in vue-cli flag

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -87,7 +87,7 @@ module.exports = (api, options) => {
       const sockjsUrl = publicOpt ? `//${publicOpt}/sockjs-node` : url.format({
         protocol,
         port,
-        hostname: urls.lanUrlForConfig || 'localhost',
+        hostname: host || 'localhost',
         pathname: '/sockjs-node'
       })
 


### PR DESCRIPTION
I tried to run the vue-cli bootstrapped app in my cloud9 ide. As cloud9 provides own layered hostname for each instance of their app. I could run the app using 'npm run serve' but the app was looking for hot reload socket at `localhost ` but my hostname was different than `localhost`. I put `--host 0.0.0.0` and did not work. So I checked the cli serve command and which this i found. 