### PR TITLE
fix(cli-service): Allow relative sockjs URL (close #1525)

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -84,6 +84,7 @@ module.exports = (api, options) => {
         ? rawPublicUrl
         : `${protocol}://${rawPublicUrl}`
       : null
+    const relativeSockJsUrl = options.relativeSockJsUrl
 
     const urls = prepareURLs(
       protocol,
@@ -99,20 +100,21 @@ module.exports = (api, options) => {
 
     // inject dev & hot-reload middleware entries
     if (!isProduction) {
-      const sockjsUrl = publicUrl
+      const sockjsUrl = relativeSockJsUrl ? '?/sockjs-node'
+        : publicUrl
         // explicitly configured via devServer.public
-        ? `?${publicUrl}/sockjs-node`
-        : isInContainer
+          ? `?${publicUrl}/sockjs-node`
+          : isInContainer
           // can't infer public netowrk url if inside a container...
           // use client-side inference (note this would break with non-root baseUrl)
-          ? ``
+            ? ``
           // otherwise infer the url
-          : `?` + url.format({
-            protocol,
-            port,
-            hostname: urls.lanUrlForConfig || 'localhost',
-            pathname: '/sockjs-node'
-          })
+            : `?` + url.format({
+              protocol,
+              port,
+              hostname: urls.lanUrlForConfig || 'localhost',
+              pathname: '/sockjs-node'
+            })
       const devClients = [
         // dev server client
         require.resolve(`webpack-dev-server/client`) + sockjsUrl,

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -11,6 +11,7 @@ const schema = createSchema(joi => joi.object({
   productionSourceMap: joi.boolean(),
   parallel: joi.boolean(),
   devServer: joi.object(),
+  relativeSockJsUrl: joi.boolean(),
   pages: joi.object(),
   crossorigin: joi.string().valid(['', 'anonymous', 'use-credentials']),
   integrity: joi.boolean(),
@@ -119,5 +120,8 @@ exports.defaults = () => ({
     proxy: null, // string | Object
     before: app => {}
   */
-  }
+  },
+
+  // whether to allow the HMR URL to be relative
+  relativeSockJsUrl: false
 })


### PR DESCRIPTION
This would simplify HMR use across multiple domain / port local dev server scenarios, while still allowing specific URLs to be selected by the public property of devServerOptions.

Added option to vue.config.js, not the devServer as that object is validated against Webpack

Default to false so as to not be a breaking change.