### PR TITLE
Remove base rules from ESLint UI

### DIFF
--- a/packages/@vue/cli-plugin-eslint/__tests__/ui.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/ui.spec.js
@@ -112,9 +112,18 @@ describe('getEslintPrompts', () => {
     'dolor': {
       meta: {
         docs: {
-          category: 'base',
+          category: 'strongly-recommended',
           description: 'Dolor description',
           url: 'http://test.com/dolor'
+        }
+      }
+    },
+    'sit': {
+      meta: {
+        docs: {
+          category: 'base',
+          description: 'Sit description',
+          url: 'http://test.com/sit'
         }
       }
     }
@@ -122,7 +131,7 @@ describe('getEslintPrompts', () => {
 
   const prompts = getEslintPrompts(data, rules)
 
-  it('creates an array with three settings', () => {
+  it('creates an array with 3 settings, leaving out category "base"', () => {
     expect(prompts).toHaveLength(3)
   })
 
@@ -147,7 +156,7 @@ describe('getEslintPrompts', () => {
     expect(prompts[2].choices).toHaveLength(4)
   })
 
-  it('sets a default value to "ERROR" for rule that belong to the choosen config', () => {
+  it('sets a default value to "ERROR" for rule that belong to the chosen config', () => {
     expect(prompts[0].default).toBe('"error"')
     expect(prompts[1].default).toBe('"error"')
     expect(prompts[2].default).toBe('"off"')

--- a/packages/@vue/cli-plugin-eslint/ui/configDescriptor.js
+++ b/packages/@vue/cli-plugin-eslint/ui/configDescriptor.js
@@ -1,7 +1,6 @@
 const CONFIG = 'org.vue.eslintrc'
 
 const CATEGORIES = [
-  'base',
   'essential',
   'strongly-recommended',
   'recommended',

--- a/packages/@vue/cli-ui/locales/en.json
+++ b/packages/@vue/cli-ui/locales/en.json
@@ -584,7 +584,6 @@
               "essential": "Essential",
               "strongly-recommended": "Strongly recommended",
               "recommended": "Recommended",
-              "use-with-caution": "Use with caution",
               "uncategorized": "Uncategorized"
             },
             "setting": {


### PR DESCRIPTION
Since the base rules are necessary to get ESLint parsing to work properly for Vue and not really something users will typically configure, I think it makes sense not to show them in the UI.