### PR TITLE
Docs: Add information about Transifex for easier collaborative translation

### DIFF
--- a/docs/dev-guide/ui-localization.md
+++ b/docs/dev-guide/ui-localization.md
@@ -18,6 +18,17 @@ The English reference locale is [here](https://github.com/vuejs/vue-cli/blob/dev
 
 Take a look at [the french localization package](https://github.com/Akryum/vue-cli-locale-fr) as an example.
 
+### Easier translation with Transifex
+
+To make collaboration and synchronisation easier, the English source locale from the `dev` branch is automatically imported to [Transifex](https://www.transifex.com/vuejs/vue-cli/dashboard/), a platform for collaborative translation.
+
+For existing languages, you can [sign up as a translator](https://www.transifex.com/vuejs/vue-cli/dashboard/).
+For new languages, you can [request the new language](https://www.transifex.com/vuejs/vue-cli/dashboard/) after signing up.
+
+In either case you will be able to translate keys as they are added or changed in the source locale.
+
+Note that the translations on Transifex are not automatically exported into the localization packages. However, maintainers of locale package maintainers can easily export their translated locale from Transifex via "View resources" (next to the language), by clicking on the "cli-ui" resource and finally choosing "Download for use".
+
 ## Translate your plugin
 
 You can put locale files compatible with [vue-i18n](https://github.com/kazupon/vue-i18n) in a `locales` folder at the root of your plugin. They will be automatically loaded into the client when the project is opened. You can then use `$t` to translate strings in your components and other vue-i18n helpers. Also, the strings used in the UI API (like `describeTask`) will go through vue-i18n as well to you can localize them.


### PR DESCRIPTION
Transifex is a platform for collaborative translation and I have been using it to maintain the German locale. I have also imported all other locales and invited both the maintainers and the contributors to use it as well for their locale packages.

Note: As a non-commercial opensource project, we can use Transifex for free. Discourse and Nextcloud, for instance, also use it. 