### PR TITLE
docs(cli-plugin-babel): Fix config file name

### DIFF
--- a/packages/@vue/cli-plugin-babel/README.md
+++ b/packages/@vue/cli-plugin-babel/README.md
@@ -4,7 +4,7 @@
 
 ## Configuration
 
-Uses Babel 7 + `babel-loader` + [@vue/babel-preset-app](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app) by default, but can be configured via `.babelrc` to use any other Babel presets or plugins.
+Uses Babel 7 + `babel-loader` + [@vue/babel-preset-app](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app) by default, but can be configured via `babel.config.js` to use any other Babel presets or plugins.
 
 By default, `babel-loader` excludes files inside `node_modules` dependencies. If you wish to explicitly transpile a dependency module, you will need to add it to the `transpileDependencies` option in `vue.config.js`:
 


### PR DESCRIPTION
Replace mention of .babelrc with babel.config.js in README as we now strongly recommend the latter