### PR TITLE
docs(cli-ui): add more notes for local development

### DIFF
--- a/packages/@vue/cli-ui/README.md
+++ b/packages/@vue/cli-ui/README.md
@@ -6,13 +6,13 @@ Before starting a local cli-ui instance,
 consider following the [contributing guide](https://github.com/vuejs/vue-cli/blob/dev/.github/CONTRIBUTING.md)
 in order to download all required dependencies of vue-cli's packages.
 
-Just after, you should serve `@vue/cli-ui-addon-webpack` by running:
+Just after, you should build `@vue/cli-ui-addon-webpack` by running:
 ```bash
 cd ../cli-ui-addon-webpack
-yarn serve
+yarn build
 ```
 
-Then you should open a new terminal and start the ui server (based on Apollo):
+Then you start the ui server (based on Apollo):
 
 ```
 cd ../cli-ui
@@ -27,16 +27,10 @@ yarn run serve
 
 #### Testing
 
-Before running E2E tests, you should start a new local testing apollo server with the following command:
+For running E2E tests, you just need to run:
 
 ```
 yarn run test:e2e
-```
-
-Then in another terminal:
-
-```
-yarn run test:e2e:dev
 ```
 
 This will open a new [Cypress](https://www.cypress.io/) window.

--- a/packages/@vue/cli-ui/README.md
+++ b/packages/@vue/cli-ui/README.md
@@ -6,10 +6,11 @@ Before starting a local cli-ui instance,
 consider following the [contributing guide](https://github.com/vuejs/vue-cli/blob/dev/.github/CONTRIBUTING.md)
 in order to download all required dependencies of vue-cli's packages.
 
-Just after, you should build `@vue/cli-ui-addon-webpack` by running:
+Just after, you should build once then serve `@vue/cli-ui-addon-webpack` by running:
 ```bash
 cd ../cli-ui-addon-webpack
-yarn build
+yarn build # just do once
+yarn serve
 ```
 
 Then you start the ui server (based on Apollo):

--- a/packages/@vue/cli-ui/README.md
+++ b/packages/@vue/cli-ui/README.md
@@ -24,3 +24,20 @@ And then in another terminal, you should serve cli-ui:
 ```
 yarn run serve
 ```
+
+#### Testing
+
+Before running E2E tests, you should start a new local testing apollo server with the following command:
+
+```
+yarn run test:e2e
+```
+
+Then in another terminal:
+
+```
+yarn run test:e2e:dev
+```
+
+This will open a new [Cypress](https://www.cypress.io/) window.
+You can now run all or specific integration tests.

--- a/packages/@vue/cli-ui/README.md
+++ b/packages/@vue/cli-ui/README.md
@@ -2,24 +2,24 @@
 
 ### Local development
 
-Before starting a local cli-ui instance, 
-consider following the [contributing guide](https://github.com/vuejs/vue-cli/blob/dev/.github/CONTRIBUTING.md) 
+Before starting a local cli-ui instance,
+consider following the [contributing guide](https://github.com/vuejs/vue-cli/blob/dev/.github/CONTRIBUTING.md)
 in order to download all required dependencies of vue-cli's packages.
- 
-Just after, you should build `@vue/cli-ui-addon-webpack` by running:
+
+Just after, you should serve `@vue/cli-ui-addon-webpack` by running:
 ```bash
 cd ../cli-ui-addon-webpack
-yarn build
-cd -
+yarn serve
 ```
 
-Then you should start a local Apollo server:
+Then you should open a new terminal and start the ui server (based on Apollo):
 
 ```
+cd ../cli-ui
 yarn run apollo
 ```
 
-And then in another terminal, you should serve cli-ui:
+And then in another terminal, you should serve the ui web app:
 
 ```
 yarn run serve

--- a/packages/@vue/cli-ui/README.md
+++ b/packages/@vue/cli-ui/README.md
@@ -1,15 +1,26 @@
 # @vue/cli-ui
 
-Start development version:
+### Local development
 
-```
-yarn run serve
+Before starting a local cli-ui instance, 
+consider following the [contributing guide](https://github.com/vuejs/vue-cli/blob/dev/.github/CONTRIBUTING.md) 
+in order to download all required dependencies of vue-cli's packages.
+ 
+Just after, you should build `@vue/cli-ui-addon-webpack` by running:
+```bash
+cd ../cli-ui-addon-webpack
+yarn build
+cd -
 ```
 
-In another terminal:
+Then you should start a local Apollo server:
 
 ```
 yarn run apollo
 ```
 
-You also need to build `@vue/cli-ui-addon-webpack`.
+And then in another terminal, you should serve cli-ui:
+
+```
+yarn run serve
+```


### PR DESCRIPTION
This should _improve_ actual README with more user-friendly notes for starting local development and explaining how to run tests in local aswell.