### PR TITLE
chore: ordered tslint rules

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/template/tslint.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tslint.json
@@ -10,12 +10,12 @@
     ]
   },
   "rules": {
-    "quotemark": [true, "single"],
     "indent": [true, "spaces", 2],
     "interface-name": false,
-    "ordered-imports": false,
+    "no-consecutive-blank-lines": false,
     "object-literal-sort-keys": false,
-    "no-consecutive-blank-lines": false
+    "ordered-imports": false,
+    "quotemark": [true, "single"]
   }
 }
 <%_ } _%>


### PR DESCRIPTION
The usual convention is to keep the TSLint rules ordered as you can see in the recommended set for example https://github.com/palantir/tslint/blob/master/src/configs/recommended.ts