### PR TITLE
fix: should not use absolute polyfill paths when `absoluteRuntime` is on

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -153,4 +153,5 @@ test('disable absoluteRuntime', () => {
   })
 
   expect(code).toMatch('import _toConsumableArray from "@babel/runtime-corejs2/helpers/esm/toConsumableArray"')
+  expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
 })

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -106,7 +106,10 @@ module.exports = (context, options = {}) => {
       ignoreBrowserslistConfig,
       configPath
     })
-    plugins.push([require('./polyfillsPlugin'), { polyfills, entryFiles }])
+    plugins.push([
+      require('./polyfillsPlugin'),
+      { polyfills, entryFiles, useAbsolutePath: !!absoluteRuntime }
+    ])
   } else {
     polyfills = []
   }


### PR DESCRIPTION
fixes #3725