### PR TITLE
feat(cli-service): add --filename option to specify the output file name

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/demo-lib-js.html
+++ b/packages/@vue/cli-service/lib/commands/build/demo-lib-js.html
@@ -1,8 +1,8 @@
 <meta charset="utf-8">
 <title><%- htmlWebpackPlugin.options.libName %> demo</title>
-<script src="./<%- htmlWebpackPlugin.options.libName %>.umd.js"></script>
+<script src="./<%- htmlWebpackPlugin.options.assetsFileName %>.umd.js"></script>
 <% if (htmlWebpackPlugin.options.cssExtract) { %>
-<link rel="stylesheet" href="./<%- htmlWebpackPlugin.options.libName %>.css">
+<link rel="stylesheet" href="./<%- htmlWebpackPlugin.options.assetsFileName %>.css">
 <% } %>
 
 <script>

--- a/packages/@vue/cli-service/lib/commands/build/demo-lib.html
+++ b/packages/@vue/cli-service/lib/commands/build/demo-lib.html
@@ -1,9 +1,9 @@
 <meta charset="utf-8">
 <title><%- htmlWebpackPlugin.options.libName %> demo</title>
 <script src="https://unpkg.com/vue"></script>
-<script src="./<%- htmlWebpackPlugin.options.libName %>.umd.js"></script>
+<script src="./<%- htmlWebpackPlugin.options.assetsFileName %>.umd.js"></script>
 <% if (htmlWebpackPlugin.options.cssExtract) { %>
-<link rel="stylesheet" href="./<%- htmlWebpackPlugin.options.libName %>.css">
+<link rel="stylesheet" href="./<%- htmlWebpackPlugin.options.assetsFileName %>.css">
 <% } %>
 
 <div id="app">

--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -31,6 +31,7 @@ module.exports = (api, options) => {
       '--target': `app | lib | wc | wc-async (default: ${defaults.target})`,
       '--formats': `list of output formats for library builds (default: ${defaults.formats})`,
       '--name': `name for lib or web-component mode (default: "name" in package.json or entry filename)`,
+      '--filename': `file name for output, only usable for 'lib' target (default: value of --name)`,
       '--no-clean': `do not remove the dist directory before building the project`,
       '--report': `generate report.html to help analyze bundle content`,
       '--report-json': 'generate report.json to help analyze bundle content',

--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
-module.exports = (api, { entry, name, formats }, options) => {
+module.exports = (api, { entry, name, formats, filename }, options) => {
   const { log, error } = require('@vue/cli-shared-utils')
   const abort = msg => {
     log()
@@ -24,7 +24,7 @@ module.exports = (api, { entry, name, formats }, options) => {
     api.service.pkg.name ||
     path.basename(entry).replace(/\.(jsx?|vue)$/, '')
   )
-
+  filename = filename || libName
   function genConfig (format, postfix = format, genHTML) {
     const config = api.resolveChainableWebpackConfig()
 
@@ -33,7 +33,7 @@ module.exports = (api, { entry, name, formats }, options) => {
       config
         .plugin('extract-css')
           .tap(args => {
-            args[0].filename = `${libName}.css`
+            args[0].filename = `${filename}.css`
             return args
           })
     }
@@ -64,12 +64,13 @@ module.exports = (api, { entry, name, formats }, options) => {
             inject: false,
             filename: 'demo.html',
             libName,
+            assetsFileName: filename,
             cssExtract: config.plugins.has('extract-css')
           }])
     }
 
     // resolve entry/output
-    const entryName = `${libName}.${postfix}`
+    const entryName = `${filename}.${postfix}`
     config.resolve
       .alias
         .set('~entry', fullEntryPath)


### PR DESCRIPTION
When build target is 'lib', developer can specify an output filename that is different from the library's name. 