### PR TITLE
fix: vue-virtual-scroller should be in devDependencies as it's client-side only

### DIFF
--- a/packages/@vue/cli-ui/package.json
+++ b/packages/@vue/cli-ui/package.json
@@ -61,7 +61,6 @@
     "semver": "^6.0.0",
     "shortid": "^2.2.11",
     "vue-cli-plugin-apollo": "^0.19.2",
-    "vue-virtual-scroller": "^1.0.0-rc.2",
     "watch": "^1.0.2"
   },
   "devDependencies": {
@@ -92,6 +91,7 @@
     "vue-router": "^3.0.3",
     "vue-template-compiler": "^2.6.10",
     "vue-timeago": "^5.1.2",
+    "vue-virtual-scroller": "^1.0.0-rc.2",
     "xterm": "^3.12.0"
   },
   "browserslist": [


### PR DESCRIPTION
This commit fixes a peer dependency warning described here:
https://github.com/vuejs/vue-cli/issues/2862#issuecomment-485777470