### PR TITLE
fix(preset): plugin invoke order don't sort by unicode order

### DIFF
--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -310,7 +310,7 @@ module.exports = class Creator extends EventEmitter {
   // { id: options } => [{ id, apply, options }]
   async resolvePlugins (rawPlugins) {
     // ensure cli-service is invoked first
-    rawPlugins = sortObject(rawPlugins, ['@vue/cli-service'])
+    rawPlugins = sortObject(rawPlugins, ['@vue/cli-service'], true)
     const plugins = []
     for (const id of Object.keys(rawPlugins)) {
       const apply = loadModule(`${id}/generator`, this.context) || (() => {})

--- a/packages/@vue/cli/lib/util/sortObject.js
+++ b/packages/@vue/cli/lib/util/sortObject.js
@@ -1,4 +1,4 @@
-module.exports = function sortObject (obj, keyOrder) {
+module.exports = function sortObject (obj, keyOrder, dontSortByUnicode) {
   if (!obj) return
   const res = {}
 
@@ -11,7 +11,7 @@ module.exports = function sortObject (obj, keyOrder) {
 
   const keys = Object.keys(obj)
 
-  keys.sort()
+  !dontSortByUnicode && keys.sort()
   keys.forEach(key => {
     res[key] = obj[key]
   })


### PR DESCRIPTION
Hi,

Thanks for the new cli, it's really easy to use!

However, this days, when I update to v3.0.4. There is a problem of the invoke order of my preset plugins.

For example, here is the plugins config of preset.json:

```json
{
    "plugins": {
        "@vue/cli-plugin-babel": {},
        "@dd/vue-cli-plugin-need-modify-based-babel": {
            "prompts": true
        }
    }
}
```

I need to invoke the `@dd/vue-cli-plugin-need-modify-based-babel` behind the `@vue/cli-plugin-babel`. But the sortObject function in v3.0.4 would change my intended order to the sort of Unicode code point value. And I think do not sort by unicode is more appropriate for preset.plugin.