### PR TITLE
fix(create): Commands added by plugin (through preset) won't have description in README

### DIFF
--- a/packages/@vue/cli/lib/util/generateReadme.js
+++ b/packages/@vue/cli/lib/util/generateReadme.js
@@ -9,6 +9,7 @@ const descriptions = {
 
 function printScripts (pkg, packageManager) {
   return Object.keys(pkg.scripts).map(key => {
+    if (!descriptions[key]) return ''
     return [
       `\n### ${descriptions[key]}`,
       '```',


### PR DESCRIPTION
For example, if my preset has vue-cli-plugin-s3-deploy, then when the project is created, my README contains the following:

````md
### undefined

```
npm run deploy
```
````

While my package.json has the following:

```js
"scripts": {
  "deploy": "vue-cli-service s3-deploy"
}
```