### PR TITLE
fix the wrong homepage link in package.json of cli-plugin-typescript

### DIFF
--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/vuejs/vue-cli/issues"
   },
-  "homepage": "https://github.com/vuejs/vue-cli/packages/@vue/cli-plugin-typescript#readme",
+  "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-plugin-typescript#readme",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
the original link cannot be opened. add 'tree/dev' into the path so it works. the same problem also occurs in other cli-plugins.