### PR TITLE
docs: fix typo & tweak link name

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -196,7 +196,7 @@ module.exports = {
 
   Note that this only affects tags injected by `html-webpack-plugin` - tags directly added in the source template (`public/index.html`) are not affected.
 
-  See also: [CORS setting attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
+  See also: [CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
 
 ### integrity
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -194,7 +194,7 @@ module.exports = {
 
   需要注意的是该选项仅影响由 `html-webpack-plugin` 在构建时注入的标签 - 直接写在模版 (`public/index.html`) 中的标签不受影响。
 
-  更多细节可查阅: [CROS setting attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
+  更多细节可查阅: [CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
 
 ### integrity
 


### PR DESCRIPTION
```
See also: [CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
```

- setting -> settings
- zh docs:  CROS -> CORS