### PR TITLE
feat!: set `whitespace: 'condense'` for template compiler

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -84,7 +84,7 @@ module.exports = (api, options) => {
           .loader('vue-loader')
           .options(Object.assign({
             compilerOptions: {
-              preserveWhitespace: false
+              whitespace: 'condense'
             }
           }, vueLoaderCacheConfig))
 


### PR DESCRIPTION
BREAKING CHANGE:
Detailed explanation: https://github.com/vuejs/vue/issues/9208#issuecomment-450012518

Take the following template as example:
```
<p>
  Welcome to <b>Vue.js</b> <i>world</i>.
  Have fun!
</p>
```

With `preserveWhitespace: false`, it was compiled as:
```
<p> Welcome to <b>Vue.js</b><i>world</i>. Have fun! </p>
```

With `whitespace: 'condense'`, it is now compiled as:
```
<p> Welcome to <b>Vue.js</b> <i>world</i>. Have fun! </p>
```

Note the **inline whitespace between tags** is preserved.

Closes #1020