### PR TITLE
fix(cli-service): Vue external add amd config

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -50,6 +50,7 @@ module.exports = (api, { entry, name, formats }, options) => {
         vue: {
           commonjs: 'vue',
           commonjs2: 'vue',
+          amd: 'Vue',
           root: 'Vue'
         }
       })


### PR DESCRIPTION
If one module builded as a lib mode(umd style), and use `SystemJs` to load in browser, it would be treated as an amd module, so Vue external need add amd config.