### PR TITLE
Lighthouse PWA audit

### DIFF
--- a/packages/@vue/cli-service/generator/router/template/src/views/Home.vue
+++ b/packages/@vue/cli-service/generator/router/template/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="home">
-    <img src="../assets/logo.png">
+    <img alt="Vue logo" src="../assets/logo.png">
     <%_ if (!rootOptions.bare) { _%>
     <HelloWorld msg="Welcome to Your Vue.js App"/>
     <%_ } else { _%>

--- a/packages/@vue/cli-service/generator/template/public/index.html
+++ b/packages/@vue/cli-service/generator/template/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/packages/@vue/cli-service/generator/template/src/App.vue
+++ b/packages/@vue/cli-service/generator/template/src/App.vue
@@ -1,7 +1,7 @@
 <%_ if (!rootOptions.router) { _%>
 <template>
   <div id="app">
-    <img src="./assets/logo.png">
+    <img alt="Vue logo" src="./assets/logo.png">
     <%_ if (!rootOptions.bare) { _%>
     <HelloWorld msg="Welcome to Your Vue.js App"/>
     <%_ } else { _%>

--- a/packages/@vue/cli-service/generator/template/src/components/HelloWorld.vue
+++ b/packages/@vue/cli-service/generator/template/src/components/HelloWorld.vue
@@ -5,29 +5,29 @@
     <p>
       For guide and recipes on how to configure / customize this project,<br>
       check out the
-      <a href="https://cli.vuejs.org" target="_blank">vue-cli documentation</a>.
+      <a href="https://cli.vuejs.org" target="_blank" rel="noopener">vue-cli documentation</a>.
     </p>
     <h3>Installed CLI Plugins</h3>
     <ul>
       <%_ for (plugin of plugins) { _%>
-      <li><a href="<%- plugin.link %>" target="_blank"><%- plugin.name %></a></li>
+      <li><a href="<%- plugin.link %>" target="_blank" rel="noopener"><%- plugin.name %></a></li>
       <%_ } _%>
     </ul>
     <h3>Essential Links</h3>
     <ul>
-      <li><a href="https://vuejs.org" target="_blank">Core Docs</a></li>
-      <li><a href="https://forum.vuejs.org" target="_blank">Forum</a></li>
-      <li><a href="https://chat.vuejs.org" target="_blank">Community Chat</a></li>
-      <li><a href="https://twitter.com/vuejs" target="_blank">Twitter</a></li>
-      <li><a href="https://news.vuejs.org" target="_blank">News</a></li>
+      <li><a href="https://vuejs.org" target="_blank" rel="noopener">Core Docs</a></li>
+      <li><a href="https://forum.vuejs.org" target="_blank" rel="noopener">Forum</a></li>
+      <li><a href="https://chat.vuejs.org" target="_blank" rel="noopener">Community Chat</a></li>
+      <li><a href="https://twitter.com/vuejs" target="_blank" rel="noopener">Twitter</a></li>
+      <li><a href="https://news.vuejs.org" target="_blank" rel="noopener">News</a></li>
     </ul>
     <h3>Ecosystem</h3>
     <ul>
-      <li><a href="https://router.vuejs.org" target="_blank">vue-router</a></li>
-      <li><a href="https://vuex.vuejs.org" target="_blank">vuex</a></li>
-      <li><a href="https://github.com/vuejs/vue-devtools#vue-devtools" target="_blank">vue-devtools</a></li>
-      <li><a href="https://vue-loader.vuejs.org" target="_blank">vue-loader</a></li>
-      <li><a href="https://github.com/vuejs/awesome-vue" target="_blank">awesome-vue</a></li>
+      <li><a href="https://router.vuejs.org" target="_blank" rel="noopener">vue-router</a></li>
+      <li><a href="https://vuex.vuejs.org" target="_blank" rel="noopener">vuex</a></li>
+      <li><a href="https://github.com/vuejs/vue-devtools#vue-devtools" target="_blank" rel="noopener">vue-devtools</a></li>
+      <li><a href="https://vue-loader.vuejs.org" target="_blank" rel="noopener">vue-loader</a></li>
+      <li><a href="https://github.com/vuejs/awesome-vue" target="_blank" rel="noopener">awesome-vue</a></li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
With some minor changes, we can significantly increase the Lighthouse score of the vue-cli default application. Considering people will use the generated app as a guide, I think it's worth following best practices. Plus it makes the pwa plugin look better to earn a good score by default :) This was addressed in #1532 though so feel free to close if you don't feel it's necessary. 

Before:
<img width="416" alt="before" src="https://user-images.githubusercontent.com/25833388/43679475-99819d0e-97da-11e8-8304-b62ae5fda737.png">

After:
<img width="416" alt="after" src="https://user-images.githubusercontent.com/25833388/43679476-9ac6ebce-97da-11e8-9aa0-2d520f35bb88.png">