### PR TITLE
feat(tslint): Support multiple configs

### DIFF
--- a/packages/@vue/cli-plugin-typescript/__tests__/tsPluginTSLint.spec.js
+++ b/packages/@vue/cli-plugin-typescript/__tests__/tsPluginTSLint.spec.js
@@ -88,3 +88,132 @@ test('should ignore issues in node_modules', async () => {
   await run('vue-cli-service lint')
   expect(await read('node_modules/bad.ts')).toMatch(updatedMain)
 })
+
+test('should handle nested tsconfig.json files', async () => {
+  const project = await create('ts-lint-nested-tsconfig', {
+    plugins: {
+      '@vue/cli-plugin-typescript': {
+        tsLint: true
+      }
+    }
+  })
+
+  const { read, write, run } = project
+  const main = await read('src/main.ts')
+  const tsconfig = await read('tsconfig.json')
+
+  // change root tsconfig.json to not include src/**/*.ts
+  const updatedTsconfig = tsconfig.replace(/\s+"src\/\*\*\/\*\.ts",/, '')
+  await write('tsconfig.json', updatedTsconfig)
+
+  // add nested tsconfig.json which includes **/*.ts files in the src directory
+  const nestedTsconfig = `
+  {
+    "include": [
+      "**/*.ts"
+    ]
+  }
+  `
+  await write('src/tsconfig.json', nestedTsconfig)
+
+  // update file to not match tslint spec
+  const updatedMain = main.replace(/;/g, '')
+  await write('src/main.ts', updatedMain)
+
+  // lint
+  await run('vue-cli-service lint')
+  expect(await read('src/main.ts')).toMatch(main)
+})
+
+test('should handle nested tslint.json files', async () => {
+  const project = await create('ts-lint-nested-tslint', {
+    plugins: {
+      '@vue/cli-plugin-typescript': {
+        tsLint: true
+      }
+    }
+  })
+
+  const { read, write, run } = project
+  const main = await read('src/main.ts')
+  const tslint = await read('tslint.json')
+
+  // add nested tslint.json which expects double quotes
+  const updatedTslint = tslint.replace(/single/, 'double')
+  await write('src/tslint.json', updatedTslint)
+
+  // update file to use double quotes
+  const updatedMain = main.replace(/'/g, '"')
+  await write('src/main.ts', updatedMain)
+
+  // lint
+  await run('vue-cli-service lint')
+  expect(await read('src/main.ts')).toMatch(updatedMain)
+})
+
+test('should handle tsconfig.json files with extends', async () => {
+  const project = await create('ts-lint-extends-tsconfig', {
+    plugins: {
+      '@vue/cli-plugin-typescript': {
+        tsLint: true
+      }
+    }
+  })
+
+  const { read, write, run } = project
+  const main = await read('src/main.ts')
+  const tsconfig = await read('tsconfig.json')
+
+  // change root tsconfig.json to not include src/**/*.ts and to exclude files named main.ts
+  const updatedTsconfig = tsconfig
+    .replace(/\s+"src\/\*\*\/\*\.ts",/, '')
+    .replace(/(\s+)("node_modules",)/, '$1$2\n$1"main.ts"')
+  await write('tsconfig.json', updatedTsconfig)
+
+  // add nested tsconfig.json which includes **/*.ts files in the src directory
+  const nestedTsconfig = `
+  {
+    "extends": "../tsconfig",
+    "include": [
+      "**/*.ts"
+    ]
+  }
+  `
+  await write('src/tsconfig.json', nestedTsconfig)
+
+  // update file to not match tslint spec
+  const updatedMain = main.replace(/;/g, '')
+  await write('src/main.ts', updatedMain)
+
+  // lint
+  await run('vue-cli-service lint')
+  // the file should be unchanged because the parent tsconfig.json excludes it
+  expect(await read('src/main.ts')).toMatch(updatedMain)
+})
+
+test('should handle specifying files on the command line', async () => {
+  const project = await create('ts-lint-command-line', {
+    plugins: {
+      '@vue/cli-plugin-typescript': {
+        tsLint: true
+      }
+    }
+  })
+
+  const { read, write, run } = project
+  const main = await read('src/main.ts')
+
+  // update file to not match tslint spec
+  const updatedMain = main.replace(/;/g, '')
+  await write('src/main.ts', updatedMain)
+
+  // lint
+  await run('vue-cli-service lint src/main.ts')
+  expect(await read('src/main.ts')).toMatch(main)
+
+  // re-write the file and lint without specifying src/main.ts
+  await write('src/main.ts', updatedMain)
+  // lint
+  await run('vue-cli-service lint src/App.vue')
+  expect(await read('src/main.ts')).toMatch(updatedMain)
+})

--- a/packages/@vue/cli-plugin-typescript/lib/tslint.js
+++ b/packages/@vue/cli-plugin-typescript/lib/tslint.js
@@ -1,5 +1,6 @@
 module.exports = function lint (args = {}, api, silent) {
   const cwd = api.resolve('.')
+  const findUp = require('find-up')
   const fs = require('fs')
   const path = require('path')
   const globby = require('globby')
@@ -53,77 +54,187 @@ module.exports = function lint (args = {}, api, silent) {
     }
   }
 
-  const program = tslint.Linter.createProgram(api.resolve('tsconfig.json'))
+  const tsconfigs = globby.sync('**/tsconfig.json', { cwd, ignore: ['node_modules'] })
 
-  // patch getSourceFile for *.vue files
-  // so that it returns the <script> block only
-  const patchProgram = program => {
-    const getSourceFile = program.getSourceFile
-    program.getSourceFile = function (file, languageVersion, onError) {
-      if (isVueFile(file)) {
-        const script = parseTSFromVueFile(file) || ''
-        return ts.createSourceFile(file, script, languageVersion, true)
-      } else {
-        return getSourceFile.call(this, file, languageVersion, onError)
+  const linterResults = tsconfigs.map(tsconfig => {
+    const configAbsolutePath = api.resolve(tsconfig)
+    const program = tslint.Linter.createProgram(configAbsolutePath)
+
+    // patch getSourceFile for *.vue files
+    // so that it returns the <script> block only
+    const patchProgram = program => {
+      const getSourceFile = program.getSourceFile
+      program.getSourceFile = function (file, languageVersion, onError) {
+        if (isVueFile(file)) {
+          const script = parseTSFromVueFile(file) || ''
+          return ts.createSourceFile(file, script, languageVersion, true)
+        } else {
+          return getSourceFile.call(this, file, languageVersion, onError)
+        }
       }
     }
-  }
 
-  patchProgram(program)
+    patchProgram(program)
 
-  const linter = new tslint.Linter(options, program)
+    const linter = new tslint.Linter(options, program)
 
-  // patch linter.updateProgram to ensure every program has correct getSourceFile
-  const updateProgram = linter.updateProgram
-  linter.updateProgram = function (...args) {
-    updateProgram.call(this, ...args)
-    patchProgram(this.program)
-  }
-
-  const config = tslint.Configuration.findConfiguration(api.resolve('tslint.json')).results
-  // create a patched config that disables the blank lines rule,
-  // so that we get correct line numbers in error reports for *.vue files.
-  const vueConfig = Object.assign(config)
-  const rules = vueConfig.rules = new Map(vueConfig.rules)
-  const rule = rules.get('no-consecutive-blank-lines')
-  rules.set('no-consecutive-blank-lines', Object.assign({}, rule, {
-    ruleSeverity: 'off'
-  }))
-
-  const lint = file => {
-    const filePath = api.resolve(file)
-    const isVue = isVueFile(file)
-    patchWriteFile()
-    linter.lint(
-      // append .ts so that tslint apply TS rules
-      filePath,
-      '',
-      // use Vue config to ignore blank lines
-      isVue ? vueConfig : config
-    )
-    restoreWriteFile()
-  }
-
-  const files = args._ && args._.length
-    ? args._
-    : ['src/**/*.ts', 'src/**/*.vue', 'src/**/*.tsx', 'tests/**/*.ts', 'tests/**/*.tsx']
-
-  return globby(files, { cwd }).then(files => {
-    files.forEach(lint)
-    if (silent) return
-    const result = linter.getResult()
-    if (result.output.trim()) {
-      process.stdout.write(result.output)
-    } else if (result.fixes.length) {
-      // some formatters do not report fixes.
-      const f = new tslint.Formatters.ProseFormatter()
-      process.stdout.write(f.format(result.failures, result.fixes))
-    } else if (!result.failures.length) {
-      console.log(`No lint errors found.\n`)
+    // patch linter.updateProgram to ensure every program has correct getSourceFile
+    const updateProgram = linter.updateProgram
+    linter.updateProgram = function (...args) {
+      updateProgram.call(this, ...args)
+      patchProgram(this.program)
     }
 
-    if (result.failures.length && !args.force) {
-      process.exitCode = 1
+    const createVueConfig = config => {
+      // create a patched config that disables the blank lines rule,
+      // so that we get correct line numbers in error reports for *.vue files.
+      const vueConfig = Object.assign(config)
+      const rules = vueConfig.rules = new Map(vueConfig.rules)
+      const rule = rules.get('no-consecutive-blank-lines')
+      rules.set('no-consecutive-blank-lines', Object.assign({}, rule, {
+        ruleSeverity: 'off'
+      }))
+
+      return vueConfig
     }
+
+    const lint = filePath => {
+      const tslintConfig = tslint.Configuration.findConfiguration(findUp.sync('tslint.json', { cwd: path.dirname(filePath) })).results
+      const isVue = isVueFile(filePath)
+      patchWriteFile()
+      linter.lint(
+        // append .ts so that tslint apply TS rules
+        filePath,
+        '',
+        // use Vue config to ignore blank lines
+        isVue ? createVueConfig(tslintConfig) : tslintConfig
+      )
+      restoreWriteFile()
+    }
+
+    const configDirectory = path.dirname(configAbsolutePath)
+
+    const resolveFiles = () => {
+      if (args._ && args._.length) {
+        return resolveFilesFromCommandLine()
+      } else {
+        return resolveFilesFromConfig()
+      }
+    }
+
+    const resolveFilesFromCommandLine = () => {
+      const files = args._
+
+      return globby(files, { cwd: cwd })
+    }
+
+    const mergeExtendsConfig = (resolvedTsconfig, configPath, followedPaths = []) => {
+      const extendedConfigFileName = resolvedTsconfig.extends
+
+      // if there's a path we've already seen, the config files create a circular dependency
+      if (followedPaths.includes(extendedConfigFileName)) {
+        throw Error('tsconfig.json "extends" property creates a circular dependency')
+      }
+
+      if (extendedConfigFileName) {
+        const extendedTsconfigPath = path.resolve(configPath, extendedConfigFileName + '.json')
+        const extendedTsconfigDir = path.dirname(extendedTsconfigPath)
+        const extendedTsconfig = JSON.parse(fs.readFileSync(extendedTsconfigPath))
+
+        // for our purpose, we only care about the "files", "includes", and "excludes" properties
+        return mergeExtendsConfig(
+          {
+            files: resolvedTsconfig.files || extendedTsconfig.files,
+            includes: resolvedTsconfig.includes || extendedTsconfig.includes,
+            excludes: resolvedTsconfig.excludes || extendedTsconfig.excludes
+          },
+          extendedTsconfigDir,
+          followedPaths.concat([extendedTsconfigPath])
+        )
+      } else {
+        return resolvedTsconfig
+      }
+    }
+
+    const resolveFilesFromConfig = () => {
+      const tsconfigJson = JSON.parse(fs.readFileSync(configAbsolutePath))
+      const fullConfig = mergeExtendsConfig(tsconfigJson, configAbsolutePath)
+      let globs = []
+      const include = fullConfig.include || []
+      // The "files" property in tsconfig.json can be relative or absolute
+      const tsconfigFiles = (fullConfig.files || [])
+        .map(file => {
+          if (file.startsWith('/')) {
+            return file
+          } else {
+            return path.resolve(configDirectory, file)
+          }
+        })
+      const ignore = fullConfig.exclude || [
+        'node_modules',
+        'bower_components',
+        'jspm_packages'
+      ]
+
+      if (include.length === 0 && tsconfigFiles.length === 0) {
+        globs = [
+          '.ts',
+          '.tsx',
+          '.d.ts'
+        ]
+      } else {
+        globs = include
+      }
+
+      return globby(globs, { cwd: configDirectory, ignore }).then(files => {
+        return files
+          .map(file => path.resolve(configDirectory, file))
+          .concat(tsconfigFiles)
+      })
+    }
+
+    return resolveFiles().then(files => {
+      files
+        .forEach(lint)
+
+      return linter.getResult()
+    })
   })
+
+  return Promise.all(linterResults)
+    .then(results => {
+      if (silent) return
+
+      const combinedResults = results.reduce((acc, result) => {
+        return {
+          errorCount: acc.errorCount + result.errorCount,
+          failures: acc.failures.concat(result.failures),
+          fixes: acc.fixes.concat(result.fixes),
+          format: acc.format,
+          output: (acc.output + result.output).replace('\n\n', '\n'),
+          warningCount: acc.warningCount + result.warningCount
+        }
+      }, {
+        errorCount: 0,
+        failures: [],
+        fixes: [],
+        format: options.formatter,
+        output: '\n',
+        warningCount: 0
+      })
+
+      if (combinedResults.output.trim()) {
+        process.stdout.write(combinedResults.output)
+      } else if (combinedResults.fixes.length) {
+        // some formatters do not report fixes.
+        const f = new tslint.Formatters.ProseFormatter()
+        process.stdout.write(f.format(combinedResults.failures, combinedResults.fixes))
+      } else if (!combinedResults.failures.length) {
+        console.log(`No lint errors found.\n`)
+      }
+
+      if (combinedResults.failures.length && !args.force) {
+        process.exitCode = 1
+      }
+    })
 }

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@types/webpack-env": "^1.13.6",
     "@vue/cli-shared-utils": "^3.0.5",
+    "find-up": "^3.0.0",
     "fork-ts-checker-webpack-plugin": "^0.4.10",
     "globby": "^8.0.1",
     "ts-loader": "^5.2.2",


### PR DESCRIPTION
## Cause

When I attempted to write Cypress tests in TypeScript, I discovered I [had to place a tsconfig.json file within the tests/e2e folder](https://docs.cypress.io/guides/tooling/typescript-support.html#Configure-tsconfig-json) in order to get Cypress to run without throwing its own errors. While that worked for running the file, this setup would cause `vue-cli-service lint` to still show those linting problems. This was not a problem, however, when running `tslint` directly from the command line.

## Changes

- The previous setup assumes a top-level tsconfig.json file and specifies what globs will be used when running `vue-cli-service lint` with `tslint`. This changes to look for any tsconfig.json file and to use the config file's "include", "exclude", and "files" properties
- When linting a file, use the closest tslint.json to determine its linting configuration
- Add tests for many of these cases involving the interaction of nested Typescript and linting configs as well as specifying files in the command line

## Concerns

- These changes should make linting with tslint much slower as I didn't do any optimizations. If requested, I'm certainly willing to work to optimize this code
- I tried to recreate [the specified behavior of the TypeScript compiler's interpretation of tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) and how its commands behave, but I don't have enough experience with TypeScript to be certain it behaves as it should. I initially tried to use the TypeScript library's handling for determining files from tsconfig.json, but my experience was it ignored .vue files despite the config including them.

## Possible Future Enhancements

- Changing `vue create` to automatically set up Cypress to use TypeScript if both Cypress and TypeScript options are selected