### PR TITLE
add analytics tags to dependency search

### DIFF
--- a/packages/@vue/cli-ui/src/components/dependency/NpmPackageSearch.vue
+++ b/packages/@vue/cli-ui/src/components/dependency/NpmPackageSearch.vue
@@ -21,6 +21,9 @@
             'name',
             'description'
           ],
+          analyticsTags: [
+            'vue-cli-ui'
+          ],
           filters
         }"
       >


### PR DESCRIPTION
This will allow us to have a focused analytics on only queries done by Vue. If you don't have access to the dashboard yet, you can let me know (make an Algolia account first, and tell the email).

Did you know the most-searched term without results is "firebase"?