### PR TITLE
fix:  failed to load config "plugin:vue/no-layout-rules" to extend from.

### DIFF
--- a/packages/@vue/cli-plugin-eslint/package.json
+++ b/packages/@vue/cli-plugin-eslint/package.json
@@ -26,7 +26,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^4.19.1",
     "eslint-loader": "^2.1.1",
-    "eslint-plugin-vue": "^4.7.1",
+    "eslint-plugin-vue": "^5.0.0",
     "globby": "^8.0.1"
   }
 }


### PR DESCRIPTION
 [to fix this issues](https://github.com/prettier/eslint-config-prettier/issues/70)

