### PR TITLE
Update package.json (@babel/core@7.4.0 issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "yorkie": "^2.0.0"
   },
   "resolutions": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.0.0 <7.4.0",
     "@babel/preset-env": "^7.0.0",
     "babel-core": "7.0.0-bridge.0",
     "ps-tree": "^1.1.1",


### PR DESCRIPTION
please check these resources below on the reasoning behind this problematic babel bug:

- https://stackoverflow.com/questions/55251983/what-does-this-error-mean-with-usebuiltins-option-required-direct-setting-of

- https://github.com/parcel-bundler/parcel/issues/2819
- https://github.com/parcel-bundler/parcel/commit/53c09b3cfa3a14bc0dc9875950b31e43d4a9a2e4