### PR TITLE
chore: add `repository.directory` field to each `package.json`

### DIFF
--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/babel-preset-app"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-init/package.json
+++ b/packages/@vue/cli-init/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-init"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-overlay/package.json
+++ b/packages/@vue/cli-overlay/package.json
@@ -8,7 +8,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-overlay"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-babel/package.json
+++ b/packages/@vue/cli-plugin-babel/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-babel"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-e2e-cypress/package.json
+++ b/packages/@vue/cli-plugin-e2e-cypress/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-e2e-cypress"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-e2e-nightwatch/package.json
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-e2e-nightwatch"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-eslint/package.json
+++ b/packages/@vue/cli-plugin-eslint/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-eslint"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-pwa/package.json
+++ b/packages/@vue/cli-plugin-pwa/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-pwa"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-typescript"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-unit-jest"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-plugin-unit-mocha/package.json
+++ b/packages/@vue/cli-plugin-unit-mocha/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-unit-mocha"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-service-global/package.json
+++ b/packages/@vue/cli-service-global/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-service-global"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -9,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-service"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-shared-utils/package.json
+++ b/packages/@vue/cli-shared-utils/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-shared-utils"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-test-utils/package.json
+++ b/packages/@vue/cli-test-utils/package.json
@@ -4,7 +4,8 @@
   "description": "test utilities for vue-cli packages",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-test-utils"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli-ui-addon-webpack/package.json
+++ b/packages/@vue/cli-ui-addon-webpack/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vue/cli-ui-addon-webpack",
   "version": "3.4.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-ui-addon-webpack"
+  },
   "files": [
     "dist",
     "src"

--- a/packages/@vue/cli-ui-addon-widgets/package.json
+++ b/packages/@vue/cli-ui-addon-widgets/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vue/cli-ui-addon-widgets",
   "version": "3.4.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-ui-addon-widgets"
+  },
   "files": [
     "dist",
     "src"

--- a/packages/@vue/cli-ui/package.json
+++ b/packages/@vue/cli-ui/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vue/cli-ui",
   "version": "3.4.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-ui"
+  },
   "scripts": {
     "serve": "cross-env VUE_APP_CLI_UI_URL=ws://localhost:4030/graphql VUE_APP_GRAPHQL_PORT=4030 vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/packages/@vue/cli-upgrade/package.json
+++ b/packages/@vue/cli-upgrade/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-upgrade"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -7,7 +7,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/eslint-config-airbnb/package.json
+++ b/packages/@vue/eslint-config-airbnb/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/eslint-config-airbnb"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/eslint-config-prettier/package.json
+++ b/packages/@vue/eslint-config-prettier/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/eslint-config-prettier"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/eslint-config-standard/package.json
+++ b/packages/@vue/eslint-config-standard/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/eslint-config-standard"
   },
   "keywords": [
     "vue",

--- a/packages/@vue/eslint-config-typescript/package.json
+++ b/packages/@vue/eslint-config-typescript/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-cli.git"
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/eslint-config-typescript"
   },
   "keywords": [
     "vue",


### PR DESCRIPTION
This field allows you specify path of each package in a monorepo thanks to [this npm RFC](https://github.com/npm/rfcs/blob/latest/accepted/0010-monorepo-subdirectory-declaration.md). Main benefit of providing this field is a more accurate link to the package's source code from its npmjs.com page.

I had to add `repository` section in three packages: `cli-ui`, `cli-ui-addon-widgets`, `cli`cli-ui-addon-webpack` as it was missing from their `package.json`.