### PR TITLE
fix(cli-plugin-unit-jest): When using TS & Babel, make ts-jest use babelConfig 

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -79,6 +79,12 @@ const applyTS = module.exports.applyTS = (api, invoking) => {
       moduleFileExtensions: ['ts', 'tsx'],
       transform: {
         '^.+\\.tsx?$': 'ts-jest'
+      },
+      global: !api.hasPlugin('babel') ? undefined : {
+        'ts-jest': {
+          // we need babel to transpile JSX
+          babelConfig: true
+        }
       }
     },
     devDependencies: {

--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -79,12 +79,6 @@ const applyTS = module.exports.applyTS = (api, invoking) => {
       moduleFileExtensions: ['ts', 'tsx'],
       transform: {
         '^.+\\.tsx?$': 'ts-jest'
-      },
-      global: !api.hasPlugin('babel') ? undefined : {
-        'ts-jest': {
-          // we need babel to transpile JSX
-          babelConfig: true
-        }
       }
     },
     devDependencies: {
@@ -94,6 +88,14 @@ const applyTS = module.exports.applyTS = (api, invoking) => {
   })
   if (api.hasPlugin('babel')) {
     api.extendPackage({
+      jest: {
+        global: {
+          'ts-jest': {
+            // we need babel to transpile JSX
+            babelConfig: true
+          }
+        }
+      },
       devDependencies: {
         // this is for now necessary to force ts-jest and vue-jest to use babel 7
         'babel-core': '7.0.0-bridge.0'


### PR DESCRIPTION
tsconfig.json is set to preserve jsx:
```json
"jsx": "preserve"
``` 
Because Typescript can't compile JSX into Vue-style render functions, only React-style.

But that means:
* When using Typescript and Babel, Typescript will emit Javascript that still contains JSX. That's fine with`build` and `serve` if we also use babel to conmplie the JSX afterwards. But in Jest, we can only pick one transform, we can't chain them.
* When Only using Typescript, we can't use JSX at all.

This PR is meant to fix the first issue: ts-jest should use babel to transform result for correct JSX transforms by setting its `babelConfig` option.

close #3100

Sidenote: The second issue still exists, and likely isn't resolable. We should probably document it, though, and also mention in the prompt messages.