### PR TITLE
Adding host option to vue ui tool

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -116,6 +116,7 @@ program
   .command('ui')
   .description('start and open the vue-cli ui')
   .option('-p, --port <port>', 'Port used for the UI server (by default search for available port)')
+  .option('--host <host>', 'Host used for the UI server (localhost by default)')
   .option('-D, --dev', 'Run in dev mode')
   .option('--quiet', `Don't output starting messages`)
   .option('--headless', `Don't open browser on start and output port`)

--- a/packages/@vue/cli/lib/ui.js
+++ b/packages/@vue/cli/lib/ui.js
@@ -7,7 +7,10 @@ async function ui (options = {}, context = process.cwd()) {
   if (!port) {
     port = await portfinder.getPortPromise()
   }
-
+  let host = options.host
+  if (!host) {
+    host = 'localhost'
+  }
   // Config
   process.env.VUE_APP_CLI_UI_URL = ''
 
@@ -29,6 +32,7 @@ async function ui (options = {}, context = process.cwd()) {
 
   const opts = {
     port,
+    host,
     graphqlPath: '/graphql',
     subscriptionsPath: '/graphql',
     enableMocks: false,
@@ -55,7 +59,7 @@ async function ui (options = {}, context = process.cwd()) {
     }
 
     // Open browser
-    const url = `http://localhost:${port}`
+    const url = `http://${host}:${port}`
     if (!options.quiet) log(`🌠  Ready on ${url}`)
     if (options.headless) {
       console.log(port)


### PR DESCRIPTION
- This allows for using `vue ui` in virtual development environments (like vagrant for example).