### PR TITLE
 fix: remove webpack-preprocessor from cypress config

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/__tests__/cypressPlugin.spec.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/__tests__/cypressPlugin.spec.js
@@ -27,3 +27,29 @@ test('should work', async () => {
     await project.run(`vue-cli-service test:e2e --headless`)
   }
 })
+
+test('should work with TS', async () => {
+  const project = await create('e2e-cypress-ts', {
+    plugins: {
+      '@vue/cli-plugin-typescript': {
+        'classComponent': true,
+        'tsLint': true,
+        'lintOn': ['save']
+      },
+      '@vue/cli-plugin-e2e-cypress': {}
+    }
+  })
+
+  const pkg = JSON.parse(await project.read('package.json'))
+  expect(pkg.devDependencies).toHaveProperty('@cypress/webpack-preprocessor')
+
+  const config = JSON.parse(await project.read('cypress.json'))
+  config.video = false
+  await project.write('cypress.json', JSON.stringify(config))
+
+  if (!process.env.CI) {
+    await project.run(`vue-cli-service test:e2e`)
+  } else if (!process.env.APPVEYOR) {
+    await project.run(`vue-cli-service test:e2e --headless`)
+  }
+})

--- a/packages/@vue/cli-plugin-e2e-cypress/__tests__/cypressPlugin.spec.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/__tests__/cypressPlugin.spec.js
@@ -14,9 +14,6 @@ test('should work', async () => {
     }
   })
 
-  const pkg = JSON.parse(await project.read('package.json'))
-  expect(pkg.devDependencies).toHaveProperty('@cypress/webpack-preprocessor')
-
   const config = JSON.parse(await project.read('cypress.json'))
   config.video = false
   await project.write('cypress.json', JSON.stringify(config))
@@ -39,9 +36,6 @@ test('should work with TS', async () => {
       '@vue/cli-plugin-e2e-cypress': {}
     }
   })
-
-  const pkg = JSON.parse(await project.read('package.json'))
-  expect(pkg.devDependencies).toHaveProperty('@cypress/webpack-preprocessor')
 
   const config = JSON.parse(await project.read('cypress.json'))
   config.video = false

--- a/packages/@vue/cli-plugin-e2e-cypress/generator/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/generator/index.js
@@ -5,9 +5,6 @@ module.exports = api => {
   })
 
   api.extendPackage({
-    devDependencies: {
-      '@cypress/webpack-preprocessor': '^3.0.0'
-    },
     scripts: {
       'test:e2e': 'vue-cli-service test:e2e'
     }

--- a/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/plugins/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/plugins/index.js
@@ -1,12 +1,18 @@
 // https://docs.cypress.io/guides/guides/plugins-guide.html
-/* eslint-disable import/no-extraneous-dependencies, global-require */
-const webpack = require('@cypress/webpack-preprocessor')
+
+// if you need a custom webpack configuration you can uncomment the following import
+// and then use the `file:preprocessor` event
+// as explained in the cypress docs
+// https://docs.cypress.io/api/plugins/preprocessors-api.html#Examples
+
+// /* eslint-disable import/no-extraneous-dependencies, global-require */
+// const webpack = require('@cypress/webpack-preprocessor')
 
 module.exports = (on, config) => {
-  on('file:preprocessor', webpack({
-    webpackOptions: require('@vue/cli-service/webpack.config'),
-    watchOptions: {}
-  }))
+  // on('file:preprocessor', webpack({
+  //  webpackOptions: require('@vue/cli-service/webpack.config'),
+  //  watchOptions: {}
+  // }))
 
   return Object.assign({}, config, {
     fixturesFolder: 'tests/e2e/fixtures',

--- a/packages/@vue/cli-plugin-e2e-cypress/package.json
+++ b/packages/@vue/cli-plugin-e2e-cypress/package.json
@@ -22,12 +22,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@cypress/webpack-preprocessor": "^3.0.0",
     "@vue/cli-shared-utils": "^3.1.1",
     "cypress": "^3.1.0",
     "eslint-plugin-cypress": "^2.0.1"
-  },
-  "peerDependencies": {
-    "@cypress/webpack-preprocessor": "^3.0.0"
   }
 }


### PR DESCRIPTION
Removes the `@cypress/webpack-preprocessor` from the generated cypress configuration, as it leads to several issues regarding file watching, headless mode and TS support.

~~Note that the dependency is still there, so any user needing it back just have to uncomment the lines in the generated config.~~ 
Update: after discussing with @sodatea the dependency is not needed and has been removed. Users can install it manually if they need it.

Note that I also added a simple test with cypress with TS

Fixes #2903 