### PR TITLE
feat(plugin-pwa): manifest cross-origin option

### DIFF
--- a/packages/@vue/cli-plugin-pwa/README.md
+++ b/packages/@vue/cli-plugin-pwa/README.md
@@ -54,7 +54,7 @@ file, or the `"vue"` field in `package.json`.
   - Default: `'default'`
 
 - **pwa.assetsVersion**
-  
+
   - Default: `''`
 
     This option is used if you need to add a version to your icons and manifest, against browser’s cache. This will append `?v=<pwa.assetsVersion>` to the URLs of the icons and manifest.
@@ -64,6 +64,12 @@ file, or the `"vue"` field in `package.json`.
   - Default: `'manifest.json'`
 
     The path of app’s manifest.
+
+- **pwa.manifestCrossOrigin**
+
+  - Default: `undefined`
+
+    Use this option if CORS must be used when fetching the manifest. See [cross-origin values](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#Attributes) for more details.
 
 - **pwa.iconPaths**
 

--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -42,6 +42,7 @@ module.exports = class HtmlPwaPlugin {
           appleMobileWebAppStatusBarStyle,
           assetsVersion,
           manifestPath,
+          manifestCrossOrigin,
           iconPaths
         } = this.options
         const { publicPath } = compiler.options.output
@@ -64,10 +65,10 @@ module.exports = class HtmlPwaPlugin {
           }),
 
           // Add to home screen for Android and modern mobile browsers
-          makeTag('link', {
+          makeTag('link', Object.assign({
             rel: 'manifest',
             href: `${publicPath}${manifestPath}${assetsVersionStr}`
-          }),
+          }, manifestCrossOrigin ? { crossorigin: manifestCrossOrigin } : {})),
           makeTag('meta', {
             name: 'theme-color',
             content: themeColor


### PR DESCRIPTION
To be able to fetch the manifest behind Basic Auth with CORS.