### PR TITLE
fix: Import createTimeAgo from vue-timeago

### DIFF
--- a/packages/@vue/cli-ui/src/i18n.js
+++ b/packages/@vue/cli-ui/src/i18n.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import deepmerge from 'deepmerge'
-import VueTimeago from 'vue-timeago'
+import VueTimeago, { createTimeago } from 'vue-timeago'
 
 Vue.use(VueI18n)
 
@@ -50,7 +50,7 @@ async function autoDetect () {
     }
 
     const dateFnsLocale = i18n.locale.toLowerCase().replace(/-/g, '_')
-    Vue.component('VueTimeago', VueTimeago.createTimeago({
+    Vue.component('VueTimeago', createTimeago({
       name: 'VueTimeago',
       locale: i18n.locale,
       locales: {


### PR DESCRIPTION
Hi! :wave: 

While I was investigating #3410, I noticed that we were using `VueTimeago.createTimeAgo`, but `createTimeAgo` is a named export.