### PR TITLE
Fix modern plugin when building multi page applications with output in sub directories

### DIFF
--- a/packages/@vue/cli-service/lib/webpack/ModernModePlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/ModernModePlugin.js
@@ -25,7 +25,10 @@ class ModernModePlugin {
         // get stats, write to disk
         await fs.ensureDir(this.targetDir)
         const htmlName = path.basename(data.plugin.options.filename)
-        const tempFilename = path.join(this.targetDir, `legacy-assets-${htmlName}.json`)
+        // Watch out for output files in sub directories
+        const htmlPath = path.dirname(data.plugin.options.filename)
+        const tempFilename = path.join(this.targetDir, htmlPath, `legacy-assets-${htmlName}.json`)
+        await fs.mkdirp(path.dirname(tempFilename))
         await fs.writeFile(tempFilename, JSON.stringify(data.body))
         cb()
       })
@@ -52,7 +55,9 @@ class ModernModePlugin {
 
         // inject links for legacy assets as <script nomodule>
         const htmlName = path.basename(data.plugin.options.filename)
-        const tempFilename = path.join(this.targetDir, `legacy-assets-${htmlName}.json`)
+        // Watch out for output files in sub directories
+        const htmlPath = path.dirname(data.plugin.options.filename)
+        const tempFilename = path.join(this.targetDir, htmlPath, `legacy-assets-${htmlName}.json`)
         const legacyAssets = JSON.parse(await fs.readFile(tempFilename, 'utf-8'))
           .filter(a => a.tagName === 'script' && a.attributes)
         legacyAssets.forEach(a => { a.attributes.nomodule = '' })


### PR DESCRIPTION
The modern plugin will fail for multi page applications if the output is in sub directories. For example:

```
index.html
app2/index.html
```

This makes sure to append the directory to the `legacy-assets-index.html.json` files and make sure the sub-directories are created if needed. Solves my problems referenced in https://github.com/vuejs/vue-cli/issues/1683