### PR TITLE
feat(cli-service): add history api fallback for multi-page mode

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -303,6 +303,9 @@ function genHistoryApiFallbackRewrites (baseUrl, pages = {}) {
   const path = require('path')
   const multiPageRewrites = Object
     .keys(pages)
+    // sort by length in reversed order to avoid overrides
+    // eg. 'page11' should appear in front of 'page1'
+    .sort((a, b) => b.length - a.length)
     .map(name => ({
       from: new RegExp(`^/${name}`),
       to: path.posix.join(baseUrl, pages[name].filename || `${name}.html`)

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -33,7 +33,6 @@ module.exports = (api, options) => {
     const isProduction = process.env.NODE_ENV === 'production'
 
     const url = require('url')
-    const path = require('path')
     const chalk = require('chalk')
     const webpack = require('webpack')
     const WebpackDevServer = require('webpack-dev-server')
@@ -139,9 +138,7 @@ module.exports = (api, options) => {
       clientLogLevel: 'none',
       historyApiFallback: {
         disableDotRule: true,
-        rewrites: [
-          { from: /./, to: path.posix.join(options.publicPath, 'index.html') }
-        ]
+        rewrites: genHistoryApiFallbackRewrites(options.publicPath, options.pages)
       },
       contentBase: api.resolve('public'),
       watchContentBase: !isProduction,
@@ -300,6 +297,20 @@ function checkInContainer () {
     const content = fs.readFileSync(`/proc/1/cgroup`, 'utf-8')
     return /:\/(lxc|docker|kubepods)\//.test(content)
   }
+}
+
+function genHistoryApiFallbackRewrites (baseUrl, pages = {}) {
+  const path = require('path')
+  const multiPageRewrites = Object
+    .keys(pages)
+    .map(name => ({
+      from: new RegExp(`^/${name}`),
+      to: path.posix.join(baseUrl, pages[name].filename || `${name}.html`)
+    }))
+  return [
+    ...multiPageRewrites,
+    { from: /./, to: path.posix.join(baseUrl, 'index.html') }
+  ]
 }
 
 module.exports.defaultModes = {


### PR DESCRIPTION
With `multi-page` configuration like: 

```js
module.exports = {
  pages: {
    main: {
      entry: 'src/main.js',
      template: 'public/index.html',
      filename: 'index.html'
    },
    preview: {
      entry: 'src/preview.js',
      template: 'public/index.html',
      filename: 'preview.html'
    }
  }
}
```

HTML for page `preview` can only be accessed by `localhost:8080/preview.html`.

This plays well with vue-router + `hash` mode. But with `history` mode, `preview.html` would not be accessible. 

eg. accessing `localhost:8080/preview.html/about` will result in `index.html` because `/preview.html/about` is a not found request and being fallback.

This PR adds support for multi-page fallback, it fallback `${baseUrl}/${name of page}` to the correct html file (filename specified or `${name}.html`). 

In above case, the two pages could be accessed by `localhost:8080/main` and `localhost:8080/preview`.
