### PR TITLE
fix setting env by `-e` in e2e tests

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/index.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/index.js
@@ -37,7 +37,7 @@ module.exports = (api, options) => {
         rawArgs.push('--config', require.resolve('./nightwatch.config.js'))
       }
 
-      if (rawArgs.indexOf('--env') === -1) {
+      if (rawArgs.indexOf('--env') === -1 && rawArgs.indexOf('-e') === -1) {
         rawArgs.push('--env', 'chrome')
       }
 


### PR DESCRIPTION
Before it was only checking for `--env`. So if `-e something` was used, the generated command line included `-e` and `--env`:

    ... -e something ... --env chrome

Now it does not append `--env chrome` if `-e` is used.