### PR TITLE
Support yml, yaml und json tslint Configuration files

### DIFF
--- a/packages/@vue/cli-plugin-typescript/lib/tslint.js
+++ b/packages/@vue/cli-plugin-typescript/lib/tslint.js
@@ -1,4 +1,4 @@
-module.exports = function lint (args = {}, api, silent) {
+module.exports = function lint(args = {}, api, silent) {
   const cwd = api.resolve('.')
   const fs = require('fs')
   const path = require('path')
@@ -80,7 +80,11 @@ module.exports = function lint (args = {}, api, silent) {
     patchProgram(this.program)
   }
 
-  const tslintConfigPath = api.resolve('tslint.json')
+
+  const tslintConfigPath = tslint.Configuration.CONFIG_FILENAMES
+    .map(filename => api.resolve(filename))
+    .filter(file => !!fs.existsSync(file))
+    .pop();
 
   const config = tslint.Configuration.findConfiguration(tslintConfigPath).results
   // create a patched config that disables the blank lines rule,

--- a/packages/@vue/cli-plugin-typescript/lib/tslint.js
+++ b/packages/@vue/cli-plugin-typescript/lib/tslint.js
@@ -1,4 +1,4 @@
-module.exports = function lint(args = {}, api, silent) {
+module.exports = function lint (args = {}, api, silent) {
   const cwd = api.resolve('.')
   const fs = require('fs')
   const path = require('path')
@@ -80,11 +80,9 @@ module.exports = function lint(args = {}, api, silent) {
     patchProgram(this.program)
   }
 
-
   const tslintConfigPath = tslint.Configuration.CONFIG_FILENAMES
     .map(filename => api.resolve(filename))
-    .filter(file => !!fs.existsSync(file))
-    .pop();
+    .find(file => fs.existsSync(file))
 
   const config = tslint.Configuration.findConfiguration(tslintConfigPath).results
   // create a patched config that disables the blank lines rule,
@@ -117,7 +115,7 @@ module.exports = function lint(args = {}, api, silent) {
   // respect linterOptions.exclude from tslint.json
   if (config.linterOptions && config.linterOptions.exclude) {
     // use the raw tslint.json data because config contains absolute paths
-    const rawTslintConfig = tslint.Configuration.readConfigurationFile(tslintConfigPath);
+    const rawTslintConfig = tslint.Configuration.readConfigurationFile(tslintConfigPath)
     const excludedGlobs = rawTslintConfig.linterOptions.exclude
     excludedGlobs.forEach((g) => files.push('!' + g))
   }

--- a/packages/@vue/cli-plugin-typescript/lib/tslint.js
+++ b/packages/@vue/cli-plugin-typescript/lib/tslint.js
@@ -117,7 +117,7 @@ module.exports = function lint(args = {}, api, silent) {
   // respect linterOptions.exclude from tslint.json
   if (config.linterOptions && config.linterOptions.exclude) {
     // use the raw tslint.json data because config contains absolute paths
-    const rawTslintConfig = JSON.parse(fs.readFileSync(tslintConfigPath, 'utf-8'))
+    const rawTslintConfig = tslint.Configuration.readConfigurationFile(tslintConfigPath);
     const excludedGlobs = rawTslintConfig.linterOptions.exclude
     excludedGlobs.forEach((g) => files.push('!' + g))
   }


### PR DESCRIPTION
Fixes issue in #1900

Only yml, yaml und json is supported by tslint (https://github.com/HyphnKnight/tslint/commit/adb5ac92d385c646c10a8ad8de7ab8989725dbf5). 
Feature Request by @algil  for tslint.js is ignored.