### PR TITLE
fix: (cli-plugin-unit-jest) also process SVG files with jest-transform-stub

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -21,7 +21,7 @@ module.exports = (api, _, __, invoking) => {
       'transform': {
         // process *.vue files with vue-jest
         '^.+\\.vue$': 'vue-jest',
-        '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
+        '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
       },
       // support the same @ -> src alias mapping in source code
       'moduleNameMapper': {


### PR DESCRIPTION
Avoids getting a Jest unexpected token exception when requiring SVG files in template.