### PR TITLE
fix(wc): don't overwrite user-defined externals

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -56,6 +56,7 @@ module.exports = (api, { target, entry, name }) => {
     // externalize Vue in case user imports it
     config
       .externals({
+        ...config.get('externals'),
         vue: 'Vue'
       })
 


### PR DESCRIPTION
This was already fixed for `--target lib` here some time ago:

https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-service/lib/commands/build/resolveLibConfig.js#L48-L55

I just replicated the change for the web components config.