### PR TITLE
feat(serve): include networkUrl in resolved promise

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -262,7 +262,13 @@ module.exports = (api, options) => {
           // so other commands can do api.service.run('serve').then(...)
           resolve({
             server,
-            url: urls.localUrlForBrowser
+            url: urls.localUrlForBrowser,
+            networkUrl: url.format({
+              protocol,
+              hostname: urls.lanUrlForConfig,
+              port: port,
+              pathname: options.baseUrl || '/'
+            })
           })
         } else if (process.env.VUE_CLI_TEST) {
           // signal for test to check HMR


### PR DESCRIPTION
I'm working on a [vue-cli-plugin-capacitor](https://github.com/nklayman/vue-cli-plugin-capacitor), and I'd like to set up HMR for an AVD/phone. To do this, I need to start the dev server, and get the network url of it. Currently, only the lanUrl is included in the resolved promise of `api.service.run('serve')`. This PR simply adds the networkUrl to the resolved object.