### PR TITLE
fix(cli): Make sortObject consistent even when keyOrder is given

### DIFF
--- a/packages/@vue/cli/lib/Generator.js
+++ b/packages/@vue/cli/lib/Generator.js
@@ -179,6 +179,8 @@ module.exports = class Generator {
       'name',
       'version',
       'private',
+      'description',
+      'author',
       'scripts',
       'dependencies',
       'devDependencies',

--- a/packages/@vue/cli/lib/util/sortObject.js
+++ b/packages/@vue/cli/lib/util/sortObject.js
@@ -1,20 +1,20 @@
 module.exports = function sortObject (obj, keyOrder) {
   if (!obj) return
   const res = {}
-  const keys = Object.keys(obj)
-  const getOrder = key => {
-    const i = keyOrder.indexOf(key)
-    return i === -1 ? Infinity : i
-  }
+
   if (keyOrder) {
-    keys.sort((a, b) => {
-      return getOrder(a) - getOrder(b)
+    keyOrder.forEach(key => {
+      res[key] = obj[key]
+      delete obj[key]
     })
-  } else {
-    keys.sort()
   }
+
+  const keys = Object.keys(obj)
+
+  keys.sort()
   keys.forEach(key => {
     res[key] = obj[key]
   })
+
   return res
 }


### PR DESCRIPTION
The reason behind this PR is that my package.json is being rewritten everytime when I am running `vue invoke`. The keys which were not specified in the keyOrder are being inconsistent and changing everytime I am running `vue invoke`. This PR fixes that issue.