### PR TITLE
docs: enable Algolia search

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -27,6 +27,10 @@ module.exports = {
     docsBranch: 'docs',
     editLinks: true,
     sidebarDepth: 3,
+    algolia: {
+      indexName: 'cli_vuejs',
+      apiKey: 'f6df220f7d246aff64a56300b7f19f21',
+    },
     locales: {
       '/': {
         label: 'English',


### PR DESCRIPTION
Hey there! I enabled VuePress' feature to show the search via DocSearch so there's the extra features, like searching in the content, and typo tolerance. 

Thanks!