### PR TITLE
feat: support use -h show detailed usage of command

### DIFF
--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -26,6 +26,10 @@ module.exports = {
   // 选项...
 }
 ```
+### baseUrl
+
+从 Vue CLI 3.3 起已弃用，请使用[`publicPath`](#publicPath)。
+
 
 ### publicPath
 

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -209,7 +209,7 @@ module.exports = class Service {
       error(`command "${name}" does not exist.`)
       process.exit(1)
     }
-    if (!command || args.help) {
+    if (!command || args.help || args.h) {
       command = this.commands.help
     } else {
       args._.shift() // remove command itself


### PR DESCRIPTION
eg: 
command `vue-cli-service serve -h` has the same effect as `vue-cli-service serve --help`