### PR TITLE
fix: only add custom ignorePattern when no .eslintignore exists

### DIFF
--- a/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
@@ -121,7 +121,7 @@ test('should not fix with --no-fix option', async () => {
   expect(await read('src/main.js')).not.toMatch(';')
 })
 
-// #3167
+// #3167, #3243
 test('should not throw when src folder is ignored by .eslintignore', async () => {
   const project = await create('eslint-ignore', {
     plugins: {
@@ -130,11 +130,12 @@ test('should not throw when src folder is ignored by .eslintignore', async () =>
         config: 'airbnb',
         lintOn: 'commit'
       }
-    }
+    },
+    useConfigFiles: true
   })
 
   const { write, run } = project
-  await write('.eslintignore', 'src\n')
+  await write('.eslintignore', 'src\n.eslintrc.js')
 
   // should not throw
   await run('vue-cli-service lint')

--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const globby = require('globby')
 
 const renamedArrayArgs = {
@@ -31,26 +32,34 @@ module.exports = function lint (args = {}, api) {
     cwd
   }, argsConfig)
 
-  const engine = new CLIEngine(config)
+  if (!fs.existsSync(api.resolve('.eslintignore'))) {
+    // .eslintrc.js files (ignored by default)
+    // However, we need to lint & fix them so as to make the default generated project's
+    // code style consistent with user's selected eslint config.
+    // Though, if users provided their own `.eslintignore` file, we don't want to
+    // add our own customized ignore pattern here (in eslint, ignorePattern is
+    // an addition to eslintignore, i.e. it can't be overriden by user),
+    // following the principle of least astonishment.
+    config.ignorePattern = [
+      '!.*.js',
+      '!{src,tests}/**/.*.js'
+    ]
+  }
 
-  // .eslintrc.js files (ignored by default)
-  const dotFiles = [
-    '.*.js',
-    '{src,tests}/**/.*.js'
-  ].filter(pattern => globby.sync(path.join(cwd, pattern)).length)
+  const engine = new CLIEngine(config)
 
   const defaultFilesToLint = [
     'src',
     'tests',
     // root config files
-    '*.js'
+    '*.js',
+    '.*.js'
   ]
     .filter(pattern =>
       globby
         .sync(path.join(cwd, pattern))
         .some(p => !engine.isPathIgnored(p))
     )
-    .concat(dotFiles)
 
   const files = args._ && args._.length
     ? args._


### PR DESCRIPTION
closes #3243

An alternative is to generate a default `.eslintignore` file in project root. But personally I think that's an overkill.