### PR TITLE
Use gitignore best practices

### DIFF
--- a/packages/@vue/cli-service/generator/template/_gitignore
+++ b/packages/@vue/cli-service/generator/template/_gitignore
@@ -1,5 +1,4 @@
-.DS_Store
-node_modules
+node_modules/
 /dist
 <%_ if (rootOptions.plugins && rootOptions.plugins['@vue/cli-plugin-e2e-nightwatch']) { _%>
 
@@ -20,12 +19,3 @@ selenium-debug.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# Editor directories and files
-.idea
-.vscode
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw*


### PR DESCRIPTION
The main purpose of this is to remove platform specific entries from the gitignore template. Namely, OS-specific and editor-specific files belong in developers' global gitignore configuration, not the source repository gitignore, since they do not pertain to the project code itself.

This is also in the interest of keeping the template-generated surface of vue-cli as minimal as possible, since those parts do not automatically get updated when upstream improvements are made.