### PR TITLE
fix(babel-preset-app): multiPage repo add option entryFileList

### DIFF
--- a/packages/@vue/babel-preset-app/README.md
+++ b/packages/@vue/babel-preset-app/README.md
@@ -97,3 +97,9 @@ Set to `false` to disable JSX support.
 - Default: `false`.
 
 Setting this to `true` will generate code that is more performant but less spec-compliant.
+
+### entryFiles
+
+- Default: `[]`
+
+Multi page repo use entryFiles to ensure inject polyfills to all entry file.

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -52,6 +52,8 @@ module.exports = (context, options = {}) => {
     forceAllTransforms,
     decoratorsBeforeExport,
     decoratorsLegacy,
+    // entry file list
+    entryFiles,
 
     // Undocumented option of @babel/plugin-transform-runtime.
     // When enabled, an absolute path is used when importing a runtime helper atfer tranforming.
@@ -103,7 +105,7 @@ module.exports = (context, options = {}) => {
       ignoreBrowserslistConfig,
       configPath
     })
-    plugins.push([require('./polyfillsPlugin'), { polyfills }])
+    plugins.push([require('./polyfillsPlugin'), { polyfills, entryFiles }])
   } else {
     polyfills = []
   }

--- a/packages/@vue/babel-preset-app/polyfillsPlugin.js
+++ b/packages/@vue/babel-preset-app/polyfillsPlugin.js
@@ -1,13 +1,17 @@
 // add polyfill imports to the first file encountered.
-module.exports = ({ types }) => {
+module.exports = ({ types }, { entryFiles = [] }) => {
   let entryFile
   return {
     name: 'vue-cli-inject-polyfills',
     visitor: {
       Program (path, state) {
-        if (!entryFile) {
-          entryFile = state.filename
-        } else if (state.filename !== entryFile) {
+        if (entryFiles.length === 0) {
+          if (!entryFile) {
+            entryFile = state.filename
+          } else if (state.filename !== entryFile) {
+            return
+          }
+        } else if (!entryFiles.includes(state.filename)) {
           return
         }
 


### PR DESCRIPTION
To inject polyfills to all entry file.
Multi page repo now will be only inject polyfills to the first entry file.And the queue of entry file list may be different.So the hash may change in different machine.
We should inject polyfills to all entry file.