### PR TITLE
feat: loosen the restriction of typescript version

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -9,7 +9,7 @@ module.exports = (api, {
 
   api.extendPackage({
     devDependencies: {
-      typescript: api.hasPlugin('eslint') ? '~3.2.2' : '^3.0.0'
+      typescript: '^3.2.1'
     }
   })
 

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -38,7 +38,7 @@
     "@types/chai": "^4.1.0",
     "@types/jest": "^23.1.4",
     "@types/mocha": "^5.2.6",
-    "typescript": "~3.2.2",
+    "typescript": "^3.2.1",
     "vue-class-component": "^6.2.0",
     "vue-property-decorator": "^7.0.0"
   }


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/pull/184
@typescript-eslint/eslint-plugin has now loosen their requirement for peer dep.
And users are now able to disable the warning by specifying `warnOnUnsupportedTypeScriptVersion` in `parserOptions`.
So to ease maintenance burden, we should also loosen this restriction.