### PR TITLE
fix(ci): make matcher more precise

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "<rootDir>/scripts/testSetup.js"
     ],
     "testMatch": [
-      "**/*.spec.js"
+      "**/__tests__/**/*.spec.js"
     ]
   },
   "lint-staged": {


### PR DESCRIPTION
After adding the testMatch parameter,
jest is now picking up files as test suites that it should not:
example:
`cli-plugin-unit-mocha/generator/template/tests/unit/HelloWorld.spec.js`

This commit makes jest match only files in `__tests__`