### PR TITLE
docs: mention caveat about missing plugins when in legacy config

### DIFF
--- a/docs/guide/browser-compatibility.md
+++ b/docs/guide/browser-compatibility.md
@@ -89,6 +89,12 @@ Vue CLI uses two environment variables to communicate this:
 **Important:** These variables are only accessible when/after `chainWebpack()` and `configureWebpack()` functions are evaluated, (so not directly in the `vue.config.js` module's root scope). That means it's also available in the postcss config file.
 :::
 
+::: warning Caveat: Adjusting webpack plugins
+Some Plugins, i.e. `html-webpack-plugin`, `preload-plugin` etc. are only included in the config for modern mode. Trying to tap into their options in the legacy config can s an error as the plugins don't exist.
+
+Use the above tip about *Detecting the Current Mode* to manipulate plugins in the right mode only, and/or check if the plugin actually exists in the current mode's config before trying to tap into their options.
+:::
+
 [autoprefixer]: https://github.com/postcss/autoprefixer
 [babel-preset-env]: https://new.babeljs.io/docs/en/next/babel-preset-env.html
 [babel-preset-app]: https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app

--- a/docs/guide/browser-compatibility.md
+++ b/docs/guide/browser-compatibility.md
@@ -90,7 +90,7 @@ Vue CLI uses two environment variables to communicate this:
 :::
 
 ::: warning Caveat: Adjusting webpack plugins
-Some Plugins, i.e. `html-webpack-plugin`, `preload-plugin` etc. are only included in the config for modern mode. Trying to tap into their options in the legacy config can s an error as the plugins don't exist.
+Some Plugins, i.e. `html-webpack-plugin`, `preload-plugin` etc. are only included in the config for modern mode. Trying to tap into their options in the legacy config can throw an error as the plugins don't exist.
 
 Use the above tip about *Detecting the Current Mode* to manipulate plugins in the right mode only, and/or check if the plugin actually exists in the current mode's config before trying to tap into their options.
 :::


### PR DESCRIPTION
We don't include some plugins during legacy build when building in modern mode. Trying to tap into their options causes `webpack-chain` to throw a pretty cryptic error.

This warning should help people deal with that situation.

----

close #3845