### PR TITLE
Fixed progress-path background color for dark mode

### DIFF
--- a/packages/@vue/cli-ui-addon-webpack/src/components/BuildProgress.vue
+++ b/packages/@vue/cli-ui-addon-webpack/src/components/BuildProgress.vue
@@ -119,7 +119,7 @@ export default {
     >>> .background
       stroke rgba($vue-ui-color-dark, .1)
       .vue-ui-dark-mode &
-        stroke $vue-ui-color-darker
+        stroke $vue-ui-color-dark
 
   .operations
     color $vue-ui-color-dark

--- a/packages/@vue/cli-ui-addon-webpack/src/components/BuildProgress.vue
+++ b/packages/@vue/cli-ui-addon-webpack/src/components/BuildProgress.vue
@@ -166,7 +166,9 @@ export default {
       width 100%
       height @width
       border-radius 50%
-      background $vue-ui-color-dark
+      background rgba(black, .1)
+      .vue-ui-dark-mode &
+        background: $vue-ui-color-dark
       transition background .15s
       for n in (1..4)
         &:nth-child({n})

--- a/packages/@vue/cli-ui-addon-webpack/src/components/BuildProgress.vue
+++ b/packages/@vue/cli-ui-addon-webpack/src/components/BuildProgress.vue
@@ -166,7 +166,7 @@ export default {
       width 100%
       height @width
       border-radius 50%
-      background rgba(black, .1)
+      background $vue-ui-color-dark
       transition background .15s
       for n in (1..4)
         &:nth-child({n})


### PR DESCRIPTION
On dark mode the remaining progress bar color was the same color as the background.