### PR TITLE
fix: Use relative paths in manifest.json for compatibility with Github Pages

### DIFF
--- a/packages/@vue/cli-plugin-pwa/generator/template/public/manifest.json
+++ b/packages/@vue/cli-plugin-pwa/generator/template/public/manifest.json
@@ -3,17 +3,17 @@
   "short_name": "<%- rootOptions.projectName %>",
   "icons": [
     {
-      "src": "/img/icons/android-chrome-192x192.png",
+      "src": "img/icons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/android-chrome-512x512.png",
+      "src": "img/icons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
-  "start_url": "/index.html",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#4DBA87"

--- a/packages/@vue/cli-plugin-pwa/generator/template/public/manifest.json
+++ b/packages/@vue/cli-plugin-pwa/generator/template/public/manifest.json
@@ -3,17 +3,17 @@
   "short_name": "<%- rootOptions.projectName %>",
   "icons": [
     {
-      "src": "img/icons/android-chrome-192x192.png",
+      "src": "./img/icons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "img/icons/android-chrome-512x512.png",
+      "src": "./img/icons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
-  "start_url": "index.html",
+  "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#4DBA87"


### PR DESCRIPTION
When deploying applications using Github Pages, and other scenarios, absolute paths don't work because the website is served under a subdirectory. But using relative paths should work in all scenarios where `manifest.json`, `index.html` and the icons folder are on the same location. Which should be the case with the generated files if they are not modified.

In case this is not accepted, it should at least be documented because the current setup is generating PWAs that don't have proper icons in Github Pages. This same thing happens with vuepress, so once this is resolved I'll do the same on the other repo.