### PR TITLE
fix(cli-plugin-eslint): Resolve proper ESLint package

### DIFF
--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -1,6 +1,9 @@
 module.exports = (api, options) => {
   if (options.lintOnSave) {
     const extensions = require('./eslintOptions').extensions(api)
+    const { loadModule } = require('@vue/cli-shared-utils')
+    const cwd = api.getCwd()
+    const eslintPkg = loadModule('eslint/package.json', cwd, true)
 
     // eslint-loader doesn't bust cache when eslint config changes
     // so we have to manually generate a cache identifier that takes the config
@@ -9,7 +12,7 @@ module.exports = (api, options) => {
       'eslint-loader',
       {
         'eslint-loader': require('eslint-loader/package.json').version,
-        'eslint': require('eslint/package.json').version
+        'eslint': eslintPkg.version
       },
       [
         '.eslintrc.js',
@@ -38,7 +41,7 @@ module.exports = (api, options) => {
               cacheIdentifier,
               emitWarning: options.lintOnSave !== 'error',
               emitError: options.lintOnSave === 'error',
-              formatter: require('eslint/lib/formatters/codeframe')
+              formatter: loadModule('eslint/lib/formatters/codeframe', cwd, true)
             })
     })
   }

--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -28,8 +28,8 @@ const defaultFilesToLint = [
 module.exports = function lint (args = {}, api) {
   const path = require('path')
   const cwd = api.resolve('.')
-  const { CLIEngine } = require('eslint')
-  const { log, done, exit, chalk } = require('@vue/cli-shared-utils')
+  const { log, done, exit, chalk, loadModule } = require('@vue/cli-shared-utils')
+  const { CLIEngine } = loadModule('eslint', cwd, true)
   const extensions = require('./eslintOptions').extensions(api)
 
   const argsConfig = normalizeConfig(args)


### PR DESCRIPTION
Currently `@vue/cli-plugin-eslint` and it's `lint` command relies strictly on the ESLint package that has been set in its `package.json`.

There is however one problem with this - if a user updates the ESLint by him/herself - it won't be reflected by using `vue-cli-service lint` as it will resolve the `ESlint` specified in this plugin's package.json.

It might also lead to the following problem: https://github.com/vuejs/eslint-plugin-vue/issues/568
After updating both ESLint and `eslint-plugin-vue` the ESLint no longer resolves the right `eslint-plugin-vue`. 

In order to fix this problem I'm resolving the `ESLint` package using `loadModule` from shared utils.

Although this solves the problem, I still have few things on my mind:
- Perhaps we should add `eslint` and `eslint-plugin-vue` to package.json automatically in `generator.js` and get rid of them as part of this plugin's dependencies?
- Or maybe we want to keep it as is - that is all hidden from users and instead create a `next` tag on npm  for beta releases of this plugin? It would however result in an extra work preparing additional releases.

What do you think about it? I'm not sure this is the proper way to address this matter so let's discuss.
