### PR TITLE
fix(cli-service): drop webpack NoEmitOnErrorsPlugin usage

### DIFF
--- a/packages/@vue/cli-service/lib/config/dev.js
+++ b/packages/@vue/cli-service/lib/config/dev.js
@@ -15,10 +15,6 @@ module.exports = (api, options) => {
         .output
           .globalObject('this')
 
-      webpackConfig
-        .plugin('no-emit-on-errors')
-          .use(require('webpack/lib/NoEmitOnErrorsPlugin'))
-
       if (!process.env.VUE_CLI_TEST && options.devServer.progress !== false) {
         webpackConfig
           .plugin('progress')


### PR DESCRIPTION
As per comment https://github.com/vuejs/vue-cli/issues/1451#issuecomment-448952314, https://github.com/vuejs/vue-cli/issues/1451#issuecomment-450410469.

`NoEmitOnErrorsPlugin` is not necessarily needed anymore and causing problems, kindly remove it.