### PR TITLE
修正 webpack.md 中文翻译

### DIFF
--- a/docs/zh/guide/webpack.md
+++ b/docs/zh/guide/webpack.md
@@ -38,7 +38,7 @@ module.exports = {
 
 ## 链式操作 (高级)
 
-webpack 内部的配置是通过 [webpack-chain](https://github.com/mozilla-neutrino/webpack-chain) 维护的。这个库提供了一个 webpack 原始配置的上层抽象，使其可以定义具名的 loader 规则和具名插件，并有机会在后期进入这些规则并对它们的选项进行修改。
+Vue CLI 内部的 webpack 配置是通过 [webpack-chain](https://github.com/mozilla-neutrino/webpack-chain) 维护的。这个库提供了一个 webpack 原始配置的上层抽象，使其可以定义具名的 loader 规则和具名插件，并有机会在后期进入这些规则并对它们的选项进行修改。
 
 它允许我们更细粒度的控制其内部配置。接下来有一些常见的在 `vue.config.js` 中的 `chainWebpack` 修改的例子。
 


### PR DESCRIPTION
原来的翻译有一点歧义，可能让人误以为 webpack 内部在使用 [webpack-chain](https://github.com/mozilla-neutrino/webpack-chain)。修改了一下让意思更准确。