### PR TITLE
docs(deployment): add deployment instructions for Heroku

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -290,24 +290,7 @@ We will also use [Express](https://expressjs.com/) to serve the static (dist) fi
     app.listen(port);
     ```
 
-
-3. Edit your `package.json` and define the Node.js and NPM versions that your Heroku app will use. To do this, add an `engine` section in your `package.json` file.
-
-    ```json
-    {
-      ...
-      "engine": {
-        "node": "^10.0.0",
-        "npm": "^6.0.0"
-      }
-      ...
-    }
-    ```
-
-    _Feel free to use the version that matches your local installation or your preferred version._
-
-
-4. Also in your `package.json` file, add a `start` script.
+3. In your `package.json` file, add a `start` script.
 
     ```json
     {
@@ -319,9 +302,9 @@ We will also use [Express](https://expressjs.com/) to serve the static (dist) fi
     }
     ```
 
-5. Push your code to your Heroku Git repository.
+4. Push your code to your Heroku Git repository.
 
-6. You may also push your code to your Github repository and link it your Heroku app to deploy from there. Just go to the **Deploy** tab of your Heroku app, and choose **Github** in the deployment method.
+5. You may also push your code to your Github repository and link it your Heroku app to deploy from there. Just go to the **Deploy** tab of your Heroku app, and choose **Github** in the deployment method.
 
 ### Surge
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -261,7 +261,67 @@ npm install -g now
 
 ### Heroku
 
-> TODO | Open to contribution.
+To deploy with [Heroku](https://heroku.com/), we will use the official [Node.js buildpack](https://github.com/heroku/heroku-buildpack-nodejs). Heroku will automatically use this buildpack when it sees the `package.json` file in the root of your project.
+
+We will also use [Express](https://expressjs.com/) to serve the static (dist) files to the Heroku load balancer.
+
+
+1. Install and add Express to your dependencies
+
+    ```bash
+    npm install express --save
+    ```
+
+2. Create a `server.js` file in the root of your project.
+
+    ```js
+    const port = process.env.PORT || 3000
+
+    let express = require('express'),
+        path = require('path'),
+        app = express()
+
+    app.use(express.static(path.resolve(__dirname, 'dist')))
+
+    app.get('*', (req, res) => {
+      res.sendFile(path.resolve(__dirname, 'dist', 'index.html'))
+    })
+
+    app.listen(port);
+    ```
+
+
+3. Edit your `package.json` and define the Node.js and NPM versions that your Heroku app will use. To do this, add an `engine` section in your `package.json` file.
+
+    ```json
+    {
+      ...
+      "engine": {
+        "node": "^10.0.0",
+        "npm": "^6.0.0"
+      }
+      ...
+    }
+    ```
+
+    _Feel free to use the version that matches your local installation or your preferred version._
+
+
+4. Also in your `package.json` file, add a `start` script.
+
+    ```json
+    {
+      ...
+      "scripts": {
+        "start": "node server.js"
+      }
+      ...
+    }
+    ```
+
+5. Push your code to your Heroku Git repository.
+
+6. You may also push your code to your Github repository and link it your Heroku app to deploy from there. Just go to the **Deploy** tab of your Heroku app, and choose **Github** in the deployment method.
 
 ### Surge
 


### PR DESCRIPTION
This uses Express.js to serve the dist directory to Heroku's load
balancer.