### PR TITLE
Include Tip about computed env vars

### DIFF
--- a/docs/guide/mode-and-env.md
+++ b/docs/guide/mode-and-env.md
@@ -74,7 +74,7 @@ In addition to `VUE_APP_*` variables, there are also two special variables that 
 
 All resolved env variables will be available inside `public/index.html` as discussed in [HTML - Interpolation](./html-and-static-assets.md#interpolation).
 
-::: You can have computed env vars in your vue.config.js file. They still need to be prefixed with `VUE_APP_`. This is useful for version info `process.env.VUE_APP_VERSION = `"${require('./package.json').version}"`` :::
+::: tip You can have computed env vars in your vue.config.js file. They still need to be prefixed with `VUE_APP_`. This is useful for version info `process.env.VUE_APP_VERSION = `"${require('./package.json').version}"`` :::
 
 ## Local Only Variables
 

--- a/docs/guide/mode-and-env.md
+++ b/docs/guide/mode-and-env.md
@@ -74,6 +74,8 @@ In addition to `VUE_APP_*` variables, there are also two special variables that 
 
 All resolved env variables will be available inside `public/index.html` as discussed in [HTML - Interpolation](./html-and-static-assets.md#interpolation).
 
+::: You can have computed env vars in your vue.config.js file. They still need to be prefixed with `VUE_APP_`. This is useful for version info `process.env.VUE_APP_VERSION = `"${require('./package.json').version}"`` :::
+
 ## Local Only Variables
 
 Sometimes you might have env variables that should not be committed into the codebase, especially if your project is hosted in a public repository. In that case you should use an `.env.local` file instead. Local env files are ignored in `.gitignore` by default.


### PR DESCRIPTION
I'm personally using this frivolously in my own footer
```
// vue.config.js
const revision = require('child_process').execSync('git rev-parse HEAD').toString().trim()
const pjson = require('./package.json')

process.env.VUE_APP_COMMIT = `"${revision}"`
process.env.VUE_APP_VERSION = `"${pjson.version}"`
module.exports = {}
```

```
<template>
  <footer>
      <span>v{{ version }} ({{ commit }})</span>
  </footer>
</template>

<script>
export default {
  data: function () {
    return {
      version: process.env.VUE_APP_VERSION,
      commit: process.env.VUE_APP_COMMIT
    }
  }
}
```

# Validation
 - I'm using this.
 - The inline require doesn't cause lint issues on vue-cli v3 config files. I did a full builds to check.