### PR TITLE
Fix typo

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -226,7 +226,7 @@ async function build (args, api, options) {
             isFreshBuild
           ) {
             console.log(
-              chalk.gray(`Tip: the direcotry is meant to be served by an HTTP server, and will not work if\n` +
+              chalk.gray(`Tip: the directory is meant to be served by an HTTP server, and will not work if\n` +
               `you open it directly over file:// protocol. To preview it locally, use an HTTP\n` +
               `server like the ${chalk.yellow(`serve`)} package on npm.\n`)
             )


### PR DESCRIPTION
Fixes typo in console.log output when the build is the first build
(direcotry => directory)