### PR TITLE
feat(build): set output target before configureWebpack, close #1941

### DIFF
--- a/packages/@vue/cli-service/__tests__/buildLib.spec.js
+++ b/packages/@vue/cli-service/__tests__/buildLib.spec.js
@@ -88,3 +88,43 @@ test('build as lib (js)', async () => {
     return window.testLib.bar
   })).toBe(2)
 })
+
+test('build as lib with webpackConfiguration depending on target (js)', async () => {
+  const project = await create('build-lib-js-webpack-target', defaultPreset)
+  await project.write('src/a-library.js', `
+    export default {
+      foo: 'bar'
+    }
+  `)
+
+  await project.write('src/main.js', `
+    export * from 'a-library'
+  `)
+
+  await project.write('vue.config.js', `
+    const path = require('path')
+    module.exports = {
+      configureWebpack: config => {
+        config.resolve.alias['a-library'] = path.resolve(__dirname, 'src', 'a-library.js')
+
+        if (config.output.libraryTarget === 'umd') {
+          return
+        }
+
+        config.externals = ['a-library']
+      }
+    }
+  `)
+
+  const { stdout } = await project.run('vue-cli-service build --target lib --name testLib src/main.js')
+  expect(stdout).toMatch('Build complete.')
+
+  expect(project.has('dist/testLib.umd.js')).toBe(true)
+  expect(project.has('dist/testLib.common.js')).toBe(true)
+
+  const umdContent = await project.read('dist/testLib.umd.js')
+  expect(umdContent).toContain(`foo: 'bar'`)
+
+  const commonContent = await project.read('dist/testLib.common.js')
+  expect(commonContent).not.toContain(`foo: 'bar'`)
+})

--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -75,6 +75,9 @@ module.exports = (api, { entry, name }, options) => {
       .alias
         .set('~entry', fullEntryPath)
 
+    // set output target before user configureWebpack hooks are applied
+    config.output.libraryTarget(format)
+
     // set entry/output after user configureWebpack hooks are applied
     const rawConfig = api.resolveWebpackConfig(config)
 


### PR DESCRIPTION
Solves #1941. This allows tweaking the webpack config for different targets when building libraries.