### PR TITLE
Add heroku deployment guide

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -285,7 +285,7 @@ git commit -m "add static configuration"
 heroku login
 heroku create
 heroku buildpacks:add heroku/nodejs
-heroku buildpacks:add https://github.com/hone/heroku-buildpack-static
+heroku buildpacks:add https://github.com/heroku/heroku-buildpack-static
 git push heroku master
 ```
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -261,7 +261,30 @@ npm install -g now
 
 ### Heroku
 
-> TODO | Open to contribution.
+Create a `static.json` file:
+
+```json
+{
+  "root": "dist",
+  "clean_urls": true,
+  "routes": {
+    "/**": "index.html"
+  }
+}
+```
+
+```bash
+git add static.json
+git commit -m "add static configuration"
+
+heroku login
+heroku create
+heroku buildpacks:add heroku/nodejs
+heroku buildpacks:add https://github.com/hone/heroku-buildpack-static
+git push heroku master
+```
+
+More info: https://gist.github.com/hone/24b06869b4c1eca701f9
 
 ### Surge
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -261,7 +261,7 @@ npm install -g now
 
 ### Heroku
 
-1. [install HerokU CLI](https://devcenter.heroku.com/articles/heroku-cli)
+1. [Install Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 
 2. Create a `static.json` file:
 ```json

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -261,8 +261,9 @@ npm install -g now
 
 ### Heroku
 
-Create a `static.json` file:
+1. [install HerokU CLI](https://devcenter.heroku.com/articles/heroku-cli)
 
+2. Create a `static.json` file:
 ```json
 {
   "root": "dist",
@@ -273,10 +274,14 @@ Create a `static.json` file:
 }
 ```
 
+3. Add `static.json` file to git
 ```bash
 git add static.json
 git commit -m "add static configuration"
+```
 
+4. Deploy to Heroku
+```bash
 heroku login
 heroku create
 heroku buildpacks:add heroku/nodejs


### PR DESCRIPTION
I see there are many other guides for heroku proposed:

- https://github.com/vuejs/vue-cli/pull/3684
- https://github.com/vuejs/vue-cli/pull/3607
- https://github.com/vuejs/vue-cli/pull/3445
- https://github.com/vuejs/vue-cli/pull/3285
- https://github.com/vuejs/vue-cli/pull/2998
- https://github.com/vuejs/vue-cli/pull/3365

But all of them include some sort of node server which isn't really required with `heroku-buildpack-static` buildpack.

I'd argue that, this is the easiest and most straightforward way to deploy vue-cli app to heroku ;)