### PR TITLE
Fix issues with prefetch override docs

### DIFF
--- a/docs/guide/html-and-static-assets.md
+++ b/docs/guide/html-and-static-assets.md
@@ -51,7 +51,8 @@ module.exports = {
     // or:
     // modify its options:
     config.plugin('prefetch').tap(options => {
-      options.fileBlackList.push([/myasyncRoute(.)+?\.js$/])
+      options[0].fileBlacklist = options[0].fileBlacklist || []
+      options[0].fileBlacklist.push([/myasyncRoute(.)+?\.js$/])
       return options
     })
   }

--- a/docs/zh/guide/html-and-static-assets.md
+++ b/docs/zh/guide/html-and-static-assets.md
@@ -51,7 +51,8 @@ module.exports = {
     // 或者
     // 修改它的选项：
     config.plugin('prefetch').tap(options => {
-      options.fileBlackList.push([/myasyncRoute(.)+?\.js$/])
+      options[0].fileBlacklist = options[0].fileBlacklist || []
+      options[0].fileBlacklist.push([/myasyncRoute(.)+?\.js$/])
       return options
     })
   }


### PR DESCRIPTION
This fixes the following issues:
* The option is `fileBlacklist`, not `fileBlackList` (lowercase "L").
* This option is not specified by default, so you have to make sure it exists before calling `push` on it.
* You have to use `options[0]` to access the first options array member to get to the actual plugin options object (I'm not sure if this is documented better elsewhere?).