### PR TITLE
fix(cli-ui): folder list when root windows

### DIFF
--- a/packages/@vue/cli-ui/apollo-server/connectors/folders.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/folders.js
@@ -24,7 +24,13 @@ function isDirectory (file) {
 }
 
 async function list (base, context) {
-  const files = await fs.readdir(base, 'utf8')
+  let dir = base
+  if (isPlatformWindows) {
+    if (base.match(/^([A-Z]{1}:)$/)) {
+      dir = path.join(base, '\\')
+    }
+  }
+  const files = await fs.readdir(dir, 'utf8')
   return files.map(
     file => {
       const folderPath = path.join(base, file)


### PR DESCRIPTION
Issue: https://github.com/vuejs/vue-cli/issues/3253

It's a node issue on Windows when using drive path without backslash.