### PR TITLE
Adds css.alwaysExtract config option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -198,8 +198,8 @@ module.exports = {
 
 ### css.extract
 
-- Type: `boolean`
-- Default: `true` (in production mode, always `false` otherwise)
+- Type: `boolean | string`
+- Default: `'production'`
 
   Whether to extract CSS in your components into a standalone CSS files (instead of inlined in JavaScript and injected dynamically).
 
@@ -207,14 +207,7 @@ module.exports = {
 
   When building as a library, you can also set this to `false` to avoid your users having to import the CSS themselves.
 
-  Extracting CSS is always disabled in `development` since it breaks Hot Module Replacement.
-
-### css.alwaysExtract
-
-- Type: `boolean`
-- Default: `false`
-
-  Overrides `css.extract` and other checks determining if CSS should be extracted in to standalone file. 
+  Extracting CSS is disabled by default in `development` since it breaks Hot Module Replacement, can be enabled by setting this to `true`.
 
 ### css.sourceMap
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -209,6 +209,13 @@ module.exports = {
 
   Extracting CSS is always disabled in `development` since it breaks Hot Module Replacement.
 
+### css.alwaysExtract
+
+- Type: `boolean`
+- Default: `false`
+
+  Overrides `css.extract` and other checks determining if CSS should be extracted in to standalone file. 
+
 ### css.sourceMap
 
 - Type: `boolean`

--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -113,6 +113,19 @@ test('css.extract', () => {
   })
 })
 
+test('css.alwaysExtract', () => {
+  const config = genConfig({
+    vue: {
+      css: {
+        alwaysExtract: true
+      }
+    }
+  }, 'development')
+  LANGS.forEach(lang => {
+    expect(findLoaders(config, lang)).toContain(extractLoaderPath)
+  })
+})
+
 test('css.sourceMap', () => {
   const config = genConfig({
     postcss: {},

--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -113,16 +113,16 @@ test('css.extract', () => {
   })
 })
 
-test('css.alwaysExtract', () => {
+test('css.extract when development', () => {
   const config = genConfig({
     vue: {
       css: {
-        alwaysExtract: true
+        extract: 'production'
       }
     }
   }, 'development')
   LANGS.forEach(lang => {
-    expect(findLoaders(config, lang)).toContain(extractLoaderPath)
+    expect(findLoaders(config, lang)).not.toContain(extractLoaderPath)
   })
 })
 

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -15,15 +15,14 @@ module.exports = (api, options) => {
 
     const {
       modules = false,
-      extract = true,
-      alwaysExtract = false,
+      extract = 'production',
       sourceMap = false,
       loaderOptions = {}
     } = options.css || {}
 
     const shadowMode = !!process.env.VUE_CLI_CSS_SHADOW_MODE
     const isProd = process.env.NODE_ENV === 'production'
-    const shouldExtract = (isProd && extract !== false && !shadowMode) || alwaysExtract
+    const shouldExtract = ((!isProd && extract === true) || (isProd && (extract === true || extract === 'production'))) && !shadowMode
     const filename = getAssetPath(
       options,
       `css/[name]${options.filenameHashing ? '.[contenthash:8]' : ''}.css`,

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -16,13 +16,14 @@ module.exports = (api, options) => {
     const {
       modules = false,
       extract = true,
+      alwaysExtract = false,
       sourceMap = false,
       loaderOptions = {}
     } = options.css || {}
 
     const shadowMode = !!process.env.VUE_CLI_CSS_SHADOW_MODE
     const isProd = process.env.NODE_ENV === 'production'
-    const shouldExtract = isProd && extract !== false && !shadowMode
+    const shouldExtract = (isProd && extract !== false && !shadowMode) || alwaysExtract
     const filename = getAssetPath(
       options,
       `css/[name]${options.filenameHashing ? '.[contenthash:8]' : ''}.css`,

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -18,6 +18,7 @@ const schema = createSchema(joi => joi.object({
   css: joi.object({
     modules: joi.boolean(),
     extract: joi.alternatives().try(joi.boolean(), joi.object()),
+    alwaysExtract: joi.boolean(),
     sourceMap: joi.boolean(),
     loaderOptions: joi.object({
       css: joi.object(),

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -17,8 +17,7 @@ const schema = createSchema(joi => joi.object({
   // css
   css: joi.object({
     modules: joi.boolean(),
-    extract: joi.alternatives().try(joi.boolean(), joi.object()),
-    alwaysExtract: joi.boolean(),
+    extract: joi.alternatives().try(joi.boolean(), joi.object(), joi.string().allow('production')),
     sourceMap: joi.boolean(),
     loaderOptions: joi.object({
       css: joi.object(),


### PR DESCRIPTION
I found no logical option how to override those checks. So, I added option that allows to bypass assumptions that everyone uses HMR and doesn't want to extract CSS in to separate file while in development mode.