### PR TITLE
Typo

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -114,7 +114,7 @@ program
 program
   .command('ui')
   .description('start and open the vue-cli ui')
-  .option('-p, --port <port>', 'Port used for the UI server (by default search for awailable port)')
+  .option('-p, --port <port>', 'Port used for the UI server (by default search for available port)')
   .option('-D, --dev', 'Run in dev mode')
   .option('--quiet', `Don't output starting messages`)
   .option('--headless', `Don't open browser on start and output port`)


### PR DESCRIPTION
There seems to be a typo when displaying the usage of the command -- see changeset.