### PR TITLE
feat: set pretendToBeVisual option for jsdom-global

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/setup.js
+++ b/packages/@vue/cli-plugin-unit-mocha/setup.js
@@ -1,1 +1,1 @@
-require('jsdom-global')()
+require('jsdom-global')(undefined, { pretendToBeVisual: true })


### PR DESCRIPTION
- Set `pretendToBeVisual` to `true` in jsdom-global. This adds features like `requestAnimationFrame`, and keeps the jsdom environment in line with [Jest](https://github.com/facebook/jest/blob/6d3da9be06350bfa7414b609807ebd0cbdf0c416/packages/jest-environment-jsdom/src/index.js#L31)