### PR TITLE
Add license to addons

### DIFF
--- a/packages/@vue/cli-ui-addon-webpack/package.json
+++ b/packages/@vue/cli-ui-addon-webpack/package.json
@@ -11,6 +11,7 @@
     "lint": "vue-cli-service lint",
     "prepublishOnly": "yarn run lint --no-fix && yarn run build"
   },
+  "license": "MIT",
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.2.2",
     "@vue/cli-plugin-eslint": "^3.2.2",

--- a/packages/@vue/cli-ui-addon-widgets/package.json
+++ b/packages/@vue/cli-ui-addon-widgets/package.json
@@ -11,6 +11,7 @@
     "lint": "vue-cli-service lint",
     "prepublishOnly": "yarn run lint --no-fix && yarn run build"
   },
+  "license": "MIT",
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.2.2",
     "@vue/cli-plugin-eslint": "^3.2.2",


### PR DESCRIPTION
The direct dependencies from cli "cli-ui-addon-webpack" and "cli-ui-addon-widgets" were missing the license information. Simply adding a line in package.json for npm to be able to pick up the license information.