### PR TITLE
feat(ui): add --host option for vue ui

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -115,6 +115,7 @@ program
 program
   .command('ui')
   .description('start and open the vue-cli ui')
+  .option('-H, --host <host>', 'host used for the UI server (default: localhost)')
   .option('-p, --port <port>', 'Port used for the UI server (by default search for available port)')
   .option('-D, --dev', 'Run in dev mode')
   .option('--quiet', `Don't output starting messages`)

--- a/packages/@vue/cli/lib/ui.js
+++ b/packages/@vue/cli/lib/ui.js
@@ -3,6 +3,7 @@ const { portfinder, server } = require('@vue/cli-ui/server')
 const shortid = require('shortid')
 
 async function ui (options = {}, context = process.cwd()) {
+  const host = options.host || 'localhost'
   let port = options.port
   if (!port) {
     port = await portfinder.getPortPromise()
@@ -28,6 +29,7 @@ async function ui (options = {}, context = process.cwd()) {
   if (!options.quiet) log(`🚀  Starting GUI...`)
 
   const opts = {
+    host,
     port,
     graphqlPath: '/graphql',
     subscriptionsPath: '/graphql',
@@ -55,7 +57,7 @@ async function ui (options = {}, context = process.cwd()) {
     }
 
     // Open browser
-    const url = `http://localhost:${port}`
+    const url = `http://${host}:${port}`
     if (!options.quiet) log(`🌠  Ready on ${url}`)
     if (options.headless) {
       console.log(port)


### PR DESCRIPTION
We sometimes develop on a remote server, which makes it impossible to access vue ui via IP, so add an option that allows the user to set the host