### PR TITLE
docs: add notes on the `vue inspect` command

### DIFF
--- a/docs/guide/webpack.md
+++ b/docs/guide/webpack.md
@@ -156,6 +156,11 @@ You can redirect the output into a file for easier inspection:
 ``` bash
 vue inspect > output.js
 ```
+By default inspect will out put the development config. To see the production configuration
+
+``` bash
+vue inspect --mode production > output.prod.js
+```
 
 Note the output is not a valid webpack config file, it's a serialized format only meant for inspection.
 

--- a/docs/guide/webpack.md
+++ b/docs/guide/webpack.md
@@ -156,7 +156,7 @@ You can redirect the output into a file for easier inspection:
 ``` bash
 vue inspect > output.js
 ```
-By default inspect will out put the development config. To see the production configuration
+By default, `inspect` command will show the output for development config. To see the production configuration, you need to run
 
 ``` bash
 vue inspect --mode production > output.prod.js


### PR DESCRIPTION
Adding description that vue inspect defaults to development and how to see the production config details and rules.