### PR TITLE
fix: use an environment variable to determine the entry files to inject default polyfills

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -1,9 +1,15 @@
+const path = require('path')
 const babel = require('@babel/core')
 const preset = require('../index')
 const defaultOptions = {
   babelrc: false,
-  presets: [preset]
+  presets: [preset],
+  filename: 'test-entry-file.js'
 }
+
+beforeEach(() => {
+  process.env.VUE_CLI_ENTRY_FILES = JSON.stringify([path.join(process.cwd(), 'test-entry-file.js')])
+})
 
 test('polyfill detection', () => {
   let { code } = babel.transformSync(`
@@ -12,9 +18,10 @@ test('polyfill detection', () => {
     babelrc: false,
     presets: [[preset, {
       targets: { node: 'current' }
-    }]]
+    }]],
+    filename: 'test-entry-file.js'
   })
-  // default i  ncludes
+  // default includes
   expect(code).not.toMatch(`import "core-js/modules/es6.promise"`)
   // usage-based detection
   expect(code).not.toMatch(`import "core-js/modules/es6.map"`)
@@ -25,7 +32,8 @@ test('polyfill detection', () => {
     babelrc: false,
     presets: [[preset, {
       targets: { ie: 9 }
-    }]]
+    }]],
+    filename: 'test-entry-file.js'
   }))
   // default includes
   expect(code).toMatch(`import "core-js/modules/es6.promise"`)
@@ -44,7 +52,8 @@ test('modern mode always skips polyfills', () => {
     presets: [[preset, {
       targets: { ie: 9 },
       useBuiltIns: 'usage'
-    }]]
+    }]],
+    filename: 'test-entry-file.js'
   })
   // default includes
   expect(code).not.toMatch(`import "core-js/modules/es6.promise"`)
@@ -58,7 +67,8 @@ test('modern mode always skips polyfills', () => {
     presets: [[preset, {
       targets: { ie: 9 },
       useBuiltIns: 'entry'
-    }]]
+    }]],
+    filename: 'test-entry-file.js'
   }))
   // default includes
   expect(code).not.toMatch(`import "core-js/modules/es6.promise"`)
@@ -133,7 +143,8 @@ test('disable absoluteRuntime', () => {
     babelrc: false,
     presets: [[preset, {
       absoluteRuntime: false
-    }]]
+    }]],
+    filename: 'test-entry-file.js'
   })
 
   expect(code).toMatch('import _toConsumableArray from "@babel/runtime-corejs2/helpers/esm/toConsumableArray"')

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -30,6 +30,7 @@ function getPolyfills (targets, includes, { ignoreBrowserslistConfig, configPath
 module.exports = (context, options = {}) => {
   const presets = []
   const plugins = []
+  const defaultEntryFiles = JSON.parse(process.env.VUE_CLI_ENTRY_FILES || '[]')
 
   // JSX
   if (options.jsx !== false) {
@@ -53,7 +54,8 @@ module.exports = (context, options = {}) => {
     decoratorsBeforeExport,
     decoratorsLegacy,
     // entry file list
-    entryFiles,
+    // TODO:
+    entryFiles = defaultEntryFiles,
 
     // Undocumented option of @babel/plugin-transform-runtime.
     // When enabled, an absolute path is used when importing a runtime helper atfer tranforming.

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -54,7 +54,6 @@ module.exports = (context, options = {}) => {
     decoratorsBeforeExport,
     decoratorsLegacy,
     // entry file list
-    // TODO:
     entryFiles = defaultEntryFiles,
 
     // Undocumented option of @babel/plugin-transform-runtime.

--- a/packages/@vue/babel-preset-app/polyfillsPlugin.js
+++ b/packages/@vue/babel-preset-app/polyfillsPlugin.js
@@ -1,17 +1,10 @@
 // add polyfill imports to the first file encountered.
 module.exports = ({ types }, { entryFiles = [] }) => {
-  let entryFile
   return {
     name: 'vue-cli-inject-polyfills',
     visitor: {
       Program (path, state) {
-        if (entryFiles.length === 0) {
-          if (!entryFile) {
-            entryFile = state.filename
-          } else if (state.filename !== entryFile) {
-            return
-          }
-        } else if (!entryFiles.includes(state.filename)) {
+        if (!entryFiles.includes(state.filename)) {
           return
         }
 

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -270,6 +270,11 @@ module.exports = class Service {
       )
     }
 
+    const entryFiles = Object.values(config.entry).reduce((allEntries, curr) => {
+      return allEntries.concat(curr)
+    }, [])
+    process.env.VUE_CLI_ENTRY_FILES = JSON.stringify(entryFiles)
+
     return config
   }
 

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -270,7 +270,7 @@ module.exports = class Service {
       )
     }
 
-    const entryFiles = Object.values(config.entry).reduce((allEntries, curr) => {
+    const entryFiles = Object.values(config.entry || []).reduce((allEntries, curr) => {
       return allEntries.concat(curr)
     }, [])
     process.env.VUE_CLI_ENTRY_FILES = JSON.stringify(entryFiles)


### PR DESCRIPTION
The old logic is not reliable due to the presence of thread-loader
closes #2983