### PR TITLE
chore(deps): update Prettier to 1.14

### DIFF
--- a/packages/@vue/eslint-config-prettier/package.json
+++ b/packages/@vue/eslint-config-prettier/package.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.2",
-    "prettier": "^1.12.1"
+    "prettier": "^1.14.0"
   }
 }


### PR DESCRIPTION
It has been released this weekend: https://prettier.io/blog/2018/07/29/1.14.0.html