### PR TITLE
Add a deployment guide for Render

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -411,7 +411,7 @@ Deploy your application using nginx inside of a docker container.
 
 ### Render
 
-On Render, create a new Web Service, and give Render’s GitHub app permission to access your new repo.
+On Render, create a new Web Service, and give Render’s GitHub app permission to access your repo.
 
 Use the following values during creation:
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -408,3 +408,24 @@ Deploy your application using nginx inside of a docker container.
     curl localhost:8080
     # <!DOCTYPE html><html lang=en>...</html>
     ```
+
+### Render
+
+On Render, create a new Web Service, and give Render’s GitHub app permission to access your new repo.
+
+Use the following values during creation:
+
+ - **Environment:** `Static Site`
+ - **Build Command:** `npm run build` or `yarn build`
+ - **Publish directory:** `dist`
+
+That’s it! Your app will be live on your Render URL as soon as the build finishes.
+
+In order to receive direct hits using `history mode` on Vue Router, you need to add the following redirect rules in the `Redirects` tab under your site.
+
+Select `Redirects`, click on `Add Redirect Rule` button and
+
+ - **Source Path:** `/*`
+ - **Destination Path:** `/index.html`
+ - **Status:** `200`
+


### PR DESCRIPTION
This PR introduces a guide for deploying Vue.js apps on the `Render` platform. [Render](https://render.com) completely frees up developers and teams from managing infrastructure by abstracting over complexities and minimizing cognitive overhead for developers.