### PR TITLE
fix: remove deprecated opptions in babel-plugin-transform-runtime 7

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -135,11 +135,8 @@ module.exports = (context, options = {}) => {
 
   // transform runtime, but only for helpers
   plugins.push([require('@babel/plugin-transform-runtime'), {
-    polyfill: false,
     regenerator: useBuiltIns !== 'usage',
-    useBuiltIns: useBuiltIns !== false,
     useESModules: !process.env.VUE_CLI_BABEL_TRANSPILE_MODULES,
-    moduleName: path.dirname(require.resolve('@babel/runtime/package.json'))
   }])
 
   return {


### PR DESCRIPTION
Per [babel-plugin-transform-runtime](https://babeljs.io/docs/en/next/babel-plugin-transform-runtime#polyfill), these options have been removed in v7 by just making it the default.