### PR TITLE
docs: add tip about jsx options

### DIFF
--- a/packages/@vue/babel-preset-app/README.md
+++ b/packages/@vue/babel-preset-app/README.md
@@ -88,8 +88,7 @@ Use this option when you have 3rd party dependencies that are not processed by B
 
 - Default: `true`.
 
-Set to `false` to disable JSX support.
-Or you can toggle [@vue/babel-preset-jsx](https://github.com/vuejs/jsx/tree/dev/packages/babel-preset-jsx) features here
+Set to `false` to disable JSX support. Or you can toggle [@vue/babel-preset-jsx](https://github.com/vuejs/jsx/tree/dev/packages/babel-preset-jsx) features here.
 
 ### loose
 

--- a/packages/@vue/babel-preset-app/README.md
+++ b/packages/@vue/babel-preset-app/README.md
@@ -89,6 +89,7 @@ Use this option when you have 3rd party dependencies that are not processed by B
 - Default: `true`.
 
 Set to `false` to disable JSX support.
+Or you can toggle [@vue/babel-preset-jsx](https://github.com/vuejs/jsx/tree/dev/packages/babel-preset-jsx) features here
 
 ### loose
 


### PR DESCRIPTION
missing document when i want to disabled @vue/babel-preset-jsx injectH feature

**Reasons to try to contribute**
because the document does not have any description of the  `@vue/babel-preset-jsx` feature configuration

`@vue/babel-preset-app`文档只提到可以通过设置 `jsx:false` 来关闭 jsx 语法，但实际上源码里面还会通过 `jsx`字段来配置 `@vue/babel-preset-jsx` 的功能，却没有任何说明……