### PR TITLE
fix(cli-service): #3433 reduced verbose logging in containers when recompiling

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -208,26 +208,30 @@ module.exports = (api, options) => {
           ? publicUrl.replace(/([^/])$/, '$1/')
           : urls.lanUrlForTerminal
 
-        console.log()
-        console.log(`  App running at:`)
-        console.log(`  - Local:   ${chalk.cyan(urls.localUrlForTerminal)} ${copied}`)
-        if (!isInContainer) {
-          console.log(`  - Network: ${chalk.cyan(networkUrl)}`)
-        } else {
+        // only display this message once on start up if we're inside a 
+        // container to prevent flooding logs on recompiles
+        if (!isFirstCompile || (isFirstCompile && isInContainer)) {
           console.log()
-          console.log(chalk.yellow(`  It seems you are running Vue CLI inside a container.`))
-          if (!publicUrl && options.publicPath && options.publicPath !== '/') {
+          console.log(`  App running at:`)
+          console.log(`  - Local:   ${chalk.cyan(urls.localUrlForTerminal)} ${copied}`)
+          if (!isInContainer) {
+            console.log(`  - Network: ${chalk.cyan(networkUrl)}`)
+          } else {
             console.log()
-            console.log(chalk.yellow(`  Since you are using a non-root publicPath, the hot-reload socket`))
-            console.log(chalk.yellow(`  will not be able to infer the correct URL to connect. You should`))
-            console.log(chalk.yellow(`  explicitly specify the URL via ${chalk.blue(`devServer.public`)}.`))
-            console.log()
+            console.log(chalk.yellow(`  It seems you are running Vue CLI inside a container.`))
+            if (!publicUrl && options.publicPath && options.publicPath !== '/') {
+              console.log()
+              console.log(chalk.yellow(`  Since you are using a non-root publicPath, the hot-reload socket`))
+              console.log(chalk.yellow(`  will not be able to infer the correct URL to connect. You should`))
+              console.log(chalk.yellow(`  explicitly specify the URL via ${chalk.blue(`devServer.public`)}.`))
+              console.log()
+            }
+            console.log(chalk.yellow(`  Access the dev server via ${chalk.cyan(
+              `${protocol}://localhost:<your container's external mapped port>${options.publicPath}`
+            )}`))
           }
-          console.log(chalk.yellow(`  Access the dev server via ${chalk.cyan(
-            `${protocol}://localhost:<your container's external mapped port>${options.publicPath}`
-          )}`))
+          console.log()
         }
-        console.log()
 
         if (isFirstCompile) {
           isFirstCompile = false


### PR DESCRIPTION
Each time a recompile happens, ~10 lines of logs are generated. When running on a native CLI this isn't a problem since the console clears and redraws in place. However, inside a container, the linear logs become very verbose. See below:

![image](https://user-images.githubusercontent.com/226882/52525352-62641500-2c76-11e9-8e65-80264d6498f7.png)

This patch only shows the messages on first compile. After that, only the `Compiling` and `Compiling complete` messages appear on each subsequent recompile (after the dotted red line below).

![image](https://user-images.githubusercontent.com/226882/52525385-e7e7c500-2c76-11e9-99f8-ae4fa646853d.png)
