### PR TITLE
fix(resolvePreset): Gives priority to ~/.vuerc presets

### DIFF
--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -265,7 +265,9 @@ module.exports = class Creator extends EventEmitter {
     let preset
     const savedPresets = loadOptions().presets || {}
 
-    if (name.endsWith('.json')) {
+    if (name in savedPresets) {
+      preset = savedPresets[name]
+    } else if (name.endsWith('.json')) {
       preset = await fs.readJson(name)
     } else if (name.includes('/')) {
       logWithSpinner(`Fetching remote preset ${chalk.cyan(name)}...`)
@@ -278,8 +280,6 @@ module.exports = class Creator extends EventEmitter {
         error(`Failed fetching remote preset ${chalk.cyan(name)}:`)
         throw e
       }
-    } else {
-      preset = savedPresets[name]
     }
 
     // use default preset if user has not overwritten it


### PR DESCRIPTION
close #1871 

I could also provide a fix by adding a validator to here https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli/lib/Creator.js#L395 Let me know which one you prefer.