### PR TITLE
Add notes for multi-page apps on references to 'prefetch' plugin

### DIFF
--- a/docs/guide/html-and-static-assets.md
+++ b/docs/guide/html-and-static-assets.md
@@ -39,8 +39,7 @@ By default, a Vue CLI app will automatically generate prefetch hints for all Jav
 
 The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vuejs/preload-webpack-plugin) and can be modified / deleted via `chainWebpack` as `config.plugin('prefetch')`.
 
-::: tip 
-Note for multi page setups
+::: tip Note for multi page setups
 When using a multipage setup, the plugin name above should be changed to match the structure 'prefetch-{pagename}', for example 'prefetch-app'.
 :::
 

--- a/docs/guide/html-and-static-assets.md
+++ b/docs/guide/html-and-static-assets.md
@@ -37,7 +37,7 @@ The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vu
 
 By default, a Vue CLI app will automatically generate prefetch hints for all JavaScript files generated for async chunks (as a result of [on-demand code splitting via dynamic `import()`](https://webpack.js.org/guides/code-splitting/#dynamic-imports)).
 
-The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vuejs/preload-webpack-plugin) and can be modified / deleted via `chainWebpack` as `config.plugin('prefetch')`.
+The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vuejs/preload-webpack-plugin) and can be modified / deleted via `chainWebpack` as `config.plugin('prefetch-app')`.
 
 Example:
 
@@ -46,11 +46,11 @@ Example:
 module.exports = {
   chainWebpack: config => {
     // remove the prefetch plugin
-    config.plugins.delete('prefetch')
+    config.plugins.delete('prefetch-app')
 
     // or:
     // modify its options:
-    config.plugin('prefetch').tap(options => {
+    config.plugin('prefetch-app').tap(options => {
       options[0].fileBlacklist = options[0].fileBlacklist || []
       options[0].fileBlacklist.push(/myasyncRoute(.)+?\.js$/)
       return options
@@ -84,7 +84,7 @@ module.exports = {
   chainWebpack: config => {
     config.plugins.delete('html')
     config.plugins.delete('preload')
-    config.plugins.delete('prefetch')
+    config.plugins.delete('prefetch-app')
   }
 }
 ```

--- a/docs/guide/html-and-static-assets.md
+++ b/docs/guide/html-and-static-assets.md
@@ -39,7 +39,8 @@ By default, a Vue CLI app will automatically generate prefetch hints for all Jav
 
 The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vuejs/preload-webpack-plugin) and can be modified / deleted via `chainWebpack` as `config.plugin('prefetch')`.
 
-::: tip Note for multi page setups
+::: tip 
+Note for multi page setups
 When using a multipage setup, the plugin name above should be changed to match the structure 'prefetch-{pagename}', for example 'prefetch-app'.
 :::
 

--- a/docs/guide/html-and-static-assets.md
+++ b/docs/guide/html-and-static-assets.md
@@ -37,7 +37,10 @@ The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vu
 
 By default, a Vue CLI app will automatically generate prefetch hints for all JavaScript files generated for async chunks (as a result of [on-demand code splitting via dynamic `import()`](https://webpack.js.org/guides/code-splitting/#dynamic-imports)).
 
-The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vuejs/preload-webpack-plugin) and can be modified / deleted via `chainWebpack` as `config.plugin('prefetch-app')`.
+The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vuejs/preload-webpack-plugin) and can be modified / deleted via `chainWebpack` as `config.plugin('prefetch')`.
+
+### Note for multi page setups
+When using a multipage setup, the plugin name above should be changed to match the structure 'prefetch-{pagename}', for example 'prefetch-app'.
 
 Example:
 
@@ -46,11 +49,11 @@ Example:
 module.exports = {
   chainWebpack: config => {
     // remove the prefetch plugin
-    config.plugins.delete('prefetch-app')
+    config.plugins.delete('prefetch')
 
     // or:
     // modify its options:
-    config.plugin('prefetch-app').tap(options => {
+    config.plugin('prefetch').tap(options => {
       options[0].fileBlacklist = options[0].fileBlacklist || []
       options[0].fileBlacklist.push(/myasyncRoute(.)+?\.js$/)
       return options
@@ -84,7 +87,7 @@ module.exports = {
   chainWebpack: config => {
     config.plugins.delete('html')
     config.plugins.delete('preload')
-    config.plugins.delete('prefetch-app')
+    config.plugins.delete('prefetch')
   }
 }
 ```

--- a/docs/guide/html-and-static-assets.md
+++ b/docs/guide/html-and-static-assets.md
@@ -39,8 +39,9 @@ By default, a Vue CLI app will automatically generate prefetch hints for all Jav
 
 The hints are injected using [@vue/preload-webpack-plugin](https://github.com/vuejs/preload-webpack-plugin) and can be modified / deleted via `chainWebpack` as `config.plugin('prefetch')`.
 
-### Note for multi page setups
+::: tip Note for multi page setups
 When using a multipage setup, the plugin name above should be changed to match the structure 'prefetch-{pagename}', for example 'prefetch-app'.
+:::
 
 Example:
 


### PR DESCRIPTION
I have edited the code examples to reference the plugin by the name 'prefetch-app', as this seems to be the correct name the webpack config requires from inspecting the generated config. I have tested and can confirm this works with the example that deletes the plugin altogether, but not the blacklisting example.