### PR TITLE
feat: support dart-sass as default sass implementation

### DIFF
--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -62,7 +62,7 @@ test('default loaders', () => {
     })
   })
   // sass indented syntax
-  expect(findOptions(config, 'sass', 'sass')).toEqual({ indentedSyntax: true, sourceMap: false })
+  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ indentedSyntax: true, sourceMap: false })
 })
 
 test('production defaults', () => {
@@ -193,8 +193,14 @@ test('css.loaderOptions', () => {
     }
   })
 
-  expect(findOptions(config, 'scss', 'sass')).toEqual({ data, sourceMap: false })
-  expect(findOptions(config, 'sass', 'sass')).toEqual({ data, indentedSyntax: true, sourceMap: false })
+  expect(findOptions(config, 'scss', 'sass')).toMatchObject({ data, sourceMap: false })
+  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ data, indentedSyntax: true, sourceMap: false })
+})
+
+test('should use dart sass implementation whenever possible', () => {
+  const config = genConfig()
+  expect(findOptions(config, 'scss', 'sass')).toMatchObject({ fiber: require('fibers'), implementation: require('sass') })
+  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ fiber: require('fibers'), implementation: require('sass') })
 })
 
 test('skip postcss-loader if no postcss config found', () => {

--- a/packages/@vue/cli-service/__tests__/generator.spec.js
+++ b/packages/@vue/cli-service/__tests__/generator.spec.js
@@ -1,0 +1,47 @@
+const generateWithPlugin = require('@vue/cli-test-utils/generateWithPlugin')
+
+test('node sass (legacy)', async () => {
+  const { pkg, files } = await generateWithPlugin([
+    {
+      id: '@vue/cli-service',
+      apply: require('../generator'),
+      options: {
+        cssPreprocessor: 'sass'
+      }
+    }
+  ])
+
+  expect(files['src/App.vue']).toMatch('<style lang="scss">')
+  expect(pkg).toHaveProperty(['devDependencies', 'node-sass'])
+})
+
+test('node sass', async () => {
+  const { pkg, files } = await generateWithPlugin([
+    {
+      id: '@vue/cli-service',
+      apply: require('../generator'),
+      options: {
+        cssPreprocessor: 'node-sass'
+      }
+    }
+  ])
+
+  expect(files['src/App.vue']).toMatch('<style lang="scss">')
+  expect(pkg).toHaveProperty(['devDependencies', 'node-sass'])
+})
+
+test('dart sass', async () => {
+  const { pkg, files } = await generateWithPlugin([
+    {
+      id: '@vue/cli-service',
+      apply: require('../generator'),
+      options: {
+        cssPreprocessor: 'dart-sass'
+      }
+    }
+  ])
+
+  expect(files['src/App.vue']).toMatch('<style lang="scss">')
+  expect(pkg).toHaveProperty(['devDependencies', 'sass'])
+  expect(pkg).toHaveProperty(['devDependencies', 'fibers'])
+})

--- a/packages/@vue/cli-service/__tests__/serve.spec.js
+++ b/packages/@vue/cli-service/__tests__/serve.spec.js
@@ -93,3 +93,14 @@ test('serve with no public dir', async () => {
     }
   )
 })
+
+test('dart sass', async () => {
+  const project = await create('test-dart-sass', exports.defaultPreset = {
+    useConfigFiles: false,
+    cssPreprocessor: 'dart-sass',
+    plugins: {}
+  })
+
+  // should build successfully
+  await project.run('vue-cli-service build')
+})

