### PR TITLE
chore: Update Workbox dependency

### DIFF
--- a/packages/@vue/cli-plugin-pwa/package.json
+++ b/packages/@vue/cli-plugin-pwa/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@vue/cli-shared-utils": "^3.0.5",
-    "workbox-webpack-plugin": "^3.6.2"
+    "workbox-webpack-plugin": "^3.6.3"
   },
   "devDependencies": {
     "register-service-worker": "^1.0.0"


### PR DESCRIPTION
This contains a fix for a bug with precached redirected responses; see https://github.com/GoogleChrome/workbox/releases/tag/v3.6.3