### PR TITLE
fix(ci): add testMatch because of mock-preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "/temp/",
       "/scripts/",
       ".*.helper.js"
-    ]
+    ],
+    "testMatch": ["**/*.spec.js"]
   },
   "lint-staged": {
     "*.{js,vue}": [


### PR DESCRIPTION
In commit [3b21fad86](https://github.com/vuejs/vue-cli/commit/3b21fad86) js files were added to the `__tests__` folder and jest was interpreting them as test suites. Not finding any tests in them, it made the following ci command fail 
```
yarn test
```
Therefore, AppVeyor is saying that the tests are not passing.
Passing now