### PR TITLE
Add support for loading WebAssembly and ES Modules

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -38,7 +38,7 @@ module.exports = (api, options) => {
 
     webpackConfig.resolve
       .extensions
-        .merge(['.js', '.jsx', '.vue', '.json'])
+        .merge(['.wasm', '.mjs', '.js', '.jsx', '.vue', '.json'])
         .end()
       .modules
         .add('node_modules')


### PR DESCRIPTION
Hello,

It is pretty common to see `.wasm` and `.mjs` files nowadays, some library start using them and this break by default in `vue-cli` without extending like this.

This pull request add support for those kind of files out-of-the-box.

**vue.config.js**
```JS
module.exports = {
  chainWebpack: config => config.resolve.extensions.prepend('.mjs').prepend('.wasm')
}
```
**Do not hesitate to ping me if you have any questions / need something.**

Regards