### PR TITLE
feat!: enable splitChunks by default even in development mode

### DIFF
--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -24,24 +24,26 @@ module.exports = (api, options) => {
     const outputDir = api.resolve(options.outputDir)
 
     // code splitting
-    webpackConfig
-      .optimization.splitChunks({
-        cacheGroups: {
-          vendors: {
-            name: `chunk-vendors`,
-            test: /[\\/]node_modules[\\/]/,
-            priority: -10,
-            chunks: 'initial'
-          },
-          common: {
-            name: `chunk-common`,
-            minChunks: 2,
-            priority: -20,
-            chunks: 'initial',
-            reuseExistingChunk: true
+    if (process.env.NODE_ENV !== 'test') {
+      webpackConfig
+        .optimization.splitChunks({
+          cacheGroups: {
+            vendors: {
+              name: `chunk-vendors`,
+              test: /[\\/]node_modules[\\/]/,
+              priority: -10,
+              chunks: 'initial'
+            },
+            common: {
+              name: `chunk-common`,
+              minChunks: 2,
+              priority: -20,
+              chunks: 'initial',
+              reuseExistingChunk: true
+            }
           }
-        }
-      })
+        })
+    }
 
     // HTML plugin
     const resolveClientEnv = require('../util/resolveClientEnv')

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -24,26 +24,24 @@ module.exports = (api, options) => {
     const outputDir = api.resolve(options.outputDir)
 
     // code splitting
-    if (isProd && !process.env.CYPRESS_ENV) {
-      webpackConfig
-        .optimization.splitChunks({
-          cacheGroups: {
-            vendors: {
-              name: `chunk-vendors`,
-              test: /[\\/]node_modules[\\/]/,
-              priority: -10,
-              chunks: 'initial'
-            },
-            common: {
-              name: `chunk-common`,
-              minChunks: 2,
-              priority: -20,
-              chunks: 'initial',
-              reuseExistingChunk: true
-            }
+    webpackConfig
+      .optimization.splitChunks({
+        cacheGroups: {
+          vendors: {
+            name: `chunk-vendors`,
+            test: /[\\/]node_modules[\\/]/,
+            priority: -10,
+            chunks: 'initial'
+          },
+          common: {
+            name: `chunk-common`,
+            minChunks: 2,
+            priority: -20,
+            chunks: 'initial',
+            reuseExistingChunk: true
           }
-        })
-    }
+        }
+      })
 
     // HTML plugin
     const resolveClientEnv = require('../util/resolveClientEnv')


### PR DESCRIPTION
BREAKING CHANGE:
This changes the output directory structures for development mode
(app.js -> index.js + chunk-common.js + chunk-vendors.js).
By enabling splitChunks by default, the memory usage of webpack may be
greatly reduced for large multi-page projects.

This commit fixes #3838
May also fix #2991