### PR TITLE
Fix Template files for main.js and router when not using a compiler

### DIFF
--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -1,5 +1,7 @@
 module.exports = (api, options) => {
-  api.render('./template')
+  api.render('./template', {
+    doesCompile: api.hasPlugin('babel') || api.hasPlugin('typescript')
+  })
 
   api.extendPackage({
     scripts: {

--- a/packages/@vue/cli-service/generator/router/index.js
+++ b/packages/@vue/cli-service/generator/router/index.js
@@ -7,7 +7,8 @@ module.exports = (api, options = {}) => {
     }
   })
   api.render('./template', {
-    historyMode: options.routerHistoryMode
+    historyMode: options.routerHistoryMode,
+    doesCompile: api.hasPlugin('babel') || api.hasPlugin('typescript')
   })
 
   if (api.invoking) {

--- a/packages/@vue/cli-service/generator/router/template/src/router.js
+++ b/packages/@vue/cli-service/generator/router/template/src/router.js
@@ -21,7 +21,13 @@ export default new Router({
       // route level code-splitting
       // this generates a separate chunk (about.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
+      <%_ if (doesCompile) { _%>
       component: () => import(/* webpackChunkName: "about" */ './views/About.vue')
+      <%_ } else { _%>
+      component: function () { 
+        return import(/* webpackChunkName: "about" */ './views/About.vue')
+      }
+      <%_ } _%>
     }
   ]
 })

--- a/packages/@vue/cli-service/generator/template/src/main.js
+++ b/packages/@vue/cli-service/generator/template/src/main.js
@@ -4,5 +4,9 @@ import App from './App.vue'
 Vue.config.productionTip = false
 
 new Vue({
-  render: h => h(App)
+  <%_ if (doesCompile) { _%>
+  render: h => h(App),
+  <%_ } else { _%>
+  render: function (h) { return h(App) },
+  <%_ } _%>
 }).$mount('#app')


### PR DESCRIPTION
Currently, both `main.js` and `router.js` templates contain arrow functions.

When a user chooses not to select babel or typescript during project creation, the generated code will fail in browsers that don't support arrow functions.

Since we aim to be compatible with IE 11 out of the box, I added conditionals to the templates for these files to use a normal function instead when neither babel nor typescript plugins are detected.