### PR TITLE
feat(cli-service): templateParameters per page

### DIFF
--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -189,7 +189,8 @@ module.exports = (api, options) => {
           entry,
           template = `public/${name}.html`,
           filename = `${name}.html`,
-          chunks
+          chunks,
+          templateParameters
         } = normalizePageConfig(multiPageConfig[name])
         // inject entry
         webpackConfig.entry(name).add(api.resolve(entry))
@@ -210,7 +211,10 @@ module.exports = (api, options) => {
           chunks: chunks || ['chunk-vendors', 'chunk-common', name],
           template: templatePath,
           filename: ensureRelative(outputDir, filename),
-          title
+          title,
+          templateParameters: (compilation, assets, pluginOptions) => {
+            return Object.assign(htmlOptions.templateParameters(compilation, assets, pluginOptions), templateParameters)
+          }
         })
 
         webpackConfig


### PR DESCRIPTION
Use custom [template parameters](https://github.com/jantimon/html-webpack-plugin#options) defined in each htmlWebpackPlugin pages configuration:

- Should I take into account a Function in the configuration ?
- Should I update the documentation according to this change ?