### PR TITLE
Add module concatenation hint

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
+++ b/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
@@ -6,3 +6,6 @@ if (typeof window !== 'undefined') {
     __webpack_public_path__ = i[1] // eslint-disable-line
   }
 }
+
+// Indicate to webpack that this file can be concatenated
+export default null


### PR DESCRIPTION
Allow Webpack to process this file as an ES Module, which allows
concatenating using ModuleConcatenationPlugin, resulting in a slightly
smaller bundle and removes the overhead of a runtime `require()`.