### PR TITLE
Fix a message in checkNodeVersion.

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -11,7 +11,7 @@ function checkNodeVersion (wanted, id) {
   if (!semver.satisfies(process.version, wanted)) {
     console.log(chalk.red(
       'You are using Node ' + process.version + ', but this version of ' + id +
-      'requires Node ' + wanted + '.\nPlease upgrade your Node version.'
+      ' requires Node ' + wanted + '.\nPlease upgrade your Node version.'
     ))
     process.exit(1)
   }


### PR DESCRIPTION
From `this version of vue-clirequires Node >=8.9.`
To `this version of vue-cli requires Node >=8.9.`