### PR TITLE
fix(unit-mocha): set `url` option for jsdom-global

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/setup.js
+++ b/packages/@vue/cli-plugin-unit-mocha/setup.js
@@ -1,1 +1,1 @@
-require('jsdom-global')(undefined, { pretendToBeVisual: true })
+require('jsdom-global')(undefined, { pretendToBeVisual: true, url: 'http://localhost' })


### PR DESCRIPTION
Set `url: 'http://localhost'` option to jsdom-global. This fix `SecurityError: localStorage is not available for opaque origins` in mocha tests caused of jsdom (jsdom/jsdom#2304).