### PR TITLE
Removed padding reset from current project dropdown

### DIFF
--- a/packages/@vue/cli-ui/src/components/TopBar.vue
+++ b/packages/@vue/cli-ui/src/components/TopBar.vue
@@ -199,7 +199,6 @@ export default {
 
   >>> .trigger
     .vue-ui-button
-      padding 0 !important
       .vue-ui-icon.right
         width 20px
         height @width


### PR DESCRIPTION
Currently the project dropdown does not have left and right padding, it is removed here:
https://github.com/vuejs/vue-cli/blob/714d12ab1e2bbb6148f7f30b65f87e6ea743b36d/packages/%40vue/cli-ui/src/components/TopBar.vue#L200-L202

When the project name is short it is not a problem as seen here:
![short project name](https://user-images.githubusercontent.com/920747/45445268-0e0a3880-b6ca-11e8-95e6-628f0ea5d0b3.png)

... but when the project name is longer then it does not look that nice:

![long project name - bad](https://user-images.githubusercontent.com/920747/45445463-98529c80-b6ca-11e8-87b9-aa0f01a88f53.png)

My suggestion is to get rid of that padding reset, so it looks much better:

![long project name - good](https://user-images.githubusercontent.com/920747/45445519-bd470f80-b6ca-11e8-8c13-ad365f0ae25f.png)
