### PR TITLE
chore: Make the logging consistent and pretty

### DIFF
--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -141,7 +141,6 @@ module.exports = class Creator extends EventEmitter {
     }
 
     // run generator
-    log()
     log(`🚀  Invoking generators...`)
     this.emit('creation', { event: 'invoking-generators' })
     const plugins = await this.resolvePlugins(preset.plugins)
@@ -163,7 +162,6 @@ module.exports = class Creator extends EventEmitter {
     }
 
     // run complete cbs if any (injected by generators)
-    log()
     logWithSpinner('⚓', `Running completion hooks...`)
     this.emit('creation', { event: 'completion-hooks' })
     for (const cb of createCompleteCbs) {

--- a/packages/@vue/cli/lib/add.js
+++ b/packages/@vue/cli/lib/add.js
@@ -6,7 +6,6 @@ const {
   log,
   error,
   hasProjectYarn,
-  stopSpinner,
   resolvePluginId,
   resolveModule,
   loadModule
@@ -30,9 +29,6 @@ async function add (pluginName, options = {}, context = process.cwd()) {
   const packageManager = loadOptions().packageManager || (hasProjectYarn(context) ? 'yarn' : 'npm')
   await installPackage(context, packageManager, null, packageName)
 
-  stopSpinner()
-
-  log()
   log(`${chalk.green('✔')}  Successfully installed plugin: ${chalk.cyan(packageName)}`)
   log()
 

--- a/packages/@vue/cli/lib/invoke.js
+++ b/packages/@vue/cli/lib/invoke.js
@@ -131,6 +131,7 @@ async function runGenerator (context, plugin, pkg = getPkg(context)) {
 
   if (!isTestOrDebug && depsChanged) {
     log(`📦  Installing additional dependencies...`)
+    log()
     const packageManager =
       loadOptions().packageManager || (hasProjectYarn(context) ? 'yarn' : 'npm')
     await installDeps(context, packageManager)
@@ -141,12 +142,11 @@ async function runGenerator (context, plugin, pkg = getPkg(context)) {
     for (const cb of createCompleteCbs) {
       await cb()
     }
+    stopSpinner()
+    log()
   }
 
-  stopSpinner()
-
-  log()
-  log(`   Successfully invoked generator for plugin: ${chalk.cyan(plugin.id)}`)
+  log(`${chalk.green('✔')}  Successfully invoked generator for plugin: ${chalk.cyan(plugin.id)}`)
   if (!process.env.VUE_CLI_TEST && hasProjectGit(context)) {
     const { stdout } = await execa('git', [
       'ls-files',


### PR DESCRIPTION
Basically, the current logging is a bit haphazard with sometimes having a gap of 2 empty lines and sometimes with a gap of 1 empty line. This PR makes it consistent.

1. After running package install command, we don't need a new `log()`
2. Prettified invoking generator log
3. Made sure there's an empty line before the output of package install