### PR TITLE
 增强proxy: 对齐webpack devServer的proxy

### DIFF
--- a/packages/@vue/cli-service/lib/util/prepareProxy.js
+++ b/packages/@vue/cli-service/lib/util/prepareProxy.js
@@ -11,6 +11,7 @@ const url = require('url')
 const path = require('path')
 const chalk = require('chalk')
 const address = require('address')
+const contextMatcher = require('http-proxy-middleware/lib/context-matcher')
 
 const defaultConfig = {
   logLevel: 'silent',
@@ -66,7 +67,7 @@ module.exports = function prepareProxy (proxy, appPublicFolder) {
         }
         if (context) {
           // Explicit context, e.g. /api
-          return pathname.match(context)
+          return contextMatcher.match(context, pathname, req);
         } else {
           // not a static request
           if (req.method !== 'GET') {
@@ -125,7 +126,7 @@ module.exports = function prepareProxy (proxy, appPublicFolder) {
       )
       process.exit(1)
     }
-    const entry = createProxyEntry(config.target, config.onProxyReq, context)
+    const entry = createProxyEntry(config.target, config.onProxyReq, config.context || context)
     return Object.assign({}, defaultConfig, config, entry)
   })
 }


### PR DESCRIPTION
#2868 

增强proxy, 对齐 [webpack devServer的proxy](https://webpack.docschina.org/configuration/dev-server/)
支持proxy数组与 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/)中所有格式的context， 例如
```
proxy: [
      {
        context: '/ajax',
        target: 'https://localhost:3000',
      },
      {
        context: function (pathname, req) {
          const env = getPathnameEnv(pathname);
          return env === 'online';
        },
        target: 'https://localhost:8081',
        changeOrigin: true,
      },
]
```