### PR TITLE
fix(plugin api): fix generator dotfile rename for Windows.

### DIFF
--- a/packages/@vue/cli/__tests__/Generator.spec.js
+++ b/packages/@vue/cli/__tests__/Generator.spec.js
@@ -12,6 +12,7 @@ fs.ensureDirSync(templateDir)
 fs.writeFileSync(path.resolve(templateDir, 'foo.js'), 'foo(<%- options.n %>)')
 fs.ensureDirSync(path.resolve(templateDir, 'bar'))
 fs.writeFileSync(path.resolve(templateDir, 'bar/bar.js'), 'bar(<%- m %>)')
+fs.writeFileSync(path.resolve(templateDir, 'bar/_bar.js'), '.bar(<%- m %>)')
 fs.writeFileSync(path.resolve(templateDir, 'entry.js'), `
 import foo from 'foo'
 
@@ -347,6 +348,7 @@ test('api: render fs directory', async () => {
 
   expect(fs.readFileSync('/foo.js', 'utf-8')).toMatch('foo(1)')
   expect(fs.readFileSync('/bar/bar.js', 'utf-8')).toMatch('bar(2)')
+  expect(fs.readFileSync('/bar/.bar.js', 'utf-8')).toMatch('.bar(2)')
   expect(fs.readFileSync('/replace.js', 'utf-8')).toMatch('baz(2)')
   expect(fs.readFileSync('/multi-replace.js', 'utf-8')).toMatch('baz(1)\nqux(2)')
   expect(fs.readFileSync('/.gitignore', 'utf-8')).toMatch('foo')

--- a/packages/@vue/cli/lib/GeneratorAPI.js
+++ b/packages/@vue/cli/lib/GeneratorAPI.js
@@ -169,7 +169,7 @@ class GeneratorAPI {
         const globby = require('globby')
         const _files = await globby(['**/*'], { cwd: source })
         for (const rawPath of _files) {
-          const targetPath = rawPath.split(path.sep).map(filename => {
+          const targetPath = rawPath.split('/').map(filename => {
             // dotfiles are ignored when published to npm, therefore in templates
             // we need to use underscore instead (e.g. "_gitignore")
             if (filename.charAt(0) === '_' && filename.charAt(1) !== '_') {
@@ -179,7 +179,7 @@ class GeneratorAPI {
               return `${filename.slice(1)}`
             }
             return filename
-          }).join(path.sep)
+          }).join('/')
           const sourcePath = path.resolve(source, rawPath)
           const content = renderFile(sourcePath, data, ejsOptions)
           // only set file if it's not all whitespace, or is a Buffer (binary files)


### PR DESCRIPTION
Fixes issue with dotfile rename caused by Globby returning forward slashes instead of OS specific.
