### PR TITLE
fix(ui): i18n for 'Official' in plugin search results

### DIFF
--- a/packages/@vue/cli-ui/src/components/PackageSearchItem.vue
+++ b/packages/@vue/cli-ui/src/components/PackageSearchItem.vue
@@ -37,7 +37,7 @@
         </span>
         <span v-if="official" class="info">
           <VueIcon icon="star" class="top medium"/>
-          <span>Official</span>
+          <span>{{ $t('org.vue.components.project-plugin-item.official') }}</span>
         </span>
         <span class="info downloads">
           <VueIcon class="medium" icon="file_download"/>


### PR DESCRIPTION
It was correctly done in `ProjectPluginItem` but not in `PackageSearchItem`.