### PR TITLE
docs(css): sass import path

### DIFF
--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -121,7 +121,7 @@ module.exports = {
       sass: {
         // @/ is an alias to src/
         // so this assumes you have a file named `src/variables.scss`
-        data: `@import "@/variables.scss";`
+        data: `@import "~@/variables.scss";`
       },
       // pass Less.js Options to less-loader
       less:{


### PR DESCRIPTION
path should start with `~` because of css-loader url()

or it will be regarded as relative path.