### PR TITLE
WIP: fix(cli): Inform earlier in promts flow about PostCSS

### DIFF
--- a/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
+++ b/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
@@ -2,7 +2,7 @@ module.exports = cli => {
   cli.injectFeature({
     name: 'CSS Pre-processors',
     value: 'css-preprocessor',
-    description: 'Add support for CSS pre-processors like SASS, Less or Stylus',
+    description: 'Add support for CSS pre-processors like SASS, Less or Stylus (PostCSS is always included)',
     link: 'https://cli.vuejs.org/guide/css.html'
   })
 


### PR DESCRIPTION
CLI should inform earlier that PostCSS, Autoprefixer and CSS Modules already being supported.
closes #1655

Just a UX improvement. Without this, people might think they have to select "yes" for "Add Pre-Processor support" to get PostCSS, only to realize that they can't (and don't have to) and must start over if they don't want to select any of the pre-processors offered.