### PR TITLE
fix(cli-ui): ignore "false" ENOENT errors on Windows

### DIFF
--- a/packages/@vue/cli-ui/apollo-server/connectors/tasks.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/tasks.js
@@ -17,6 +17,7 @@ const { notify } = require('../util/notification')
 
 const MAX_LOGS = 2000
 const VIEW_ID = 'vue-project-tasks'
+const WIN_ENOENT_THRESHOLD = 500 // ms
 
 const tasks = new Map()
 
@@ -411,6 +412,11 @@ async function run (id, context) {
     child.on('exit', onExit)
 
     child.on('error', error => {
+      const duration = Date.now() - task.time
+      // hackish workaround for https://github.com/vuejs/vue-cli/issues/2096
+      if (process.platform === 'win32' && error.code === 'ENOENT' && duration > WIN_ENOENT_THRESHOLD) {
+        return onExit(null)
+      }
       updateOne({
         id: task.id,
         status: 'error'


### PR DESCRIPTION
Fixes #2096 .

See [this comment](https://github.com/vuejs/vue-cli/issues/2096#issuecomment-414333317):
> Another approach would be to consider the command execution duration - if we're on Windows and we get a `ENOENT` after more than 1 second, it's most probably a "false" one (this will not cover the case where you press on start and immediately on stop; a workaround would be to disable the button for 1s after starting a task).
