### PR TITLE
feat: allow indexPath to be null to disable generating index.html

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -87,6 +87,8 @@ module.exports = {
 
   Specify the output path for the generated `index.html` (relative to `outputDir`). Can also be an absolute path.
 
+  If `null`, the index HTML will not be generated.
+
 ### filenameHashing
 
 - Type: `boolean`

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -4,7 +4,7 @@ const schema = createSchema(joi => joi.object({
   baseUrl: joi.string().allow(''),
   outputDir: joi.string(),
   assetsDir: joi.string(),
-  indexPath: joi.string(),
+  indexPath: joi.string().allow(null),
   filenameHashing: joi.boolean(),
   runtimeCompiler: joi.boolean(),
   transpileDependencies: joi.array(),


### PR DESCRIPTION
The diff for this unfortunately comes out quite messy, but it's really just wrapping the relevant code in a check for if `options.indexPath` is `null`.

Feature is useful for use-cases where you're not going to use the generated index HTML anyway.

Can add a test if required.