### PR TITLE
feat: options.devServer can be a func

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -298,13 +298,15 @@ module.exports = {
 
 ### devServer
 
-- Type: `Object`
+- Type: `Object | Function`
 
   [All options for `webpack-dev-server`](https://webpack.js.org/configuration/dev-server/) are supported. Note that:
 
   - Some values like `host`, `port` and `https` may be overwritten by command line flags.
 
   - Some values like `publicPath` and `historyApiFallback` should not be modified as they need to be synchronized with [baseUrl](#baseurl) for the dev server to function properly.
+
+  If the value is a function, it will be called with no arguments, and should return a config object.
 
 ### devServer.proxy
 

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -42,6 +42,7 @@ module.exports = (api, options) => {
     const prepareProxy = require('../util/prepareProxy')
     const launchEditorMiddleware = require('launch-editor-middleware')
     const validateWebpackConfig = require('../util/validateWebpackConfig')
+    const getOptionsDevServer = require('../util/getOptionsDevServer')
 
     // resolve webpack config
     const webpackConfig = api.resolveWebpackConfig()
@@ -53,7 +54,7 @@ module.exports = (api, options) => {
     // in webpck config
     const projectDevServerOptions = Object.assign(
       webpackConfig.devServer || {},
-      options.devServer
+      getOptionsDevServer(options)
     )
 
     // expose advanced stats

--- a/packages/@vue/cli-service/lib/config/dev.js
+++ b/packages/@vue/cli-service/lib/config/dev.js
@@ -19,7 +19,9 @@ module.exports = (api, options) => {
         .plugin('no-emit-on-errors')
           .use(require('webpack/lib/NoEmitOnErrorsPlugin'))
 
-      if (!process.env.VUE_CLI_TEST && options.devServer.progress !== false) {
+      const getOptionsDevServer = require('../util/getOptionsDevServer')
+
+      if (!process.env.VUE_CLI_TEST && getOptionsDevServer(options).progress !== false) {
         webpackConfig
           .plugin('progress')
           .use(require('webpack/lib/ProgressPlugin'))

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -10,7 +10,7 @@ const schema = createSchema(joi => joi.object({
   transpileDependencies: joi.array(),
   productionSourceMap: joi.boolean(),
   parallel: joi.boolean(),
-  devServer: joi.object(),
+  devServer: joi.alternatives().try(joi.object(), joi.func()),
   pages: joi.object(),
   crossorigin: joi.string().valid(['', 'anonymous', 'use-credentials']),
   integrity: joi.boolean(),

--- a/packages/@vue/cli-service/lib/util/getOptionsDevServer.js
+++ b/packages/@vue/cli-service/lib/util/getOptionsDevServer.js
@@ -1,0 +1,8 @@
+module.exports = (options) => {
+  if (typeof options.devServer === 'function') {
+    options.devServer = options.devServer()
+  }
+
+  return options.devServer
+}
+


### PR DESCRIPTION
Useful for being able to execute some code specific to the dev server, for example, automatically generating a localhost cert for HTTPS:

```javascript
devServer: () => {
  // If no localhost.crt, generate it here and output to disk

  return {
    https: {
      key: fs.readFileSync('./localhost.key'),
      cert: fs.readFileSync('./localhost.crt')
    }
  }
}
```

Would probably be most useful if it could return a `Promise`, but looking at where it needs to be accessed I'm not sure that's possible in a clean way.