### PR TITLE
fix: `process` should be polyfilled rather than mocked

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -153,9 +153,6 @@ module.exports = (api, options) => {
         // prevent webpack from injecting useless setImmediate polyfill because Vue
         // source contains it (although only uses it if it's native).
         setImmediate: false,
-        // process is injected via DefinePlugin, although some 3rd party
-        // libraries may require a mock to work properly (#934)
-        process: 'mock',
         // prevent webpack from injecting mocks to Node native modules
         // that does not make sense for the client
         dgram: 'empty',


### PR DESCRIPTION
To be in line with webpack's default configuration and avoid confusions:
https://webpack.js.org/configuration/node/

DefinePlugin uses simple string replacements so it won't interfere with this polyfill.