### PR TITLE
fix(cli-plugin-typescript): tsconfig whitespace

### DIFF
--- a/packages/@vue/cli-plugin-typescript/__tests__/tsGenerator.spec.js
+++ b/packages/@vue/cli-plugin-typescript/__tests__/tsGenerator.spec.js
@@ -110,10 +110,11 @@ test('tsconfig.json should be valid json', async () => {
   expect(() => {
     JSON.parse(files['tsconfig.json'])
   }).not.toThrow()
+  expect(files['tsconfig.json']).not.toMatch('"  ')
 })
 
 test('compat with unit-mocha', async () => {
-  const { pkg } = await generateWithPlugin([
+  const { pkg, files } = await generateWithPlugin([
     {
       id: '@vue/cli-plugin-unit-mocha',
       apply: require('@vue/cli-plugin-unit-mocha/generator'),
@@ -131,10 +132,12 @@ test('compat with unit-mocha', async () => {
 
   expect(pkg.devDependencies).toHaveProperty('@types/mocha')
   expect(pkg.devDependencies).toHaveProperty('@types/chai')
+
+  expect(files['tsconfig.json']).not.toMatch('"  ')
 })
 
 test('compat with unit-jest', async () => {
-  const { pkg } = await generateWithPlugin([
+  const { pkg, files } = await generateWithPlugin([
     {
       id: '@vue/cli-plugin-unit-jest',
       apply: require('@vue/cli-plugin-unit-jest/generator'),
@@ -151,4 +154,6 @@ test('compat with unit-jest', async () => {
   ])
 
   expect(pkg.devDependencies).toHaveProperty('@types/jest')
+
+  expect(files['tsconfig.json']).not.toMatch('"  ')
 })

--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -13,10 +13,11 @@
     "sourceMap": true,
     "baseUrl": ".",
     "types": [
-      "node"<%_ if (hasMocha) { _%>,
+      "node"<% if (hasMocha || hasJest) { %>,<% } %>
+      <%_ if (hasMocha) { _%>
       "mocha",
       "chai"
-      <%_ } else if (hasJest) { _%>,
+      <%_ } else if (hasJest) { _%>
       "jest"
       <%_ } _%>
     ],


### PR DESCRIPTION
cli-plugin-typescript without a tests plugin generates tsconfig.json with incorrect spacing:

```json
"types": [
  "node"    ],
```

This fixes the formatting and tests each configuration:
```json
"types": [
  "node"
],
```