### PR TITLE
Fix wc entry to allow multiple file patterns

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -15,7 +15,7 @@ module.exports = (api, { target, entry, name }) => {
   const isAsync = /async/.test(target)
 
   // generate dynamic entry based on glob files
-  const resolvedFiles = require('globby').sync([entry], { cwd: api.resolve('.') })
+  const resolvedFiles = require('globby').sync(entry.split(','), { cwd: api.resolve('.') })
 
   if (!resolvedFiles.length) {
     abort(`entry pattern "${entry}" did not match any files.`)


### PR DESCRIPTION
This PR allows `globby` to get files from multiple different directories by using comma separated list of file patterns. This way we can also list specific components.

Examples:

`vue-cli-service build --target wc --name myprefix src/components/core*.vue,src/components/basic*.vue`

`vue-cli-service build --target wc --name myprefix src/components/myFirst.vue,src/components/mySecond.vue`