### PR TITLE
fix(babel): default polyfills need es6.array.iterator for IE

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -29,6 +29,8 @@ test('polyfill detection', () => {
   }))
   // default includes
   expect(code).toMatch(`import "core-js/modules/es6.promise"`)
+  // promise polyfill alone doesn't work in IE, needs this as well. fix: #1642
+  expect(code).toMatch(`import "core-js/modules/es6.array.iterator"`)
   // usage-based detection
   expect(code).toMatch(`import "core-js/modules/es6.map"`)
 })

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -1,7 +1,10 @@
 const path = require('path')
 
 const defaultPolyfills = [
-  'es6.promise'
+  'es6.promise',
+  // promise polyfill alone doesn't work in IE,
+  // needs this as well. see: #1642
+  'es6.array.iterator'
 ]
 
 function getPolyfills (targets, includes, { ignoreBrowserslistConfig, configPath }) {


### PR DESCRIPTION
close #1642