### PR TITLE
Fix typo "procress" -> "process"

### DIFF
--- a/packages/@vue/cli-ui/locales/en.json
+++ b/packages/@vue/cli-ui/locales/en.json
@@ -783,7 +783,7 @@
           "kill": "Kill",
           "status": {
             "idle": "Ready to kill",
-            "killing": "Killing procress...",
+            "killing": "Killing process...",
             "killed": "Killed successfully!",
             "error": "Couldn't kill process"
           }


### PR DESCRIPTION
Just saw this typo while trying to kill a process using a port