### PR TITLE
fix: allow relative baseUrl

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -54,10 +54,6 @@ module.exports = {
   Always use `baseUrl` instead of modifying webpack `output.publicPath`.
   :::
 
-  ::: tip
-  To have a relative `baseUrl` do not forget to prefix it with `./`. If the publicPath would be `foo/bar`, use `bsreUrl:"./foo/bar"`.
-  :::
-
 ### outputDir
 
 - Type: `string`

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -54,6 +54,10 @@ module.exports = {
   Always use `baseUrl` instead of modifying webpack `output.publicPath`.
   :::
 
+  ::: tip
+  To have a relative `baseUrl` do not forget to prefix it with `./`. If the publicPath would be `foo/bar`, use `bsreUrl:"./foo/bar"`.
+  :::
+
 ### outputDir
 
 - Type: `string`

--- a/packages/@vue/cli-service/__tests__/Service.spec.js
+++ b/packages/@vue/cli-service/__tests__/Service.spec.js
@@ -94,6 +94,16 @@ test('handle option baseUrl and outputDir correctly', () => {
   expect(service.projectOptions.outputDir).toBe('/public')
 })
 
+test('normalize baseUrl when relative', () => {
+  mockPkg({
+    vue: {
+      baseUrl: './foo/bar'
+    }
+  })
+  const service = createMockService()
+  expect(service.projectOptions.baseUrl).toBe('foo/bar/')
+})
+
 test('load project options from vue.config.js', () => {
   process.env.VUE_CLI_SERVICE_CONFIG_PATH = `/vue.config.js`
   fs.writeFileSync('/vue.config.js', `module.exports = { lintOnSave: false }`)

--- a/packages/@vue/cli-service/__tests__/Service.spec.js
+++ b/packages/@vue/cli-service/__tests__/Service.spec.js
@@ -104,6 +104,16 @@ test('normalize baseUrl when relative', () => {
   expect(service.projectOptions.baseUrl).toBe('foo/bar/')
 })
 
+test('keep baseUrl when empty', () => {
+  mockPkg({
+    vue: {
+      baseUrl: ''
+    }
+  })
+  const service = createMockService()
+  expect(service.projectOptions.baseUrl).toBe('')
+})
+
 test('load project options from vue.config.js', () => {
   process.env.VUE_CLI_SERVICE_CONFIG_PATH = `/vue.config.js`
   fs.writeFileSync('/vue.config.js', `module.exports = { lintOnSave: false }`)

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -298,10 +298,10 @@ module.exports = class Service {
     }
 
     // normalize some options
+    ensureSlash(resolved, 'baseUrl')
     if (typeof resolved.baseUrl === 'string') {
       resolved.baseUrl = resolved.baseUrl.replace(/^\.\//, '')
     }
-    ensureSlash(resolved, 'baseUrl')
     removeSlash(resolved, 'outputDir')
 
     // deprecation warning


### PR DESCRIPTION
fix #2153

When normalizing "./foo/bar" baseurl option, the code was first removing the "./" to make it relative (foo/bar).
Then it was making sure that, if it was starting with neither a `/` nor a `.`, ensure it would start with a `/`, disallowing any relative baseUrl.

I think those two normalizations should be reversed to allow for `./foo/bar` to become `foo/bar/`.