### PR TITLE
fix(serve): respect devServer.openPage field

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -242,7 +242,10 @@ module.exports = (api, options) => {
           console.log()
 
           if (args.open || projectDevServerOptions.open) {
-            openBrowser(urls.localUrlForBrowser)
+            const pageUri = ( projectDevServerOptions.openPage && typeof projectDevServerOptions.openPage === 'string' )
+              ? projectDevServerOptions.openPage
+              : ''
+            openBrowser(urls.localUrlForBrowser + pageUri)
           }
 
           // Send final app URL


### PR DESCRIPTION
Will fix issue setting openPage in vue.config.js, with the expected format:
```
devServer: {
  open: true,
  openPage: 'some-uri',
}
```
This should work in either the root devServer field, or within the configureWebpack.devServer field.