### PR TITLE
fix(cli-service-global): fix eslint-loader config (close #2654)

### DIFF
--- a/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
+++ b/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
@@ -107,7 +107,10 @@ module.exports = function createConfigPlugin (context, entry, asLib) {
                   extends: [
                     'plugin:vue/essential',
                     'eslint:recommended'
-                  ]
+                  ],
+                  parserOptions: {
+                    parser: 'babel-eslint'
+                  }
                 }
               }))
 


### PR DESCRIPTION
> this PR fixes #2654

By including the parserOptions as we do when we create an actual eslint config for normal projects, we get ESnext support for eslint during `vue serve`