### PR TITLE
fix: revert named-chunks nameResolver algorithm

### DIFF
--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -119,24 +119,15 @@ module.exports = (api, options) => {
       })
 
       // keep chunk ids stable so async chunks have consistent hash (#1916)
-      const seen = new Set()
-      const nameLength = 4
       webpackConfig
         .plugin('named-chunks')
           .use(require('webpack/lib/NamedChunksPlugin'), [chunk => {
             if (chunk.name) {
               return chunk.name
             }
-            const modules = Array.from(chunk.modulesIterable)
-            if (modules.length > 1) {
-              const hash = require('hash-sum')
-              const joinedHash = hash(modules.map(m => m.id).join('_'))
-              let len = nameLength
-              while (seen.has(joinedHash.substr(0, len))) len++
-              return `chunk-${joinedHash.substr(0, len)}`
-            } else {
-              return modules[0].id
-            }
+            return `chunk-` + Array.from(chunk.modulesIterable, m => {
+              return m.id
+            }).join('_')
           }])
     }
 

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -133,7 +133,6 @@ module.exports = (api, options) => {
               const joinedHash = hash(modules.map(m => m.id).join('_'))
               let len = nameLength
               while (seen.has(joinedHash.substr(0, len))) len++
-              seen.add(joinedHash.substr(0, len))
               return `chunk-${joinedHash.substr(0, len)}`
             } else {
               return modules[0].id


### PR DESCRIPTION
closes #1996

------

1. Hash collision is normal in multi page mode (they might share a `index.html` chunk).
2. Otherwise, chunks contain only 1 module in most cases, making the aesthetics improvement unnecessary.