### PR TITLE
Fix: revert addition of cypress-webpack-preprocessor

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/plugins/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/plugins/index.js
@@ -1,12 +1,4 @@
-// https://docs.cypress.io/guides/guides/plugins-guide.html
-const webpack = require('@cypress/webpack-preprocessor')
-
 module.exports = (on, config) => {
-  on('file:preprocessor', webpack({
-    webpackOptions: require('@vue/cli-service/webpack.config'),
-    watchOptions: {}
-  }))
-
   return Object.assign({}, config, {
     fixturesFolder: 'tests/e2e/fixtures',
     integrationFolder: 'tests/e2e/specs',

--- a/packages/@vue/cli-plugin-e2e-cypress/package.json
+++ b/packages/@vue/cli-plugin-e2e-cypress/package.json
@@ -22,7 +22,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@cypress/webpack-preprocessor": "^3.0.0",
     "@vue/cli-shared-utils": "^3.0.4",
     "cypress": "^3.0.2",
     "eslint-plugin-cypress": "^2.0.1"


### PR DESCRIPTION
When I was trying to fix #2667 I found that cypress tests were not working anymore for the default`--mode production`, but they do work for `--mode development`.

Some testing found that it is related to the addition of `cypress-webpack-preprocessor` introduced in https://github.com/vuejs/vue-cli/commit/bd32daa2db44bc50a6bc14d9887b9debd05a727b to solve #2465

Removing that makes tests work again.

I tried to find out what about the production config breaks the preprocessor, but was unsuccessful.

Since it was only introduced to provide a convenience feature (`@/` alias path support in cyprss test files) I submit this PR to revert the feature until we have found a proper fix for the problem.

Maybe we just have to remove some plugin from the production config that we load into the preprocessor, but so fa I haven't figured out which one it is.