### PR TITLE
feat!: upgrade jest to v24

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "graphql": "^14.2.1",
     "http-server": "^0.11.1",
     "inquirer": "^6.0.0",
-    "jest": "^23.1.0",
+    "jest": "^24.7.1",
     "lerna": "^3.13.2",
     "lerna-changelog": "^0.8.2",
     "lint-staged": "^8.1.5",

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.0",
-    "@types/jest": "^23.1.4",
+    "@types/jest": "^24.0.11",
     "@types/mocha": "^5.2.6",
     "typescript": "^3.4.3",
     "vue-class-component": "^7.0.2",

--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -90,8 +90,8 @@ const applyTS = (module.exports.applyTS = (api, invoking) => {
       }
     },
     devDependencies: {
-      '@types/jest': '^23.1.4',
-      'ts-jest': '^23.0.0'
+      '@types/jest': '^24.0.11',
+      'ts-jest': '^24.0.2'
     }
   })
   if (api.hasPlugin('babel')) {

--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@vue/cli-shared-utils": "^3.6.0",
-    "babel-jest": "^23.6.0",
+    "babel-jest": "^24.7.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
-    "jest": "^23.6.0",
+    "jest": "^24.7.1",
     "jest-serializer-vue": "^2.0.2",
     "jest-transform-stub": "^2.0.0",
     "jest-watch-typeahead": "^0.3.0",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@vue/test-utils": "1.0.0-beta.29",
-    "ts-jest": "^23.0.0"
+    "ts-jest": "^24.0.2"
   },
   "gitHead": "0dc793497281718762a5477a3de4a7ee439cdda6"
 }


### PR DESCRIPTION
BREAKING CHANGE:
See:
https://jestjs.io/blog/2019/01/25/jest-24-refreshing-polished-typescript-friendly
https://github.com/facebook/jest/blob/20ba4be9499d50ed0c9231b86d4a64ec8a6bd303/CHANGELOG.md#2400

closes #3450
closes #3605
closes #3497