### PR TITLE
Added interface parameter

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -21,7 +21,8 @@ module.exports = (api, options) => {
       '--mode': `specify env mode (default: development)`,
       '--host': `specify host (default: ${defaults.host})`,
       '--port': `specify port (default: ${defaults.port})`,
-      '--https': `use https (default: ${defaults.https})`
+      '--https': `use https (default: ${defaults.https})`,
+      '--interface': `specify network interface`
     }
   }, async function serve (args) {
     info('Starting development server...')
@@ -68,12 +69,14 @@ module.exports = (api, options) => {
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
     portfinder.basePort = args.port || process.env.PORT || projectDevServerOptions.port || defaults.port
     const port = await portfinder.getPortPromise()
+    const networkInterface = args.interface || process.env.INTERFACE || projectDevServerOptions.interface
 
     const urls = prepareURLs(
       protocol,
       host,
       port,
-      options.baseUrl
+      options.baseUrl,
+      networkInterface
     )
 
     const proxySettings = prepareProxy(

--- a/packages/@vue/cli-service/lib/util/prepareURLs.js
+++ b/packages/@vue/cli-service/lib/util/prepareURLs.js
@@ -10,7 +10,7 @@ const url = require('url')
 const chalk = require('chalk')
 const address = require('address')
 
-module.exports = function prepareUrls (protocol, host, port, pathname = '/') {
+module.exports = function prepareUrls (protocol, host, port, pathname = '/', networkInterface) {
   const formatUrl = hostname =>
     url.format({
       protocol,
@@ -32,7 +32,7 @@ module.exports = function prepareUrls (protocol, host, port, pathname = '/') {
     prettyHost = 'localhost'
     try {
       // This can only return an IPv4 address
-      lanUrlForConfig = address.ip()
+      lanUrlForConfig = address.ip(networkInterface)
       if (lanUrlForConfig) {
         // Check if the address is a private ip
         // https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces


### PR DESCRIPTION
Now we can use ```--interface <inteface name>``` when calling to ```vue-cli-service serve```, or set an environment variable called ```INTERFACE``` with the interface name.

Ej:
package.json
```json
"scripts": {
    "serve": "vue-cli-service serve --progress --interface Ethernet",
    "build": "vue-cli-service build"
  },
```

To show a list of the interfaces you have:
```javascript
const os = require('os');
const interfaces = os.networkInterfaces();
console.log('interfaces =>', interfaces);
```
