### PR TITLE
TypeScript plugin: Fix typo in lint command registration

### DIFF
--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -80,7 +80,7 @@ module.exports = (api, options) => {
 
   if (!api.hasPlugin('eslint')) {
     api.registerCommand('lint', {
-      descriptions: 'lint source files with TSLint',
+      description: 'lint source files with TSLint',
       usage: 'vue-cli-service lint [options] [...files]',
       options: {
         '--format [formatter]': 'specify formatter (default: codeFrame)',


### PR DESCRIPTION
When you run `vue-cli-service help`, there is no description for the `lint` command. I discovered that this was because the command registration code had a typo.