### PR TITLE
feat: add envinfo package via `vue info` in cli

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -166,7 +166,7 @@ program
         Binaries: ['Node', 'Yarn', 'npm'],
         Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
         npmPackages: '/**/{*vue*,@vue/*/}',
-        npmGlobalPackages: ['vue-cli']
+        npmGlobalPackages: ['@vue/cli']
       },
       {
         showNotFound: true,

--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -155,6 +155,27 @@ program
     loadCommand('upgrade', '@vue/cli-upgrade')(semverLevel, cleanArgs(cmd))
   })
 
+program
+  .command('info')
+  .description('print debugging information about your environment')
+  .action((cmd) => {
+    console.log(chalk.bold('\nEnvironment Info:'))
+    require('envinfo').run(
+      {
+        System: ['OS', 'CPU'],
+        Binaries: ['Node', 'Yarn', 'npm'],
+        Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
+        npmPackages: '/**/{*vue*,@vue/*/}',
+        npmGlobalPackages: ['vue-cli']
+      },
+      {
+        showNotFound: true,
+        duplicates: true,
+        fullTree: true
+      }
+    ).then(console.log)
+  })
+
 // output help information on unknown commands
 program
   .arguments('<command>')

--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -34,7 +34,7 @@
     "deepmerge": "^2.1.1",
     "download-git-repo": "^1.0.2",
     "ejs": "^2.6.1",
-    "envinfo": "^5.11.0",
+    "envinfo": "^5.11.1",
     "execa": "^0.10.0",
     "fs-extra": "^6.0.1",
     "globby": "^8.0.1",

--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -34,6 +34,7 @@
     "deepmerge": "^2.1.1",
     "download-git-repo": "^1.0.2",
     "ejs": "^2.6.1",
+    "envinfo": "^5.11.0",
     "execa": "^0.10.0",
     "fs-extra": "^6.0.1",
     "globby": "^8.0.1",


### PR DESCRIPTION
As with many other projects, an astounding number of issues and conversations center around what versions of tools, CLIs and OSs users are running. I'd like to help this issue. We already ask for this info, why not automate it?

Other command line tools such as 

- React Native
- Create React App
- Expo
- Webpack
- Solidarity
- Gatsby

have all benefitted from adding envinfo to their CLI and issue template.

Here's an example output, custom tailored for Vue:

```
Environment Info:

  System:
    OS: macOS 10.14
    CPU: x64 Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
  Binaries:
    Node: 8.12.0 - ~/.nvm/versions/node/v8.12.0/bin/node
    Yarn: 1.9.4 - ~/.yarn/bin/yarn
    npm: 6.4.1 - ~/.nvm/versions/node/v8.12.0/bin/npm
  Browsers:
    Chrome: 70.0.3538.77
    Safari: 12.0
  npmPackages:
    @vue/babel-preset-app:  3.1.1 
    @vue/cli-overlay:  3.1.0 
    @vue/cli-plugin-babel: ^3.1.0 => 3.1.0 
    @vue/cli-plugin-eslint: ^3.1.0 => 3.1.0 
    @vue/cli-service: ^3.1.0 => 3.1.0 
    @vue/cli-shared-utils:  3.1.0 
    @vue/component-compiler-utils:  2.3.0 
    @vue/preload-webpack-plugin:  1.1.0 
    @vue/web-component-wrapper:  1.2.0 
    babel-helper-vue-jsx-merge-props:  2.0.3 
    babel-plugin-transform-vue-jsx:  4.0.1 
    eslint-plugin-vue: ^5.0.0-0 => 5.0.0-beta.3 
    vue: ^2.5.17 => 2.5.17 
    vue-eslint-parser:  3.2.2 
    vue-hot-reload-api:  2.3.1 
    vue-loader:  15.4.2 
    vue-style-loader:  4.1.2 
    vue-template-compiler: ^2.5.17 => 2.5.17 
    vue-template-es2015-compiler:  1.6.0 
  npmGlobalPackages:
    vue-cli: Not Found
```

Next steps would be adding this as a requirement to your issue template, and creating an envinfo preset for vue, so that it can be run without anything installed but node via npx:

`npx envinfo --preset vue`

Open to comments and feature requests. 