### PR TITLE
Update eslint-config-typescript to use @typescript-eslint

### DIFF
--- a/packages/@vue/cli-plugin-eslint/__tests__/eslintGenerator.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/eslintGenerator.spec.js
@@ -100,7 +100,7 @@ test('typescript', async () => {
     '@vue/typescript'
   ])
   expect(pkg.eslintConfig.parserOptions).toEqual({
-    parser: 'typescript-eslint-parser'
+    parser: '@typescript-eslint/parserr'
   })
   expect(pkg.devDependencies).toHaveProperty('@vue/eslint-config-prettier')
   expect(pkg.devDependencies).toHaveProperty('@vue/eslint-config-typescript')

--- a/packages/@vue/cli-plugin-eslint/__tests__/eslintGenerator.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/eslintGenerator.spec.js
@@ -100,7 +100,7 @@ test('typescript', async () => {
     '@vue/typescript'
   ])
   expect(pkg.eslintConfig.parserOptions).toEqual({
-    parser: '@typescript-eslint/parserr'
+    parser: '@typescript-eslint/parser'
   })
   expect(pkg.devDependencies).toHaveProperty('@vue/eslint-config-prettier')
   expect(pkg.devDependencies).toHaveProperty('@vue/eslint-config-typescript')

--- a/packages/@vue/cli-plugin-eslint/generator/index.js
+++ b/packages/@vue/cli-plugin-eslint/generator/index.js
@@ -113,7 +113,7 @@ const applyTS = module.exports.applyTS = api => {
     eslintConfig: {
       extends: ['@vue/typescript'],
       parserOptions: {
-        parser: 'typescript-eslint-parser'
+        parser: '@typescript-eslint/parser'
       }
     },
     devDependencies: {

--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -9,7 +9,7 @@ module.exports = (api, {
 
   api.extendPackage({
     devDependencies: {
-      typescript: api.hasPlugin('eslint') ? '~3.1.1' : '^3.0.0'
+      typescript: api.hasPlugin('eslint') ? '~3.2.2' : '^3.0.0'
     }
   })
 

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -36,7 +36,7 @@
     "@types/chai": "^4.1.0",
     "@types/jest": "^23.1.4",
     "@types/mocha": "^5.2.4",
-    "typescript": "~3.1.1",
+    "typescript": "~3.2.2",
     "vue-class-component": "^6.2.0",
     "vue-property-decorator": "^7.0.0"
   }

--- a/packages/@vue/cli/__tests__/invoke.spec.js
+++ b/packages/@vue/cli/__tests__/invoke.spec.js
@@ -103,7 +103,7 @@ test('invoke with ts', async () => {
   expect(updatedESLintrc).toEqual(Object.assign({}, baseESLintConfig, {
     extends: ['plugin:vue/essential', 'eslint:recommended', '@vue/typescript'],
     parserOptions: {
-      parser: 'typescript-eslint-parser'
+      parser: '@typescript-eslint/parser'
     }
   }))
 })

--- a/packages/@vue/eslint-config-typescript/README.md
+++ b/packages/@vue/eslint-config-typescript/README.md
@@ -2,7 +2,7 @@
 
 > eslint-config-typescript for vue-cli
 
-See [@typescript-eslint/eslint-plugin](https://typescript-eslint.io) for available rules.
+See [@typescript-eslint/eslint-plugin](https://typescript-eslint.io/eslint-plugin) for available rules.
 
 This config is specifically designed to be used by `vue-cli` setups
 and is not meant for outside use (it can be used but some adaptations

--- a/packages/@vue/eslint-config-typescript/README.md
+++ b/packages/@vue/eslint-config-typescript/README.md
@@ -2,7 +2,7 @@
 
 > eslint-config-typescript for vue-cli
 
-See [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript) for available rules.
+See [@typescript-eslint/eslint-plugin](https://typescript-eslint.io) for available rules.
 
 This config is specifically designed to be used by `vue-cli` setups
 and is not meant for outside use (it can be used but some adaptations

--- a/packages/@vue/eslint-config-typescript/index.js
+++ b/packages/@vue/eslint-config-typescript/index.js
@@ -11,7 +11,8 @@ module.exports = {
     // https://typescript-eslint.io/parser
     'no-undef': 'off',
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': 'error',
+    // https://github.com/typescript-eslint/typescript-eslint/issues/46
+    // '@typescript-eslint/no-unused-vars': 'error',
 
     // temporary fix for https://github.com/vuejs/vue-cli/issues/1922
     // very strange as somehow this rule gets different behaviors depending

--- a/packages/@vue/eslint-config-typescript/index.js
+++ b/packages/@vue/eslint-config-typescript/index.js
@@ -8,14 +8,14 @@ module.exports = {
     parser: require.resolve('@typescript-eslint/parser')
   },
   rules: {
+    // https://typescript-eslint.io/parser
     'no-undef': 'off',
     'no-unused-vars': 'off',
-    // https://github.com/eslint/typescript-eslint-parser/issues/445
-    // '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': 'error',
 
     // temporary fix for https://github.com/vuejs/vue-cli/issues/1922
     // very strange as somehow this rule gets different behaviors depending
-    // on the presence of typescript-eslint-parser...
+    // on the presence of @typescript-eslint/parser...
     'strict': 'off'
   }
 }

--- a/packages/@vue/eslint-config-typescript/index.js
+++ b/packages/@vue/eslint-config-typescript/index.js
@@ -1,20 +1,17 @@
 module.exports = {
-  plugins: ['typescript'],
+  plugins: ['@typescript-eslint'],
   // Prerequisite `eslint-plugin-vue`, being extended, sets
   // root property `parser` to `'vue-eslint-parser'`, which, for code parsing,
   // in turn delegates to the parser, specified in `parserOptions.parser`:
   // https://github.com/vuejs/eslint-plugin-vue#what-is-the-use-the-latest-vue-eslint-parser-error
   parserOptions: {
-    parser: require.resolve('typescript-eslint-parser'),
-    // #3268
-    jsx: true
+    parser: require.resolve('@typescript-eslint/parser')
   },
   rules: {
-    // https://github.com/eslint/typescript-eslint-parser#known-issues
     'no-undef': 'off',
     'no-unused-vars': 'off',
     // https://github.com/eslint/typescript-eslint-parser/issues/445
-    // 'typescript/no-unused-vars': 'error',
+    // '@typescript-eslint/no-unused-vars': 'error',
 
     // temporary fix for https://github.com/vuejs/vue-cli/issues/1922
     // very strange as somehow this rule gets different behaviors depending

--- a/packages/@vue/eslint-config-typescript/package.json
+++ b/packages/@vue/eslint-config-typescript/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/eslint-config-typescript#readme",
   "dependencies": {
-    "eslint-plugin-typescript": "^0.14.0",
-    "typescript-eslint-parser": "^21.0.2"
+    "@typescript-eslint/eslint-plugin": "^1.1.0",
+    "@typescript-eslint/parser": "^1.1.0"
   }
 }


### PR DESCRIPTION
Packages
- typescript-eslint-parser: https://github.com/eslint/typescript-eslint-parser
- eslint-plugin-typescript: https://github.com/bradzacher/eslint-plugin-typescript
got deprecated in favor of [@typescript-eslint](https://typescript-eslint.io)