### PR TITLE
Update creating-a-project.md

### DIFF
--- a/docs/guide/creating-a-project.md
+++ b/docs/guide/creating-a-project.md
@@ -10,6 +10,9 @@ vue create hello-world
 
 ::: warning
 If you are on Windows using Git Bash with minTTY, the interactive prompts will not work. You must launch the command as `winpty vue.cmd create hello-world`.
+If you however want to still use the `vue create hello-world` syntax, you can alias the command by adding the following line to your `~/.bashrc` file.  
+`alias vue='winpty vue.cmd'`  
+You will need to restart your Git Bash terminal session to pull in the updated bashrc file.
 :::
 
 You will be prompted to pick a preset. You can either choose the default preset which comes with a basic Babel + ESLint setup, or select "Manually select features" to pick the features you need.


### PR DESCRIPTION
Always remembering to use the `winpty vue.cmd create hello-world` syntax to create vue projects is kind of clunky as that is not the default syntax; someone like me will often forget.

Letting users know that they can alias the `winpty vue.cmd` command to something that feels more intuitive is better in my opinion.