### PR TITLE
fix: Add missing package in @vue/cli-ui

### DIFF
--- a/packages/@vue/cli-ui/package.json
+++ b/packages/@vue/cli-ui/package.json
@@ -55,6 +55,7 @@
     "watch": "^1.0.2"
   },
   "devDependencies": {
+    "@vue/cli": "^3.0.5",
     "@vue/cli-plugin-babel": "^3.0.5",
     "@vue/cli-plugin-e2e-cypress": "^3.0.5",
     "@vue/cli-plugin-eslint": "^3.0.5",


### PR DESCRIPTION
The apollo-server/util/db.js  file in @vue/cli-ui uses the @vue/cli, which is not currently included in the list of dependencies. This causes an error when trying to run apollo server.

![image](https://user-images.githubusercontent.com/16408285/47006082-b5660980-d167-11e8-8c56-c9d2b263bfd1.png)
