### PR TITLE
fix: properly load non-js config files in genCacheConfig

### DIFF
--- a/packages/@vue/cli-service/lib/PluginAPI.js
+++ b/packages/@vue/cli-service/lib/PluginAPI.js
@@ -167,6 +167,9 @@ class PluginAPI {
               return fs.readFileSync(absolutePath, 'utf-8')
             }
           }
+          else {
+            return fs.readFileSync(absolutePath, 'utf-8')
+          }
         }
       }
       if (!Array.isArray(configFiles)) {


### PR DESCRIPTION
https://github.com/vuejs/vue-cli/commit/a2bc927ac837ac6b343f597be4271f0ce9d688f1#diff-04612bf191a2c1a06ac248910d9e9415R162 attempted to fix a problem with cache invalidation when javascript config files (like babel.config.js) change their content i.e. depending on an env variable.

The fix was:
```javascript
          if (absolutePath.endsWith('.js')) {
            // should evaluate config scripts to reflect environment variable changes
            try {
              return JSON.stringify(require(absolutePath))
            } catch (e) {
              return fs.readFileSync(absolutePath, 'utf-8')
            }
         }
```


However we missed to add an `else` branch to keep including non-js config files (like `.browserslistrc`) in the generation of the cache key.

This PR adds that `else {` branch

close #3631 