### PR TITLE
feat: allow devServer.contentBase to be overwritten

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -84,6 +84,7 @@ module.exports = (api, options) => {
         ? rawPublicUrl
         : `${protocol}://${rawPublicUrl}`
       : null
+    const contentBase = args.contentBase || projectDevServerOptions.contentBase || api.resolve('public')
 
     const urls = prepareURLs(
       protocol,
@@ -142,7 +143,7 @@ module.exports = (api, options) => {
           { from: /./, to: path.posix.join(options.baseUrl, 'index.html') }
         ]
       },
-      contentBase: api.resolve('public'),
+      contentBase: contentBase,
       watchContentBase: !isProduction,
       hot: !isProduction,
       quiet: true,


### PR DESCRIPTION
If you add i.e. cordova to your project, you need a static access to cordova.js, which i.e. is under 
src-cordova/platforms/android/platform_www/

With this change, you can do:

contentBase: [api.resolve('public'), api.resolve('src-cordova/platforms/android/platform_www/')]