### PR TITLE
chore(deps): update typescript-eslint-parser to ^18.0.0

### DIFF
--- a/packages/@vue/eslint-config-typescript/package.json
+++ b/packages/@vue/eslint-config-typescript/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/eslint-config-typescript#readme",
   "dependencies": {
     "eslint-plugin-typescript": "^0.12.0",
-    "typescript-eslint-parser": "^17.0.1"
+    "typescript-eslint-parser": "^18.0.0"
   }
 }


### PR DESCRIPTION
The version [18.0.0](https://github.com/eslint/typescript-eslint-parser/releases/tag/v18.0.0) add support for TypeScript 3.