### PR TITLE
fix: display project name validation warnings

### DIFF
--- a/packages/@vue/cli/lib/create.js
+++ b/packages/@vue/cli/lib/create.js
@@ -22,7 +22,10 @@ async function create (projectName, options) {
   if (!result.validForNewPackages) {
     console.error(chalk.red(`Invalid project name: "${name}"`))
     result.errors && result.errors.forEach(err => {
-      console.error(chalk.red(err))
+      console.error(chalk.red.dim('Error: ' + err))
+    })
+    result.warnings && result.warnings.forEach(warn => {
+      console.error(chalk.red.dim('Warning: ' + warn))
     })
     exit(1)
   }


### PR DESCRIPTION
Show console warning messages for "Invalid project name" error in create function.

Warnings include errors such as "name can no longer contain capital letters" or "name can no longer contain more than 214 characters".