### PR TITLE
Update babel plugin dependencies

### DIFF
--- a/packages/@vue/cli-plugin-babel/package.json
+++ b/packages/@vue/cli-plugin-babel/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-plugin-babel#readme",
   "dependencies": {
-    "@babel/core": "7.0.0-beta.47",
+    "@babel/core": "^7.0.0",
     "@vue/babel-preset-app": "^3.0.4",
-    "babel-loader": "^8.0.0-0"
+    "babel-loader": "^8.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Babel 7.1 and babel-loader 8 are now both stable.