### PR TITLE
fix(cli-service): Fix copy plugin's ignore pattern (fix #3119)

### DIFF
--- a/packages/@vue/cli-service/__tests__/build.spec.js
+++ b/packages/@vue/cli-service/__tests__/build.spec.js
@@ -13,6 +13,8 @@ test('build', async () => {
 
   // test public copy
   project.write('public/foo.js', '1')
+  // make sure that only /public/index.html is skipped (#3119)
+  project.write('public/subfolder/index.html', '1')
 
   const { stdout } = await project.run('vue-cli-service build')
   expect(stdout).toMatch('Build complete.')
@@ -22,6 +24,7 @@ test('build', async () => {
   expect(project.has('dist/js')).toBe(true)
   expect(project.has('dist/css')).toBe(true)
   expect(project.has('dist/foo.js')).toBe(true)
+  expect(project.has('dist/subfolder/index.html')).toBe(true)
 
   const index = await project.read('dist/index.html')
   // should split and preload app.js & vendor.js

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -140,7 +140,7 @@ module.exports = (api, options) => {
     const multiPageConfig = options.pages
     const htmlPath = api.resolve('public/index.html')
     const defaultHtmlPath = path.resolve(__dirname, 'index-default.html')
-    const publicCopyIgnore = ['index.html', '.DS_Store']
+    const publicCopyIgnore = ['/index.html', '.DS_Store']
 
     if (!multiPageConfig) {
       // default, single page setup.

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -140,7 +140,7 @@ module.exports = (api, options) => {
     const multiPageConfig = options.pages
     const htmlPath = api.resolve('public/index.html')
     const defaultHtmlPath = path.resolve(__dirname, 'index-default.html')
-    const publicCopyIgnore = ['/index.html', '.DS_Store']
+    const publicCopyIgnore = ['.DS_Store']
 
     if (!multiPageConfig) {
       // default, single page setup.


### PR DESCRIPTION
don't skip files named `index.html` `/public` when nested in a subfolder. We only need to ignore the index.html directly under `/public/index.html`, which is used by html-webpack-plugin as a template.

close #3119