### PR TITLE
docs: add documentation for --formats to the build options section in…

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -67,6 +67,7 @@ Options:
   --dest        specify output directory (default: dist)
   --modern      build app targeting modern browsers with auto fallback
   --target      app | lib | wc | wc-async (default: app)
+  --formats     list of output formats for library builds (default: commonjs,umd,umd-min)
   --name        name for lib or web-component mode (default: "name" in package.json or entry filename)
   --no-clean    do not remove the dist directory before building the project
   --report      generate report.html to help analyze bundle content


### PR DESCRIPTION
… cli-service.md

Pull #2583 added --formats to the cli build commands but did not add documentation to the guide for the flag