### PR TITLE
fix(cli-service): catch exception if "copy to clipboard" fails (issue #3476)

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -52,6 +52,11 @@ Options:
   --https   use https (default: false)
 ```
 
+::: tip --copy
+Copying to clipboard might not work on a few platforms.  
+If copying was successful, `(copied to clipboard)` is displayed next to the local dev server URL.
+:::
+
 The `vue-cli-service serve` command starts a dev server (based on [webpack-dev-server](https://github.com/webpack/webpack-dev-server)) that comes with Hot-Module-Replacement (HMR) working out of the box.
 
 In addition to the command line flags, you can also configure the dev server using the [devServer](../config/#devserver) field in `vue.config.js`.

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -197,8 +197,12 @@ module.exports = (api, options) => {
 
         let copied = ''
         if (isFirstCompile && args.copy) {
-          require('clipboardy').write(urls.localUrlForBrowser)
-          copied = chalk.dim('(copied to clipboard)')
+          try {
+            require('clipboardy').writeSync(urls.localUrlForBrowser)
+            copied = chalk.dim('(copied to clipboard)')
+          } catch (_) {
+            /* catch exception if copy to clipboard isn't supported (e.g. WSL), see issue #3476 */
+          }
         }
 
         const networkUrl = publicUrl


### PR DESCRIPTION
As explained in issue #3476 , `clipboardy` throws an exception on some platforms, notably Windows Subsystem for Linux. This results in an `unhandledPromiseRejection` when using the `--copy` option.
As of right now this is just very annoying, but those rejections are deprecated and will completely stop the process in the future and so forth – you know the drill.

To prevent this I changed the copying to use `writeSync()` and wrapped it in a `try catch`-block. This also means we only log `(copied to clipboard)` now if copying was actually successful.

I also added a tip to the docs, it looks like this:

___

![__copy notice](https://user-images.githubusercontent.com/30421456/53287324-ed670400-377a-11e9-80dd-9eb000c47e86.png)

___

If you think this is unnecessary and we can just fail silently without mentioning it somewhere, we can also revert this commit of course :)