### PR TITLE
created toggle with process.env.VUE_APP_ALLOW_LOCAL_SW to allow local…

### DIFF
--- a/packages/@vue/cli-plugin-pwa/generator/template/src/registerServiceWorker.js
+++ b/packages/@vue/cli-plugin-pwa/generator/template/src/registerServiceWorker.js
@@ -2,7 +2,7 @@
 
 import { register } from 'register-service-worker'
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production' || process.env.VUE_APP_ALLOW_LOCAL_SW) {
   register(`${process.env.BASE_URL}service-worker.js`, {
     ready () {
       console.log(

--- a/packages/@vue/cli-plugin-pwa/index.js
+++ b/packages/@vue/cli-plugin-pwa/index.js
@@ -18,7 +18,8 @@ module.exports = (api, options) => {
         .after('html')
 
     // generate /service-worker.js in production mode
-    if (process.env.NODE_ENV === 'production') {
+    // or when local service worker development is allowed
+    if (process.env.NODE_ENV === 'production' || process.env.VUE_APP_ALLOW_LOCAL_SW) {
       // Default to GenerateSW mode, though InjectManifest also might be used.
       const workboxPluginMode = userOptions.workboxPluginMode || 'GenerateSW'
       const workboxWebpackModule = require('workbox-webpack-plugin')
@@ -52,8 +53,11 @@ module.exports = (api, options) => {
   })
 
   // install dev server middleware for resetting service worker during dev
-  const createNoopServiceWorkerMiddleware = require('./lib/noopServiceWorkerMiddleware')
-  api.configureDevServer(app => {
-    app.use(createNoopServiceWorkerMiddleware())
-  })
+  // when local service worker development is not allowed (default)
+  if(!process.env.VUE_APP_ALLOW_LOCAL_SW) {
+    const createNoopServiceWorkerMiddleware = require('./lib/noopServiceWorkerMiddleware')
+    api.configureDevServer(app => {
+      app.use(createNoopServiceWorkerMiddleware())
+    })
+  }
 }


### PR DESCRIPTION
When building PWA's with complex functionalities and interactions, it may be desirable to have a functioning service worker in development mode. This branch has a toggle in the shape of VUE_APP_ALLOW_LOCAL_SW that, when set to true, allows the developer to have the service worker under development installed on the client while running the development server.