### PR TITLE
feat(babel): include es6.object.assign by default

### DIFF
--- a/packages/@vue/babel-preset-app/README.md
+++ b/packages/@vue/babel-preset-app/README.md
@@ -80,7 +80,7 @@ See [@babel/preset-env docs](https://new.babeljs.io/docs/en/next/babel-preset-en
 
 ### polyfills
 
-- Default: `['es6.array.iterator', 'es6.promise', 'es7.promise.finally']`
+- Default: `['es6.array.iterator', 'es6.promise', 'es6.object.assign', 'es7.promise.finally']`
 
 A list of [core-js](https://github.com/zloirock/core-js) polyfills to pre-include when using `useBuiltIns: 'usage'`. **These polyfills are automatically excluded if they are not needed for your target environments**.
 

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -6,6 +6,9 @@ const defaultPolyfills = [
   'es6.array.iterator',
   // this is required for webpack code splitting, vuex etc.
   'es6.promise',
+  // this is needed for object rest spread support in templates
+  // as vue-template-es2015-compiler 1.8+ compiles it to Object.assign() calls.
+  'es6.object.assign',
   // #2012 es6.promise replaces native Promise in FF and causes missing finally
   'es7.promise.finally'
 ]


### PR DESCRIPTION
This ensures support for Object rest spread usage in templates with [vue-template-es2015-compiler@1.8.0](https://github.com/vuejs/vue-template-es2015-compiler/releases/tag/v1.8.0).