### PR TITLE
Update devServer.proxy documentation

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -330,12 +330,12 @@ module.exports = {
   module.exports = {
     devServer: {
       proxy: {
-        '/api': {
+        '^/api': {
           target: '<url>',
           ws: true,
           changeOrigin: true
         },
-        '/foo': {
+        '^/foo': {
           target: '<other_url>'
         }
       }


### PR DESCRIPTION
So that it'll be obvious that proxies are configured via regexes. Usually it's not noticeable, but the original example becomes problematic when vue-router in history mode is used.

Here is a place where matching happens - https://github.com/binarin/vue-cli/blob/5786e273b2e133c836f53f4ab5c1d8d65f9766f5/packages/%40vue/cli-service/lib/util/prepareProxy.js#L69