### PR TITLE
refactor: remove unused `placeAtRootIfRelative` parameter

### DIFF
--- a/packages/@vue/cli-service/lib/util/getAssetPath.js
+++ b/packages/@vue/cli-service/lib/util/getAssetPath.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-module.exports = function getAssetPath (options, filePath, placeAtRootIfRelative) {
+module.exports = function getAssetPath (options, filePath) {
   return options.assetsDir
     ? path.posix.join(options.assetsDir, filePath)
     : filePath


### PR DESCRIPTION
placeAtRootIfRelative is not using so remove it