### PR TITLE
Allow relative path for VUE_CLI_CONTEXT

### DIFF
--- a/packages/@vue/cli-service/bin/vue-cli-service.js
+++ b/packages/@vue/cli-service/bin/vue-cli-service.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const path = require('path')
 const semver = require('semver')
 const { error } = require('@vue/cli-shared-utils')
 const requiredVersion = require('../package.json').engines.node
@@ -12,8 +13,13 @@ if (!semver.satisfies(process.version, requiredVersion)) {
   process.exit(1)
 }
 
+let vueCliContext = process.env.VUE_CLI_CONTEXT
+if (vueCliContext && !path.isAbsolute(vueCliContext)) {
+   vueCliContext = path.resolve(process.cwd(), vueCliContext)
+}
+
 const Service = require('../lib/Service')
-const service = new Service(process.env.VUE_CLI_CONTEXT || process.cwd())
+const service = new Service(vueCliContext || process.cwd())
 
 const rawArgv = process.argv.slice(2)
 const args = require('minimist')(rawArgv, {

--- a/packages/@vue/cli-service/webpack.config.js
+++ b/packages/@vue/cli-service/webpack.config.js
@@ -1,11 +1,16 @@
 // this file is for cases where we need to access the
 // webpack config as a file when using CLI commands.
+const path = require('path')
 
+let vueCliContext = process.env.VUE_CLI_CONTEXT
 let service = process.VUE_CLI_SERVICE
 
 if (!service || process.env.VUE_CLI_API_MODE) {
   const Service = require('./lib/Service')
-  service = new Service(process.env.VUE_CLI_CONTEXT || process.cwd())
+  if (vueCliContext && !path.isAbsolute(vueCliContext)) {
+     vueCliContext = path.resolve(process.cwd(), vueCliContext)
+  }
+  service = new Service(vueCliContext || process.cwd())
   service.init(process.env.VUE_CLI_MODE || process.env.NODE_ENV)
 }
 


### PR DESCRIPTION
As stated in the title this allows to pass a relative path as a value for `VUE_CLI_CONTEXT`. It is assumed to be relative to the current working directory.
This addresses (part of) https://github.com/vuejs/vue-cli/issues/3152