--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -36,9 +36,19 @@ module.exports = (api, options) => {
 
   if (options.cssPreprocessor) {
     const deps = {
+      // TODO: remove 'sass' option in v4
       sass: {
         'node-sass': '^4.9.0',
-        'sass-loader': '^7.0.1'
+        'sass-loader': '^7.1.0'
+      },
+      'node-sass': {
+        'node-sass': '^4.9.0',
+        'sass-loader': '^7.1.0'
+      },
+      'dart-sass': {
+        fibers: '^3.1.1',
+        'dart-sass': '^1.16.0',
+        'sass-loader': '^7.1.0'
       },
       less: {
         'less': '^3.0.4',

--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -36,7 +36,7 @@ module.exports = (api, options) => {
 
   if (options.cssPreprocessor) {
     const deps = {
-      // TODO: remove 'sass' option in v4
+      // TODO: remove 'sass' option in v4 or rename 'dart-sass' to 'sass'
       sass: {
         'node-sass': '^4.9.0',
         'sass-loader': '^7.1.0'
@@ -47,7 +47,7 @@ module.exports = (api, options) => {
       },
       'dart-sass': {
         fibers: '^3.1.1',
-        'dart-sass': '^1.16.0',
+        'sass': '^1.16.0',
         'sass-loader': '^7.1.0'
       },
       less: {

--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -47,7 +47,7 @@ module.exports = (api, options) => {
       },
       'dart-sass': {
         fibers: '^3.1.1',
-        'sass': '^1.16.0',
+        sass: '^1.16.0',
         'sass-loader': '^7.1.0'
       },
       less: {

--- a/packages/@vue/cli-service/generator/template/src/App.vue
+++ b/packages/@vue/cli-service/generator/template/src/App.vue
@@ -39,7 +39,7 @@ export default {
 <style<%-
   rootOptions.cssPreprocessor
     ? ` lang="${
-        rootOptions.cssPreprocessor === 'sass'
+        rootOptions.cssPreprocessor.includes('sass')
           ? 'scss'
           : rootOptions.cssPreprocessor
       }"`

--- a/packages/@vue/cli-service/generator/template/src/components/HelloWorld.vue
+++ b/packages/@vue/cli-service/generator/template/src/components/HelloWorld.vue
@@ -46,7 +46,7 @@ export default {
 <style scoped<%-
   rootOptions.cssPreprocessor
     ? ` lang="${
-        rootOptions.cssPreprocessor === 'sass'
+        rootOptions.cssPreprocessor.includes('sass')
           ? 'scss'
           : rootOptions.cssPreprocessor
       }"`

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -15,6 +15,12 @@ module.exports = (api, options) => {
     const shadowMode = !!process.env.VUE_CLI_CSS_SHADOW_MODE
     const isProd = process.env.NODE_ENV === 'production'
 
+    const defaultSassLoaderOptions = {}
+    try {
+      defaultSassLoaderOptions.implementation = require('sass')
+      defaultSassLoaderOptions.fiber = require('fibers')
+    } catch (e) {}
+
     const {
       modules = false,
       extract = isProd,
@@ -158,8 +164,8 @@ module.exports = (api, options) => {
 
     createCSSRule('css', /\.css$/)
     createCSSRule('postcss', /\.p(ost)?css$/)
-    createCSSRule('scss', /\.scss$/, 'sass-loader', loaderOptions.sass)
-    createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign({
+    createCSSRule('scss', /\.scss$/, 'sass-loader', Object.assign(defaultSassLoaderOptions, loaderOptions.sass))
+    createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign(defaultSassLoaderOptions, {
       indentedSyntax: true
     }, loaderOptions.sass))
     createCSSRule('less', /\.less$/, 'less-loader', loaderOptions.less)

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -76,6 +76,9 @@
     "vue-template-compiler": "^2.0.0"
   },
   "devDependencies": {
+    "fibers": "^3.1.1",
+    "sass": "^1.16.1",
+    "sass-loader": "^7.1.0",
     "vue": "^2.5.21",
     "vue-router": "^3.0.1",
     "vue-template-compiler": "^2.5.21",

--- a/packages/@vue/cli/lib/options.js
+++ b/packages/@vue/cli/lib/options.js
@@ -13,7 +13,8 @@ const presetSchema = createSchema(joi => joi.object().keys({
   router: joi.boolean(),
   routerHistoryMode: joi.boolean(),
   vuex: joi.boolean(),
-  cssPreprocessor: joi.string().only(['sass', 'less', 'stylus']),
+  // TODO: remove 'sass' or make it equivalent to 'dart-sass' in v4
+  cssPreprocessor: joi.string().only(['sass', 'dart-sass', 'node-sass', 'less', 'stylus']),
   plugins: joi.object().required(),
   configs: joi.object()
 }))

--- a/packages/@vue/cli/lib/promptModules/__tests__/cssPreprocessors.spec.js
+++ b/packages/@vue/cli/lib/promptModules/__tests__/cssPreprocessors.spec.js
@@ -14,13 +14,13 @@ test('CSS pre-processor ', async () => {
     },
     {
       message: 'Pick a CSS pre-processor',
-      choices: ['Sass', 'Less', 'Stylus'],
+      choices: ['Sass/SCSS (with dart-sass)', 'Sass/SCSS (with node-sass)', 'Less', 'Stylus'],
       choose: 0
     }
   ]
 
   const expectedOptions = {
-    cssPreprocessor: 'sass',
+    cssPreprocessor: 'dart-sass',
     plugins: {}
   }
 

--- a/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
+++ b/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
@@ -15,9 +15,17 @@ module.exports = cli => {
     message: `Pick a CSS pre-processor${process.env.VUE_CLI_API_MODE ? '' : ` (${notice})`}:`,
     description: `${notice}.`,
     choices: [
+      // In Vue CLI <= 3.3, the value of Sass option in 'sass' an means 'node-sass'.
+      // Considering the 'sass' package on NPM is actually for Dart Sass, we renamed it to 'node-sass'.
+      // In @vue/cli-service there're still codes that accepts 'sass' as an option value, for compatibility reasons,
+      // and they're meant to be removed in v4.
       {
-        name: 'Sass/SCSS',
-        value: 'sass'
+        name: 'Sass/SCSS (with dart-sass)',
+        value: 'dart-sass'
+      },
+      {
+        name: 'Sass/SCSS (with node-sass)',
+        value: 'node-sass'
       },
       {
         name: 'Less',

--- a/packages/@vue/cli/lib/util/inferRootOptions.js
+++ b/packages/@vue/cli/lib/util/inferRootOptions.js
@@ -19,7 +19,7 @@ module.exports = function inferRootOptions (pkg) {
   }
 
   // cssPreprocessors
-  if ('dart-sass' in deps) {
+  if ('sass' in deps) {
     rootOptions.cssPreprocessor = 'dart-sass'
   } else if ('node-sass' in deps) {
     // TODO: change to 'node-sass' in v4

--- a/packages/@vue/cli/lib/util/inferRootOptions.js
+++ b/packages/@vue/cli/lib/util/inferRootOptions.js
@@ -19,7 +19,10 @@ module.exports = function inferRootOptions (pkg) {
   }
 
   // cssPreprocessors
-  if ('sass-loader' in deps) {
+  if ('dart-sass' in deps) {
+    rootOptions.cssPreprocessor = 'dart-sass'
+  } else if ('node-sass' in deps) {
+    // TODO: change to 'node-sass' in v4
     rootOptions.cssPreprocessor = 'sass'
   } else if ('less-loader' in deps) {
     rootOptions.cssPreprocessor = 'less'

--- a/packages/@vue/cli/lib/util/injectImportsAndOptions.js
+++ b/packages/@vue/cli/lib/util/injectImportsAndOptions.js
@@ -25,7 +25,9 @@ module.exports = function injectImportsAndOptions (source, imports, injections) 
       }
     })
     // avoid blank line after the previous import
-    delete ast.program.body[lastImportIndex].loc
+    if (lastImportIndex !== -1) {
+      delete ast.program.body[lastImportIndex].loc
+    }
 
     const nonDuplicates = i => {
       return !importDeclarations.some(node => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3441,6 +3441,11 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
   integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 bin-links@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.2.tgz#fb74bd54bae6b7befc6c6221f25322ac830d9757"
@@ -4236,6 +4241,16 @@ cliui@^4.0.0, cliui@^4.1.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
+
+clone-deep@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-2.0.2.tgz#00db3a1e173656730d1188c3d6aced6d7ea97713"
+  integrity sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==
+  dependencies:
+    for-own "^1.0.0"
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.0"
+    shallow-clone "^1.0.0"
 
 clone@2.x, clone@^2.1.1:
   version "2.1.2"
@@ -5734,7 +5749,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -7029,6 +7044,13 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fibers@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fibers/-/fibers-3.1.1.tgz#0238902ca938347bd779523692fbeefdf4f688ab"
+  integrity sha512-dl3Ukt08rHVQfY8xGD0ODwyjwrRALtaghuqGH2jByYX1wpY+nAnRQjJ6Dbqq0DnVgNVQ9yibObzbF4IlPyiwPw==
+  dependencies:
+    detect-libc "^1.0.3"
+
 figgy-pudding@^3.1.0, figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -7278,6 +7300,11 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "=3.1.0"
 
+for-in@^0.1.3:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
+  integrity sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -7287,6 +7314,13 @@ for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
+  dependencies:
+    for-in "^1.0.1"
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
+  integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
   dependencies:
     for-in "^1.0.1"
 
@@ -9870,6 +9904,13 @@ json5@^0.5.0, json5@^0.5.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
@@ -10437,6 +10478,15 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+loader-utils@^1.0.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
+  integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^2.0.0"
+    json5 "^1.0.1"
+
 loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
@@ -10668,6 +10718,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.tail@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
+  integrity sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=
 
 lodash.template@^4.0.2, lodash.template@^4.4.0:
   version "4.4.0"
@@ -11337,6 +11392,14 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mixin-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
+  integrity sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=
+  dependencies:
+    for-in "^0.1.3"
+    is-extendable "^0.1.1"
 
 mkdirp@0.3.0:
   version "0.3.0"
@@ -14413,6 +14476,25 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
+sass-loader@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.1.0.tgz#16fd5138cb8b424bf8a759528a1972d72aad069d"
+  integrity sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==
+  dependencies:
+    clone-deep "^2.0.1"
+    loader-utils "^1.0.1"
+    lodash.tail "^4.1.1"
+    neo-async "^2.5.0"
+    pify "^3.0.0"
+    semver "^5.5.0"
+
+sass@^1.16.0, sass@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.16.1.tgz#3abbb04562c9e3a3ee11c3056956294ed333f6e6"
+  integrity sha512-lKoiOI/zsAHrdYAdcWBM0pynYCmK0t7N9OAVjxAoYvo0mDBQmlhM6w+zNuFQYeS6d3VF+7KVWwkX6oWNMJxVag==
+  dependencies:
+    chokidar "^2.0.0"
+
 sax@0.5.x:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
@@ -14615,6 +14697,15 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-1.0.0.tgz#4480cd06e882ef68b2ad88a3ea54832e2c48b571"
+  integrity sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==
+  dependencies:
+    is-extendable "^0.1.1"
+    kind-of "^5.0.0"
+    mixin-object "^2.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
closes https://github.com/vuejs/vue-cli/issues/1782

1. `sass` + `fibers` combined is ~10MiB smaller than the `node-sass` package, and approximately 1.5x slower in performance ([perf report](https://github.com/sass/dart-sass/blob/master/perf.md), and with `fibers` there's a 2x speedup)
2. [It's the future of sass](http://sass.logdown.com/posts/1022316-announcing-dart-sass)

TODOs in this PR:
1. [x] Should add tests
2. [ ] This PR uses a `try ... catch` block to test if `sass` package can be resolved and default to it. Should we make it more explicit? How?