### PR TITLE
fix(serve): also detect kubernetes containers

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -297,7 +297,7 @@ function checkInContainer () {
   const fs = require('fs')
   if (fs.existsSync(`/proc/1/cgroup`)) {
     const content = fs.readFileSync(`/proc/1/cgroup`, 'utf-8')
-    return /:\/(lxc|docker)\//.test(content)
+    return /:\/(lxc|docker|kubepods)\//.test(content)
   }
 }
 


### PR DESCRIPTION
While working on a Vue CLI 3 server / container template for CodeSandbox and having an HMR issue (an invalid webpack socket URL), looking at how HMR is configured in `serve.js`, I've noticed that `serve` should be detecting that it's running in a container, but it's not. Looking further at the [container detection code](https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-service/lib/commands/serve.js#L296), and then at `/proc/1/cgroup` inside the container, it looks like
```
12:memory:/kubepods/burstable/pod[redacted]
11:blkio:/kubepods/burstable/pod[redacted]
[...more similar lines...]
```
, so I added `kubepods` to the detection regex.

You can see it working at https://codesandbox.io/s/qv463kv6z6 (where I manually changed `serve.js` inside `node_modules/@vue/cli-service`).

![image](https://user-images.githubusercontent.com/2083930/47367725-ed7dc700-d6e8-11e8-8dc5-66a17837f59b.png)

The "access the dev server via http://localhost..." message is still a bit confusing, I could add CodeSandbox container detection if desired (@Akryum: I pinged you on Vue Discord, maybe we can discuss this further there).