### PR TITLE
fix: use sync fs methods in writeFileTree

### DIFF
--- a/packages/@vue/cli/lib/util/writeFileTree.js
+++ b/packages/@vue/cli/lib/util/writeFileTree.js
@@ -19,9 +19,9 @@ module.exports = async function writeFileTree (dir, files, previousFiles) {
   if (previousFiles) {
     await deleteRemovedFiles(dir, files, previousFiles)
   }
-  return Promise.all(Object.keys(files).map(async (name) => {
+  Object.keys(files).forEach((name) => {
     const filePath = path.join(dir, name)
-    await fs.ensureDir(path.dirname(filePath))
-    await fs.writeFile(filePath, files[name])
-  }))
+    fs.ensureDirSync(path.dirname(filePath))
+    fs.writeFileSync(filePath, files[name])
+  })
 }


### PR DESCRIPTION
closes #2275

Iterating over async functions would put too many write calls in I/O
queue in the same time, leading to weird bugs.

(On my computer this bug appears once the number of `fs.writeFile` calls > 10)