### PR TITLE
[babel-preset-app] Forward preset-env's debug option

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -41,6 +41,7 @@ module.exports = (context, options = {}) => {
   const {
     polyfills: userPolyfills,
     loose = false,
+    debug = false,
     useBuiltIns = 'usage',
     modules = false,
     targets: rawTargets,
@@ -103,6 +104,7 @@ module.exports = (context, options = {}) => {
   const envOptions = {
     spec,
     loose,
+    debug,
     modules,
     targets,
     useBuiltIns,


### PR DESCRIPTION
It allows debugging babel preset env. That's especially useful when using the `usage` option of `useBuiltIns`.