### PR TITLE
skipLibCheck: true by default

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -5,6 +5,7 @@
     "strict": true,
     "jsx": "preserve",
     "importHelpers": true,
+    "skipLibCheck": true,
     "moduleResolution": "node",
     <%_ if (options.classComponent) { _%>
     "experimentalDecorators": true,


### PR DESCRIPTION
Having this option not defined defaults to `false`, which results in a bunch of type errors for packages that are outside the developer's control. This should be set to `true` by default. Open to discussion! (draft PR)