### PR TITLE
update config pages README.md

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -101,7 +101,7 @@ module.exports = {
 
   Build the app in multi-page mode. Each "page" should have a corresponding JavaScript entry file. The value should be an object where the key is the name of the entry, and the value is either:
 
-  - An object that specifies its `entry`, `template`, `filename`, `title` and `chunks` (all optional except `entry`);
+  - An object that specifies its `entry`, `template`, `filename`, `title` and `chunks` (all optional except `entry`). Any other properties added beside those will also be passed directly to `html-webpack-plugin`, allowing user to customize said plugin;
   - Or a string specifying its `entry`.
 
   ``` js


### PR DESCRIPTION
Updates readme to reflect changes done on #2544 (commit 4cabf5e8c798287825908fb193d61fcc1e8d62af ) for v3.1.0.
Not sure if properly worded but with those changes, it fares an explanation that any other properties will also get passed along to `html-webpack-plugin`, not only listed properties.

An example would, for example, to pass data to template, like I illustrated on above issue, using `require('html-webpack-template')` as a template.