### PR TITLE
fix(docs): update zeit now deployment process considering v2

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -223,6 +223,7 @@ npm install -g now
     {
       "version": 2,
       "name": "my-vue-project",
+      "alias": "my-vue-project",
       "builds": [{ "src": "package.json", "use": "@now/static-build" }],
       "routes": [
         { "src": "^/js/(.*)", "dest": "/js/$1" },

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -221,30 +221,25 @@ npm install -g now
 
     ```json
     {
-      "name": "my-example-app",
-      "type": "static",
-      "static": {
-        "public": "dist",
-        "rewrites": [
-          {
-            "source": "**",
-            "destination": "/index.html"
-          }
-        ]
-      },
-      "alias": "vue-example",
-      "files": [
-        "dist"
+      "version": 2,
+      "name": "my-vue-project",
+      "builds": [{ "src": "package.json", "use": "@now/static-build" }],
+      "routes": [
+        { "src": "^/js/(.*)", "dest": "/js/$1" },
+        { "src": "^/css/(.*)", "dest": "/css/$1" },
+        { "src": "^/img/(.*)", "dest": "/img/$1" },
+        { "src": ".*", "dest": "/index.html" }
       ]
     }
     ```
 
-    You can further customize the static serving behavior by consulting [Now's documentation](https://zeit.co/docs/deployment-types/static).
+    You can further customize the static serving behavior by consulting [Now's documentation](https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/).
 
-3. Adding a deployment script in `package.json`:
+3. Adding a now-build and a deploy script in `package.json`:
 
     ```json
-    "deploy": "npm run build && now && now alias"
+    "now-build": "vue-cli-service build",
+    "deploy": "now --public && now alias"
     ```
 
     If you want to deploy publicly by default, you can change the deployment script to the following one:
@@ -254,6 +249,8 @@ npm install -g now
     ```
 
     This will automatically point your site's alias to the latest deployment. Now, just run `npm run deploy` to deploy your app.
+
+    * Don't forget to exclude the `node_modules` folder from being uploaded to Now to enable faster deployment. To do that, add a `.nowignore` file to the root of the project directory and add node_modules to it.
 
 ### Stdlib
 

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -135,7 +135,7 @@ module.exports = (api, options) => {
 
     // create server
     const server = new WebpackDevServer(compiler, Object.assign({
-      clientLogLevel: 'none',
+      clientLogLevel: 'silent',
       historyApiFallback: {
         disableDotRule: true,
         rewrites: genHistoryApiFallbackRewrites(options.publicPath, options.pages)


### PR DESCRIPTION
Now is currently on version 2, and it use that version by default when someone want to make a deploy, then it let us two choices:
- A) Maintain current docs about v1 deployment but set version on example JSON.
- B) Update docs considering the the advent of v2 (11/2018)

I choose option B, then i made the changes and just commit it.

### Before
<img width="922" alt="captura de tela 2019-03-05 as 00 24 51" src="https://user-images.githubusercontent.com/20749018/53779546-3e939800-3edf-11e9-8742-bb98f5bdc241.png">

### After
<img width="851" alt="captura de tela 2019-03-05 as 00 25 06" src="https://user-images.githubusercontent.com/20749018/53779554-47846980-3edf-11e9-9c46-be2b0de32d5d.png">

#### Reasons to try to contribute
- Docs need to be always updated :)

#### Refs
[ZEIT - Now about Vue.js deployment (v2)](https://zeit.co/guides/deploying-vuejs-to-now/)

Sorry my english, only a Brazilian servant.
