### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This PR add [`.editorconfig` file](https://editorconfig.org/) which will autofix trailing spaces (common case in documentation), charsets and end-of-line styles when IDE supported it (native or via plugin)