### PR TITLE
docs(css.extract): Explain "always-off" in development mode

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -175,13 +175,15 @@ module.exports = {
 ### css.extract
 
 - Type: `boolean`
-- Default: `true` (in production mode)
+- Default: `true` (in production mode, always `false` otherwise)
 
   Whether to extract CSS in your components into a standalone CSS files (instead of inlined in JavaScript and injected dynamically).
 
   This is also disabled by default when building as web components (styles are inlined and injected into shadowRoot).
 
   When building as a library, you can also set this to `false` to avoid your users having to import the CSS themselves.
+  
+  Extracting CSS is always disabled in `development` since it breaks Hot Module Replacement.
 
 ### css.sourceMap
 


### PR DESCRIPTION
closes #1801