### PR TITLE
fix(cli-service): inspect --rules (close #3334)

### DIFF
--- a/packages/@vue/cli-service/lib/commands/inspect.js
+++ b/packages/@vue/cli-service/lib/commands/inspect.js
@@ -1,44 +1,71 @@
 module.exports = (api, options) => {
-  api.registerCommand('inspect', {
-    description: 'inspect internal webpack config',
-    usage: 'vue-cli-service inspect [options] [...paths]',
-    options: {
-      '--mode': 'specify env mode (default: development)',
-      '--rule <ruleName>': 'inspect a specific module rule',
-      '--plugin <pluginName>': 'inspect a specific plugin',
-      '--rules': 'list all module rule names',
-      '--plugins': 'list all plugin names',
-      '--verbose': 'show full function definitions in output'
-    }
-  }, args => {
-    const { get } = require('@vue/cli-shared-utils')
-    const { toString } = require('webpack-chain')
-    const config = api.resolveWebpackConfig()
-    const { _: paths, verbose } = args
+  api.registerCommand(
+    'inspect',
+    {
+      description: 'inspect internal webpack config',
+      usage: 'vue-cli-service inspect [options] [...paths]',
+      options: {
+        '--mode': 'specify env mode (default: development)',
+        '--rule <ruleName>': 'inspect a specific module rule',
+        '--plugin <pluginName>': 'inspect a specific plugin',
+        '--rules': 'list all module rule names',
+        '--plugins': 'list all plugin names',
+        '--verbose': 'show full function definitions in output'
+      }
+    },
+    args => {
+      const chalk = require('chalk')
+      const { get } = require('@vue/cli-shared-utils')
+      const { toString } = require('webpack-chain')
+      const config = api.resolveWebpackConfig()
+      const { _: paths, verbose } = args
 
-    let res
-    if (args.rule) {
-      res = config.module.rules.find(r => r.__ruleNames[0] === args.rule)
-    } else if (args.plugin) {
-      res = config.plugins.find(p => p.__pluginName === args.plugin)
-    } else if (args.rules) {
-      res = config.module.rules.filter(r => r.__ruleNames).map(r => r.__ruleNames[0])
-    } else if (args.plugins) {
-      res = config.plugins.map(p => p.__pluginName || p.constructor.name)
-    } else if (paths.length > 1) {
-      res = {}
-      paths.forEach(path => {
-        res[path] = get(config, path)
-      })
-    } else if (paths.length === 1) {
-      res = get(config, paths[0])
-    } else {
-      res = config
-    }
+      let res
+      let hasUnnamedRule
+      if (args.rule) {
+        res = config.module.rules.find(r => r.__ruleNames[0] === args.rule)
+      } else if (args.plugin) {
+        res = config.plugins.find(p => p.__pluginName === args.plugin)
+      } else if (args.rules) {
+        res = config.module.rules.map(r => {
+          const name = r.__ruleNames ? r.__ruleNames[0] : 'Nameless Rule*'
 
-    const output = toString(res, { verbose })
-    console.log(output)
-  })
+          hasUnnamedRule = !hasUnnamedRule && !r.__ruleNames
+
+          return name
+        })
+      } else if (args.plugins) {
+        res = config.plugins.map(p => p.__pluginName || p.constructor.name)
+      } else if (paths.length > 1) {
+        res = {}
+        paths.forEach(path => {
+          res[path] = get(config, path)
+        })
+      } else if (paths.length === 1) {
+        res = get(config, paths[0])
+      } else {
+        res = config
+      }
+
+      const output = toString(res, { verbose })
+      console.log(output)
+
+      // Log explanation for Nameless Rules
+      if (hasUnnamedRule) {
+        console.log('--------')
+        console.log(`* => Rules that are "nameless" were added with ${chalk.green(
+          'configureWebpack()'
+        )} (possibly by a plugin).
+    Run ${chalk.green(
+    'vue-cli-service inspect'
+  )} without any arguments to inspect the full config.
+      
+    We recommend using ${chalk.green(
+    'chainWebpack()'
+  )} instead whenever possible`)
+      }
+    }
+  )
 }
 
 module.exports.defaultModes = {

--- a/packages/@vue/cli-service/lib/commands/inspect.js
+++ b/packages/@vue/cli-service/lib/commands/inspect.js
@@ -28,9 +28,9 @@ module.exports = (api, options) => {
         res = config.plugins.find(p => p.__pluginName === args.plugin)
       } else if (args.rules) {
         res = config.module.rules.map(r => {
-          const name = r.__ruleNames ? r.__ruleNames[0] : 'Nameless Rule*'
+          const name = r.__ruleNames ? r.__ruleNames[0] : 'Nameless Rule (*)'
 
-          hasUnnamedRule = !hasUnnamedRule && !r.__ruleNames
+          hasUnnamedRule = hasUnnamedRule || !r.__ruleNames
 
           return name
         })
@@ -52,17 +52,17 @@ module.exports = (api, options) => {
 
       // Log explanation for Nameless Rules
       if (hasUnnamedRule) {
-        console.log('--------')
-        console.log(`* => Rules that are "nameless" were added with ${chalk.green(
+        console.log(`--- ${chalk.green('Footnotes')} ---`)
+        console.log(`*: ${chalk.green(
+          'Nameless Rules'
+        )} were added through the ${chalk.green(
           'configureWebpack()'
-        )} (possibly by a plugin).
-    Run ${chalk.green(
+        )} API (possibly by a plugin) instead of ${chalk.green(
+          'chainWebpack()'
+        )} (recommended).
+    You can run ${chalk.green(
     'vue-cli-service inspect'
-  )} without any arguments to inspect the full config.
-      
-    We recommend using ${chalk.green(
-    'chainWebpack()'
-  )} instead whenever possible`)
+  )} without any arguments to inspect the full config and read these rules' config.`)
       }
     }
   )

--- a/packages/@vue/cli-service/lib/commands/inspect.js
+++ b/packages/@vue/cli-service/lib/commands/inspect.js
@@ -22,7 +22,7 @@ module.exports = (api, options) => {
     } else if (args.plugin) {
       res = config.plugins.find(p => p.__pluginName === args.plugin)
     } else if (args.rules) {
-      res = config.module.rules.map(r => r.__ruleNames[0])
+      res = config.module.rules.filter(r => r.__ruleNames).map(r => r.__ruleNames[0])
     } else if (args.plugins) {
       res = config.plugins.map(p => p.__pluginName || p.constructor.name)
     } else if (paths.length > 1) {


### PR DESCRIPTION
should only return rules that actually have a name 
(= which were added with the chainWebpack API)

close #3334


Alternative: Instead of filtering these cases, we could add a default name to inform the user that there are rules not included in this list?