### PR TITLE
chore: more accurate vim swap file ignore

### DIFF
--- a/packages/@vue/cli-service/generator/template/_gitignore
+++ b/packages/@vue/cli-service/generator/template/_gitignore
@@ -28,4 +28,4 @@ yarn-error.log*
 *.ntvs*
 *.njsproj
 *.sln
-*.sw*
+*.sw?


### PR DESCRIPTION
Currently this ignores more than the possible 3 character vim swap file extensions. This change will only ignore 3 letter vim swap files starting with `.sw` (most common)