### PR TITLE
fix(ie compat): include polyfill for currentScript directly

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
+++ b/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
@@ -1,9 +1,25 @@
 // This file is imported into lib/wc client bundles.
 
 if (typeof window !== 'undefined') {
+  var currentScript = window.document.currentScript;
+  if(!currentScript) {
+    // IE compat
+    try {
+      throw new Error();
+    } catch(err) {
+      var scripts = document.getElementsByTagName('script'),
+          res     = ((/.*at [^(]*\((.*):.+:.+\)$/ig).exec(err.stack) || [false])[1];
+      for(i in scripts) {
+        if(scripts[i].src === res || scripts[i].readyState === 'interactive') {
+          currentScript = scripts[i]; // eslint-disable-line
+          break;
+        }
+      }
+    }
+  }
   var i
-  if ((i = window.document.currentScript) && (i = i.src.match(/(.+\/)[^/]+\.js(\?.*)?$/))) {
-    __webpack_public_path__ = i[1] // eslint-disable-line
+  if (i = currentScript.src.match(/(.+\/)[^/]+\.js(\?.*)?$/)) {
+    __webpack_require__.p = i[1] // eslint-disable-line
   }
 }
 


### PR DESCRIPTION
it would be nice if vue-cli produces libs, that can be used in IE directly.