### PR TITLE
Fix/increase test reliability

### DIFF
--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -27,7 +27,7 @@
     "@babel/plugin-syntax-jsx": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@babel/runtime": "^7.0.0",
+    "@babel/runtime": "7.0.0-beta.55",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-transform-vue-jsx": "^4.0.1"

--- a/packages/@vue/cli-plugin-e2e-cypress/__tests__/cypressPlugin.spec.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/__tests__/cypressPlugin.spec.js
@@ -1,4 +1,4 @@
-jest.setTimeout(process.env.APPVEYOR ? 120000 : 60000)
+jest.setTimeout(120000)
 
 const create = require('@vue/cli-test-utils/createTestProject')
 
@@ -21,9 +21,5 @@ test('should work', async () => {
   config.video = false
   await project.write('cypress.json', JSON.stringify(config))
 
-  if (!process.env.CI) {
-    await project.run(`vue-cli-service test:e2e`)
-  } else if (!process.env.APPVEYOR) {
-    await project.run(`vue-cli-service test:e2e --headless`)
-  }
+  await project.run(`vue-cli-service test:e2e --headless`)
 })

--- a/packages/@vue/cli-plugin-unit-jest/__tests__/jestPlugin.spec.js
+++ b/packages/@vue/cli-plugin-unit-jest/__tests__/jestPlugin.spec.js
@@ -1,4 +1,4 @@
-jest.setTimeout(20000)
+jest.setTimeout(process.env.APPVEYOR ? 40000 : 20000)
 
 const create = require('@vue/cli-test-utils/createTestProject')
 


### PR DESCRIPTION
## Cause

When running tests locally:

- the Cypress test takes longer than 60 seconds so it times out
<img width="710" alt="screen shot 2018-10-24 at 8 25 27 pm" src="https://user-images.githubusercontent.com/751175/47468911-16c35380-d7cc-11e8-8d7e-5d845b5cc9de.png">

- the Jest w/ Babel one fails due to not being able to find a file in `@babel/runtime`
<img width="693" alt="screen shot 2018-10-24 at 8 36 45 pm" src="https://user-images.githubusercontent.com/751175/47468997-94875f00-d7cc-11e8-843b-34921def8e41.png">
.


When running on Appveyor:

- the Jest plugin test takes longer than 20 seconds.
<img width="814" alt="screen shot 2018-10-24 at 8 26 20 pm" src="https://user-images.githubusercontent.com/751175/47468915-1c209e00-d7cc-11e8-950c-1020a9719ca7.png">

## Changes

- Run Cypress tests with the `--headless` option and increase the timeout to 120 seconds. It appears a new version of Cypress doesn't automatically run the tests when the GUI is shown, so the test will never complete
- Pin the `@babel/runtime` version to `7.0.0-beta.55` as [figured out with this other library](https://github.com/jquense/yup/issues/216#issuecomment-410636827)
- Increase the Jest timeout to 40 seconds for Appveyor

## Concerns

- Pinning the Babel runtime version isn't ideal

## Possible Future Enhancements

- Figure out the root problem of why it is trying to load `interopRequireDefault.js` in the `/builtin` directory