### PR TITLE
revert: "fix: should not add polyfills from transform-runtime plugin (#3730)"

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -45,7 +45,7 @@ test('polyfill detection', () => {
   // promise polyfill alone doesn't work in IE, needs this as well. fix: #1642
   expect(code).toMatch(genCoreJSImportRegExp('es6.array.iterator'))
   // usage-based detection
-  expect(code).toMatch(/import "core-js\/modules\/es6.map"/)
+  expect(code).toMatch(/import _Map from ".*runtime-corejs2\/core-js\/map"/)
 })
 
 test('modern mode always skips polyfills', () => {
@@ -63,7 +63,7 @@ test('modern mode always skips polyfills', () => {
   // default includes
   expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
   // usage-based detection
-  expect(code).not.toMatch(/import "core-js\/modules\/es6.map"/)
+  expect(code).not.toMatch(/import _Map from ".*runtime-corejs2\/core-js\/map"/)
 
   ;({ code } = babel.transformSync(`
     const a = new Map()
@@ -78,7 +78,7 @@ test('modern mode always skips polyfills', () => {
   // default includes
   expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
   // usage-based detection
-  expect(code).not.toMatch(/import "core-js\/modules\/es6.map"/)
+  expect(code).not.toMatch(/import _Map from ".*runtime-corejs2\/core-js\/map"/)
   delete process.env.VUE_CLI_MODERN_BUILD
 })
 
@@ -107,7 +107,7 @@ test('async/await', () => {
   // should use regenerator runtime
   expect(code).toMatch(`import "regenerator-runtime/runtime"`)
   // should use required helper instead of inline
-  expect(code).toMatch(/import _asyncToGenerator from ".*runtime\/helpers\/esm\/asyncToGenerator\"/)
+  expect(code).toMatch(/import _asyncToGenerator from ".*runtime-corejs2\/helpers\/esm\/asyncToGenerator\"/)
 })
 
 test('jsx', () => {
@@ -152,6 +152,6 @@ test('disable absoluteRuntime', () => {
     filename: 'test-entry-file.js'
   })
 
-  expect(code).toMatch('import _toConsumableArray from "@babel/runtime/helpers/esm/toConsumableArray"')
-  expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
+  expect(code).toMatch('import _toConsumableArray from "@babel/runtime-corejs2/helpers/esm/toConsumableArray"')
+  // expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
 })

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -154,10 +154,10 @@ module.exports = (context, options = {}) => {
   // transform runtime, but only for helpers
   plugins.push([require('@babel/plugin-transform-runtime'), {
     regenerator: useBuiltIns !== 'usage',
-
-    // polyfills are injected by preset-env & polyfillsPlugin, so no need to add them again
-    corejs: false,
-
+    // use @babel/runtime-corejs2 so that helpers that need polyfillable APIs will reference core-js instead.
+    // if useBuiltIns is not set to 'usage', then it means users would take care of the polyfills on their own,
+    // i.e., core-js 2 is no longer needed.
+    corejs: (useBuiltIns === 'usage' && !process.env.VUE_CLI_MODERN_BUILD) ? 2 : false,
     helpers: useBuiltIns === 'usage',
     useESModules: !process.env.VUE_CLI_BABEL_TRANSPILE_MODULES,
 

--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -30,6 +30,7 @@
     "@babel/plugin-transform-runtime": "^7.4.0",
     "@babel/preset-env": "^7.0.0 < 7.4.0",
     "@babel/runtime": "^7.0.0",
+    "@babel/runtime-corejs2": "^7.2.0",
     "@vue/babel-preset-jsx": "^1.0.0-beta.2",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "core-js": "^2.6.5"

--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -40,11 +40,6 @@ module.exports = (api, options) => {
             if (transpileDepRegex && transpileDepRegex.test(filepath)) {
               return false
             }
-            // may need to add polyfills (by preset-env) for babel helpers
-            // https://github.com/babel/babel/issues/7597
-            if (/node_modules\/@babel\/runtime/.test(filepath)) {
-              return false
-            }
             // Don't transpile node_modules
             return /node_modules/.test(filepath)
           })


### PR DESCRIPTION
This reverts commit b98796938ed05ccbaa41e62db8e2f9744d3cb5ac.

Closes #3741
We need a better strategy to fix the `'Symbol' is undefined ` issue. Until then, we'll settle on the current not-ideal-but-works configuration.