### PR TITLE
fix(babel-jest): add parantheses to babel-jest regex for jsx and js f…

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -43,7 +43,7 @@ module.exports = (api, _, __, invoking) => {
     api.extendPackage({
       jest: {
         transform: {
-          '^.+\\.jsx?$': 'babel-jest'
+          '^.+\\.(jsx?)$': 'babel-jest'
         }
       }
     })


### PR DESCRIPTION
Hi!
Today I got this error by importing a **.js** file.

```bash
    SyntaxError: Unexpected token import

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:403:17)
```
 It's described already at this thread: https://github.com/facebook/jest/issues/4604

I fixed it by adding parantheses to the jsx RegExp. 
This is a really strange behavior from jest, because the regex is completely correct.