### PR TITLE
fix(cli): avoid assertion error when vue.config.js includes assignment expression

### DIFF
--- a/packages/@vue/cli/lib/util/__tests__/extendJSConfig.spec.js
+++ b/packages/@vue/cli/lib/util/__tests__/extendJSConfig.spec.js
@@ -61,3 +61,21 @@ module.exports = config`
 module.exports = config`
   )
 })
+
+test(`with extra assignment expression`, () => {
+  const value = {
+    foo: true
+  }
+  const source =
+`process.env.VUE_APP_TEST = 'test'
+module.exports = {
+  bar: 123
+}`
+  expect(extend(value, source)).toMatch(
+    `process.env.VUE_APP_TEST = 'test'
+module.exports = {
+  bar: 123,
+  foo: true
+}`
+  )
+})

--- a/packages/@vue/cli/lib/util/extendJSConfig.js
+++ b/packages/@vue/cli/lib/util/extendJSConfig.js
@@ -7,7 +7,8 @@ module.exports = function extendJSConfig (value, source) {
   const ast = recast.parse(source)
 
   recast.types.visit(ast, {
-    visitAssignmentExpression ({ node }) {
+    visitAssignmentExpression (path) {
+      const { node } = path
       if (
         node.left.type === 'MemberExpression' &&
         node.left.object.name === 'module' &&
@@ -21,6 +22,7 @@ module.exports = function extendJSConfig (value, source) {
         }
         return false
       }
+      this.traverse(path)
     }
   })
 


### PR DESCRIPTION
There is a case that Vue CLI fails to add a plugin with the following assertion error (it's a case adding `vue-cli-plugin-quasar`):

```
🚀  Invoking generator for vue-cli-plugin-quasar...
 ERROR  Error: Must either call this.traverse or return false in visitAssignmentExpression
Error: Must either call this.traverse or return false in visitAssignmentExpression
    at Context.invokeVisitorMethod (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:365:21)
    at Visitor.PVp.visitWithoutReset (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:196:32)
    at visitChildren (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:246:25)
    at Visitor.PVp.visitWithoutReset (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:204:20)
    at NodePath.each (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path.js:101:26)
    at visitChildren (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:219:18)
    at Visitor.PVp.visitWithoutReset (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:204:20)
    at visitChildren (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:246:25)
    at Visitor.PVp.visitWithoutReset (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:204:20)
    at visitChildren (/xxx/node_modules/@vue/cli/node_modules/ast-types/lib/path-visitor.js:246:25)
```

The reason is `extendJSConfig` function does not handle the case that `vue.config.js` includes assignment expression not for `module.exports`. For example, the following `vue.config.js` provides the error:

```js
process.env.VUE_APP_SOME_VAR = 'test'

module.exports = {
  // ...
}
```

We need to explicitly call `this.traverse()` method in the visitor function to avoid this error and this PR is adding it.
