### PR TITLE
Include esnext in lib

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -26,10 +26,7 @@
       ]
     },
     "lib": [
-      "es2015",
-      <%_ if (options.useTsWithBabel) { _%>
       "esnext",
-      <%_ } _%>
       "dom",
       "dom.iterable",
       "scripthost"

--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -27,6 +27,9 @@
     },
     "lib": [
       "es2015",
+      <%_ if (options.useTsWithBabel) { _%>
+      "esnext",
+      <%_ } _%>
       "dom",
       "dom.iterable",
       "scripthost"


### PR DESCRIPTION
TypeScript was complaining about `Array.includes` not existing. Having `esnext` as a target isn't sufficient.