### PR TITLE
feat(service): Enable inspector debugging for unit test by mocha

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/README.md
+++ b/packages/@vue/cli-plugin-unit-mocha/README.md
@@ -22,6 +22,7 @@
     --bail, -b    bail after first test failure
     --require, -r require the given module before running tests
     --include     include the given module into test bundle
+    --inspect-brk Enable inspector to debug the tests
   ```
 
   Default files matches are: any files in `tests/unit` that end in `.spec.(ts|js)`.

--- a/packages/@vue/cli-plugin-unit-mocha/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/index.js
@@ -28,7 +28,8 @@ module.exports = api => {
       '--timeout, -t': 'timeout threshold in milliseconds',
       '--bail, -b': 'bail after first test failure',
       '--require, -r': 'require the given module before running tests',
-      '--include': 'include the given module into test bundle'
+      '--include': 'include the given module into test bundle',
+      '--inspect-brk': 'Enable inspector to debug the tests'
     },
     details: (
       `The above list only includes the most commonly used options.\n` +
@@ -36,6 +37,11 @@ module.exports = api => {
       `http://zinserjan.github.io/mocha-webpack/docs/installation/cli-usage.html`
     )
   }, (args, rawArgv) => {
+    const inspectPos = rawArgv.indexOf('--inspect-brk')
+    let nodeArgs = []
+    if (inspectPos !== -1) {
+      nodeArgs = rawArgv.splice(inspectPos, inspectPos + 1)
+    }
     // for @vue/babel-preset-app
     process.env.VUE_CLI_BABEL_TARGET_NODE = true
     // start runner
@@ -43,6 +49,8 @@ module.exports = api => {
     const bin = require.resolve('mocha-webpack/bin/mocha-webpack')
     const hasInlineFilesGlob = args._ && args._.length
     const argv = [
+      ...nodeArgs,
+      bin,
       '--recursive',
       '--require',
       require.resolve('./setup.js'),
@@ -57,7 +65,7 @@ module.exports = api => {
     ]
 
     return new Promise((resolve, reject) => {
-      const child = execa(bin, argv, { stdio: 'inherit' })
+      const child = execa('node', argv, { stdio: 'inherit' })
       child.on('error', reject)
       child.on('exit', code => {
         if (code !== 0) {


### PR DESCRIPTION
Mocha test cases cannot be debugged by the same solution of jest [doc](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest#debugging-tests):
```
node --inspect-brk ./node_modules/.bin/vue-cli-service test:unit
```
The command above will start the debugger on `vue-cli-service` instead of mocha, the mocha is running in another process so the `--inspect-brk` argument must be added to the node command which run the `mocha-webpack`. Here is the debugging solution from `mocha-webpack`:
https://github.com/zinserjan/mocha-webpack/issues/67#issuecomment-260088018

A new option `--inspect-brk` is added in this PR to enable the debug mode of `mocha-webpack`.