### PR TITLE
fix(cli-ui): apollo server awaiting for running e2e tests

### DIFF
--- a/packages/@vue/cli-ui/package.json
+++ b/packages/@vue/cli-ui/package.json
@@ -11,8 +11,8 @@
     "prepublishOnly": "yarn run lint --no-fix && yarn run build",
     "test:e2e:dev": "cross-env VUE_APP_CLI_UI_URL=ws://localhost:4040/graphql vue-cli-service test:e2e --mode development",
     "test:e2e:run": "vue-cli-service test:e2e --mode production --headless --url=http://localhost:4040",
-    "test:e2e": "yarn run test:clear && start-server-and-test apollo:run:test http://localhost:4040 test:e2e:dev",
-    "test:run": "yarn run test:clear && start-server-and-test apollo:run:test http://localhost:4040 test:e2e:run",
+    "test:e2e": "yarn run test:clear && start-server-and-test apollo:run:test http-get://localhost:4040/graphql?query={cwd} test:e2e:dev",
+    "test:run": "yarn run test:clear && start-server-and-test apollo:run:test http-get://localhost:4040/graphql?query={cwd} test:e2e:run",
     "test:clear": "rimraf ../../test/cli-ui-test && rimraf ./live-test",
     "test": "yarn run build && cd ../cli-ui-addon-webpack && yarn run build && cd ../cli-ui && yarn run test:run"
   },


### PR DESCRIPTION
Close #2308.

To run e2e tests after Apollo server is up, we use [start-server-and-test](https://github.com/bahmutov/start-server-and-test) that internally use [wait-on](https://github.com/jeffbski/wait-on).

> For http(s) resources wait-on will check that the requests are returning 2XX (success) to HEAD or GET requests (after following any redirects).
>
> ~ wait-on documentation

- `http://localhost:4040` returns a 404, so it won't works
- `http://localhost:4040/graphql` returns a 405 because wait-on use a HEAD request
- `http-get://localhost:4040/graphql` for forcing a GET request, but it returns a 400 because I didn't provided any `query` parameter.
- `http-get://localhost:4040/graphql?query={cwd}` works fine

![capture d ecran de 2018-08-22 15-49-15](https://user-images.githubusercontent.com/2103975/44467587-86c62980-a623-11e8-8afc-ec80cb862a76.png)
