### PR TITLE
fix: pin jest-watch-typeahead to 0.2.1, avoid introducing jest 24 deps

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -29,7 +29,7 @@
     "jest": "^23.6.0",
     "jest-serializer-vue": "^2.0.2",
     "jest-transform-stub": "^2.0.0",
-    "jest-watch-typeahead": "^0.3.0",
+    "jest-watch-typeahead": "0.2.1",
     "vue-jest": "^3.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
fixes #3833