### PR TITLE
Adds missing installation instructions for Vue UI

### DIFF
--- a/docs/guide/creating-a-project.md
+++ b/docs/guide/creating-a-project.md
@@ -58,7 +58,7 @@ Options:
 
 ## Using the GUI
 
-You can also create and manage projects using a graphical interface with the `vue ui` command:
+You can also create and manage projects using the graphical interface provided by [Vue UI](https://github.com/vuejs/ui). After a successful [installation of Vue UI](https://github.com/vuejs/ui#installation), you can open the GUI with the command: 
 
 ``` bash
 vue ui


### PR DESCRIPTION
The [Using the GUI](https://cli.vuejs.org/guide/creating-a-project.html#using-the-gui) part of page [Creating a project](https://cli.vuejs.org/guide/creating-a-project.html#vue-create) was missing instructions on installing Vue UI before running `vue ui`.

This PR adds instructions to first install Vue UI before running `vue ui`.