### PR TITLE
fix(cli-plugin-e2e-cypress): #2047 custom --config option error for cypress

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/index.js
@@ -17,6 +17,7 @@ module.exports = (api, options) => {
     removeArg(rawArgs, 'headless', 0)
     removeArg(rawArgs, 'mode')
     removeArg(rawArgs, 'url')
+    removeArg(rawArgs, 'config')
 
     info(`Starting e2e tests...`)
 
@@ -26,7 +27,7 @@ module.exports = (api, options) => {
 
     const cyArgs = [
       args.headless ? 'run' : 'open', // open or run
-      '--config', `baseUrl=${url}`,
+      '--config', [`baseUrl=${url}`, ... args.config && args.config.split(',') || []].join(','),
       ...rawArgs
     ]
 


### PR DESCRIPTION
Fix https://github.com/vuejs/vue-cli/issues/2047 by join the config of user with the `baseUrl` one of vueCLI