### PR TITLE
feat: use ESLint v5 by default everywhere

### DIFF
--- a/packages/@vue/cli-plugin-eslint/generator/index.js
+++ b/packages/@vue/cli-plugin-eslint/generator/index.js
@@ -13,15 +13,7 @@ module.exports = (api, { config, lintOn = [] }, _, invoking) => {
       lint: 'vue-cli-service lint'
     },
     eslintConfig,
-    // TODO:
-    // Move these dependencies to package.json in v4.
-    // Now in v3 we have to add redundant eslint related dependencies
-    // in order to keep compatibility with v3.0.x users who defaults to ESlint v4.
-    devDependencies: {
-      'babel-eslint': '^10.0.1',
-      'eslint': '^5.8.0',
-      'eslint-plugin-vue': '^5.0.0'
-    }
+    devDependencies: {}
   }
 
   const injectEditorConfig = (config) => {

--- a/packages/@vue/cli-plugin-eslint/package.json
+++ b/packages/@vue/cli-plugin-eslint/package.json
@@ -25,12 +25,10 @@
   "dependencies": {
     "@vue/cli-shared-utils": "^3.5.1",
     "babel-eslint": "^10.0.1",
+    "eslint": "^5.8.0",
     "eslint-loader": "^2.1.2",
+    "eslint-plugin-vue": "^5.0.0",
     "globby": "^9.0.0",
     "webpack": ">=4 < 4.29"
-  },
-  "optionalDependencies": {
-    "eslint": "^4.19.1",
-    "eslint-plugin-vue": "^4.7.1"
   }
 }

--- a/packages/@vue/cli-service-global/package.json
+++ b/packages/@vue/cli-service-global/package.json
@@ -28,8 +28,8 @@
     "@vue/cli-service": "^3.5.3",
     "babel-eslint": "^10.0.1",
     "chalk": "^2.4.2",
-    "eslint": "^4.19.1",
-    "eslint-plugin-vue": "^4.7.1",
+    "eslint": "^5.8.0",
+    "eslint-plugin-vue": "^5.0.0",
     "resolve": "^1.10.0",
     "vue": "^2.6.6",
     "vue-template-compiler": "^2.6.6"


### PR DESCRIPTION
BREAKING CHANGE: may cause old projects' linting fail
(those scaffolded with Vue CLI 3.0.x).