### PR TITLE
翻译错误

### DIFF
--- a/docs/zh/guide/cli-service.md
+++ b/docs/zh/guide/cli-service.md
@@ -65,7 +65,7 @@ npx vue-cli-service serve
 
   --mode        指定环境模式 (默认值：production)
   --dest        指定输出目录 (默认值：dist)
-  --modern      面向现代浏览器不带自动回退地构建应用
+  --modern      面向现代浏览器带自动回退地构建应用
   --target      app | lib | wc | wc-async (默认值：app)
   --name        库或 Web Components 模式下的名字 (默认值：package.json 中的 "name" 字段或入口文件名)
   --no-clean    在构建项目之前不清除目标目录


### PR DESCRIPTION
原话是'--modern build app targeting modern browsers with auto fallback'