### PR TITLE
Add note about comments in .env files

### DIFF
--- a/docs/guide/mode-and-env.md
+++ b/docs/guide/mode-and-env.md
@@ -9,10 +9,12 @@ You can specify env variables by placing the following files in your project roo
 .env.[mode].local   # only loaded in specified mode, ignored by git
 ```
 
-An env file simply contains key=value pairs of environment variables:
+An env file simply contains key=value pairs of environment variables (lines not starting with letter or numbers will be ignored):
 
 ```
+# Comment
 FOO=bar
+#OLD_VAR=not_used
 VUE_APP_SECRET=secret
 ```
 


### PR DESCRIPTION
You can put "comments" in .env files, because lines that don't start with letters or numbers are ignored - see [here](https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-service/lib/util/loadEnv.js#L17) for the code that reads these files.

I'm not sure if this constitutes "official" support for comments in .env files or not - or if it's just taking advantage of an implementation detail.

Either way, I wanted to put comments into this file, so this was useful information to me - and something that I had to figure out myself.

This commit adds a note about this to the docs, using the `#` to denote a comment line - although any non-alphanumeric char would work.