### PR TITLE
chore: remove support for legacy `vue-cli-service e2e` command

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/index.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/index.js
@@ -58,13 +58,6 @@ module.exports = (api, options) => {
       return runner
     })
   })
-
-  // TODO remove in RC
-  api.registerCommand('e2e', (args, rawArgv) => {
-    const { warn } = require('@vue/cli-shared-utils')
-    warn(`Deprecation Warning: "vue-cli-service e2e" has been renamed to "vue-cli-service test:e2e".`)
-    return api.service.run('test:e2e', args, rawArgv)
-  })
 }
 
 module.exports.defaultModes = {


### PR DESCRIPTION
BREAKING CHANGE:
"vue-cli-service e2e" has been deprecated in v3 and
renamed to "vue-cli-service test:e2e". Now the legacy command is
completely removed.