### PR TITLE
WIP: Fix(eslint): Set parserOptions.ecmaVersion to 2017

### DIFF
--- a/packages/@vue/cli-plugin-eslint/__tests__/eslintGenerator.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/eslintGenerator.spec.js
@@ -12,7 +12,8 @@ test('base', async () => {
     'plugin:vue/essential', 'eslint:recommended'
   ])
   expect(pkg.eslintConfig.parserOptions).toEqual({
-    parser: 'babel-eslint'
+    parser: 'babel-eslint',
+    ecmaVersion: 2017
   })
 })
 
@@ -31,7 +32,8 @@ test('airbnb', async () => {
     '@vue/airbnb'
   ])
   expect(pkg.eslintConfig.parserOptions).toEqual({
-    parser: 'babel-eslint'
+    parser: 'babel-eslint',
+    ecmaVersion: 2017
   })
   expect(pkg.devDependencies).toHaveProperty('@vue/eslint-config-airbnb')
 })
@@ -51,7 +53,8 @@ test('standard', async () => {
     '@vue/standard'
   ])
   expect(pkg.eslintConfig.parserOptions).toEqual({
-    parser: 'babel-eslint'
+    parser: 'babel-eslint',
+    ecmaVersion: 2017
   })
   expect(pkg.devDependencies).toHaveProperty('@vue/eslint-config-standard')
 })
@@ -71,7 +74,8 @@ test('prettier', async () => {
     '@vue/prettier'
   ])
   expect(pkg.eslintConfig.parserOptions).toEqual({
-    parser: 'babel-eslint'
+    parser: 'babel-eslint',
+    ecmaVersion: 2017
   })
   expect(pkg.devDependencies).toHaveProperty('@vue/eslint-config-prettier')
 })

--- a/packages/@vue/cli-plugin-eslint/eslintOptions.js
+++ b/packages/@vue/cli-plugin-eslint/eslintOptions.js
@@ -10,7 +10,8 @@ exports.config = api => {
   }
   if (!api.hasPlugin('typescript')) {
     config.parserOptions = {
-      parser: 'babel-eslint'
+      parser: 'babel-eslint',
+      ecmaVersion: 2017,
     }
   }
   return config

--- a/packages/@vue/cli-plugin-eslint/generator.js
+++ b/packages/@vue/cli-plugin-eslint/generator.js
@@ -83,7 +83,9 @@ const applyTS = module.exports.applyTS = api => {
     eslintConfig: {
       extends: ['@vue/typescript'],
       parserOptions: {
-        parser: 'typescript-eslint-parser'
+        parser: 'typescript-eslint-parser',
+        // un-set ecmaVersion in case it was set because of babel before (see eslintOptions.js)
+        ecmaVersion: undefined
       }
     },
     devDependencies: {


### PR DESCRIPTION
This keeps babel-eslint from complaining about newer syntax like async/await