### PR TITLE
docs: fix html asset preload example

### DIFF
--- a/docs/guide/html-and-static-assets.md
+++ b/docs/guide/html-and-static-assets.md
@@ -52,7 +52,7 @@ module.exports = {
     // modify its options:
     config.plugin('prefetch').tap(options => {
       options[0].fileBlacklist = options[0].fileBlacklist || []
-      options[0].fileBlacklist.push([/myasyncRoute(.)+?\.js$/])
+      options[0].fileBlacklist.push(/myasyncRoute(.)+?\.js$/)
       return options
     })
   }


### PR DESCRIPTION
`fileBlacklist` is an array of regexes, so a regex must be pushed, without being wrapped in another array, otherwise currently error is being thrown for this example:
```
TypeError: regex.test is not a function
  - index.js:58 options.fileBlacklist.options.fileBlacklist.every.regex
    .../[@vue]/preload-webpack-plugin/src/index.js:58:58
```