### PR TITLE
Add the GitHub Pages platform guide

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -35,7 +35,23 @@ If you are using the PWA plugin, your app must be served over HTTPS so that [Ser
 
 ### GitHub Pages
 
-> TODO | Open to contribution.
+There are a few different ways to deploy as described by [GitHub Pages documentation](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/).  One way is to publish using a `/docs` folder on `master` branch.
+
+Create an initial `vue.config.js` file to [update the `outputDir`](https://cli.vuejs.org/config/#outputdir) value to match `docs`. Typically, your static website will be hosted on https://yourUserName.github.io/yourProjectName, so you will also want to [update the `BASE_URL`](https://github.com/vuejs/vue-cli/tree/dev/docs/config#baseurl) value to match:
+
+  ```javascript
+  // vue.config.js file to be place in the root of your repository
+  // make sure you update `yourProjectName` with the name of your GitHub project
+
+  module.exports = {
+    baseUrl: process.env.NODE_ENV === 'production'
+      ? '/yourProjectName/'
+      : '/',
+    outputDir: 'docs'
+  }
+  ```
+
+Generate the production build in `docs` directory with `npm run build`. Commit the `vue.config.js` file and the built files `docs/*`, then push to your repository's `master` branch. On GitHub, configure your repository's setting to [Publish your GitHub Pages site from a `docs` folder on your `master` branch](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/#publishing-your-github-pages-site-from-a-docs-folder-on-your-master-branch)
 
 ### GitLab Pages
 


### PR DESCRIPTION
Public repository at: https://github.com/serixscorpio/to-ghp illustrates publishing to GitHub Pages using the docs in this PR.
- published result https://serixscorpio.github.io/to-ghp/
- vue init commit: https://github.com/serixscorpio/to-ghp/commit/aec6c6515a31f56516197ca0a45564e41013c90a
- the commit that adds the files per documentation in this PR: https://github.com/serixscorpio/to-ghp/commit/b3978429c62ff60413124b6a92818bcc392a21a5
- using vue-cli `3.0.0-rc.4`