### PR TITLE
chore(plugin/nightwatch): bump nightwatch dependency

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/package.json
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/package.json
@@ -26,7 +26,7 @@
     "chromedriver": "^2.45.0",
     "deepmerge": "^3.0.0",
     "execa": "^1.0.0",
-    "nightwatch": "^0.9.21",
+    "nightwatch": "^1.0.18",
     "selenium-server": "^3.141.59"
   }
 }


### PR DESCRIPTION
The yarn.lock file changes fairly drastically when I run yarn so not committing it in this PR. I was able to run the test and it ran successfully. I also ran this in the context of a new project and everything seems to work well with boilerplate generators.

```bash
$ yarn -v
1.13.0
```

![image](https://user-images.githubusercontent.com/5770711/51944170-2dcba000-23d0-11e9-8e6c-36b47c75ec99.png)
