### PR TITLE
fix: should not add polyfills from transform-runtime plugin

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -107,7 +107,7 @@ test('async/await', () => {
   // should use regenerator runtime
   expect(code).toMatch(`import "regenerator-runtime/runtime"`)
   // should use required helper instead of inline
-  expect(code).toMatch(/import _asyncToGenerator from ".*runtime\/helpers\/esm\/asyncToGenerator\"/)
+  expect(code).toMatch(/import _asyncToGenerator from ".*runtime-corejs2\/helpers\/esm\/asyncToGenerator\"/)
 })
 
 test('jsx', () => {
@@ -152,6 +152,6 @@ test('disable absoluteRuntime', () => {
     filename: 'test-entry-file.js'
   })
 
-  expect(code).toMatch('import _toConsumableArray from "@babel/runtime/helpers/esm/toConsumableArray"')
+  expect(code).toMatch('import _toConsumableArray from "@babel/runtime-corejs2/helpers/esm/toConsumableArray"')
   expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
 })

--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -45,7 +45,7 @@ test('polyfill detection', () => {
   // promise polyfill alone doesn't work in IE, needs this as well. fix: #1642
   expect(code).toMatch(genCoreJSImportRegExp('es6.array.iterator'))
   // usage-based detection
-  expect(code).toMatch(/import _Map from ".*runtime-corejs2\/core-js\/map"/)
+  expect(code).toMatch(/import "core-js\/modules\/es6.map"/)
 })
 
 test('modern mode always skips polyfills', () => {
@@ -63,7 +63,7 @@ test('modern mode always skips polyfills', () => {
   // default includes
   expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
   // usage-based detection
-  expect(code).not.toMatch(/import _Map from ".*runtime-corejs2\/core-js\/map"/)
+  expect(code).not.toMatch(/import "core-js\/modules\/es6.map"/)
 
   ;({ code } = babel.transformSync(`
     const a = new Map()
@@ -78,7 +78,7 @@ test('modern mode always skips polyfills', () => {
   // default includes
   expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
   // usage-based detection
-  expect(code).not.toMatch(/import _Map from ".*runtime-corejs2\/core-js\/map"/)
+  expect(code).not.toMatch(/import "core-js\/modules\/es6.map"/)
   delete process.env.VUE_CLI_MODERN_BUILD
 })
 
@@ -107,7 +107,7 @@ test('async/await', () => {
   // should use regenerator runtime
   expect(code).toMatch(`import "regenerator-runtime/runtime"`)
   // should use required helper instead of inline
-  expect(code).toMatch(/import _asyncToGenerator from ".*runtime-corejs2\/helpers\/esm\/asyncToGenerator\"/)
+  expect(code).toMatch(/import _asyncToGenerator from ".*runtime\/helpers\/esm\/asyncToGenerator\"/)
 })
 
 test('jsx', () => {
@@ -152,6 +152,6 @@ test('disable absoluteRuntime', () => {
     filename: 'test-entry-file.js'
   })
 
-  expect(code).toMatch('import _toConsumableArray from "@babel/runtime-corejs2/helpers/esm/toConsumableArray"')
-  // expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
+  expect(code).toMatch('import _toConsumableArray from "@babel/runtime/helpers/esm/toConsumableArray"')
+  expect(code).not.toMatch(genCoreJSImportRegExp('es6.promise'))
 })

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -37,6 +37,7 @@ module.exports = (context, options = {}) => {
     presets.push([require('@vue/babel-preset-jsx'), typeof options.jsx === 'object' ? options.jsx : {}])
   }
 
+  const runtimePath = path.dirname(require.resolve('@babel/runtime/package.json'))
   const {
     polyfills: userPolyfills,
     loose = false,
@@ -62,7 +63,7 @@ module.exports = (context, options = {}) => {
     // However, this may cause hash inconsitency if the project is moved to another directory.
     // So here we allow user to explicit disable this option if hash consistency is a requirement
     // and the runtime version is sure to be correct.
-    absoluteRuntime = path.dirname(require.resolve('@babel/runtime/package.json'))
+    absoluteRuntime = runtimePath
   } = options
 
   // resolve targets
@@ -162,6 +163,18 @@ module.exports = (context, options = {}) => {
     useESModules: !process.env.VUE_CLI_BABEL_TRANSPILE_MODULES,
 
     absoluteRuntime
+  }])
+
+  // until one of the two issues is resolved:
+  // https://github.com/babel/babel/issues/7597
+  // https://github.com/babel/babel/issues/9903
+  // we need to alias @babel/runtime to @babel/runtime-corejs2 for compatibility
+  const runtimeCoreJs2Path = path.dirname(require.resolve('@babel/runtime-corejs2/package.json'))
+  plugins.push([require('babel-plugin-module-resolver'), {
+    alias: {
+      '@babel/runtime': '@babel/runtime-corejs2',
+      [runtimePath]: runtimeCoreJs2Path
+    }
   }])
 
   return {

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -154,10 +154,10 @@ module.exports = (context, options = {}) => {
   // transform runtime, but only for helpers
   plugins.push([require('@babel/plugin-transform-runtime'), {
     regenerator: useBuiltIns !== 'usage',
-    // use @babel/runtime-corejs2 so that helpers that need polyfillable APIs will reference core-js instead.
-    // if useBuiltIns is not set to 'usage', then it means users would take care of the polyfills on their own,
-    // i.e., core-js 2 is no longer needed.
-    corejs: (useBuiltIns === 'usage' && !process.env.VUE_CLI_MODERN_BUILD) ? 2 : false,
+
+    // polyfills are injected by preset-env & polyfillsPlugin, so no need to add them again
+    corejs: false,
+
     helpers: useBuiltIns === 'usage',
     useESModules: !process.env.VUE_CLI_BABEL_TRANSPILE_MODULES,
 

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -165,17 +165,21 @@ module.exports = (context, options = {}) => {
     absoluteRuntime
   }])
 
-  // until one of the two issues is resolved:
+  // use @babel/runtime-corejs2 so that helpers that need polyfillable APIs will reference core-js instead.
+  // if useBuiltIns is not set to 'usage', then it means users would take care of the polyfills on their own,
+  // i.e., core-js is no longer needed.
+  // this extra plugin can be removed once one of the two issues resolves:
   // https://github.com/babel/babel/issues/7597
   // https://github.com/babel/babel/issues/9903
-  // we need to alias @babel/runtime to @babel/runtime-corejs2 for compatibility
-  const runtimeCoreJs2Path = path.dirname(require.resolve('@babel/runtime-corejs2/package.json'))
-  plugins.push([require('babel-plugin-module-resolver'), {
-    alias: {
-      '@babel/runtime': '@babel/runtime-corejs2',
-      [runtimePath]: runtimeCoreJs2Path
-    }
-  }])
+  if (useBuiltIns === 'usage' && !process.env.VUE_CLI_MODERN_BUILD) {
+    const runtimeCoreJs2Path = path.dirname(require.resolve('@babel/runtime-corejs2/package.json'))
+    plugins.push([require('babel-plugin-module-resolver'), {
+      alias: {
+        '@babel/runtime': '@babel/runtime-corejs2',
+        [runtimePath]: runtimeCoreJs2Path
+      }
+    }])
+  }
 
   return {
     presets,

--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -33,7 +33,7 @@
     "@babel/runtime-corejs2": "^7.2.0",
     "@vue/babel-preset-jsx": "^1.0.0-beta.3",
     "babel-plugin-dynamic-import-node": "^2.2.0",
+    "babel-plugin-module-resolver": "3.2.0",
     "core-js": "^2.6.5"
-  },
-  "gitHead": "0dc793497281718762a5477a3de4a7ee439cdda6"
+  }
 }

--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -40,11 +40,6 @@ module.exports = (api, options) => {
             if (transpileDepRegex && transpileDepRegex.test(filepath)) {
               return false
             }
-            // may need to add polyfills (by preset-env) for babel helpers
-            // https://github.com/babel/babel/issues/7597
-            if (/node_modules\/@babel\/runtime/.test(filepath)) {
-              return false
-            }
             // Don't transpile node_modules
             return /node_modules/.test(filepath)
           })

--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -40,6 +40,11 @@ module.exports = (api, options) => {
             if (transpileDepRegex && transpileDepRegex.test(filepath)) {
               return false
             }
+            // may need to add polyfills (by preset-env) for babel helpers
+            // https://github.com/babel/babel/issues/7597
+            if (/node_modules\/@babel\/runtime/.test(filepath)) {
+              return false
+            }
             // Don't transpile node_modules
             return /node_modules/.test(filepath)
           })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3240,6 +3240,17 @@ babel-plugin-jest-hoist@^23.2.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
   integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
 
+babel-plugin-module-resolver@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz#ddfa5e301e3b9aa12d852a9979f18b37881ff5a7"
+  integrity sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
@@ -6431,7 +6442,7 @@ eslint-plugin-vue@^4.5.0, eslint-plugin-vue@^4.7.1:
   dependencies:
     vue-eslint-parser "^2.0.3"
 
-eslint-plugin-vue@^5.2.2:
+eslint-plugin-vue@^5.0.0, eslint-plugin-vue@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-5.2.2.tgz#86601823b7721b70bc92d54f1728cfc03b36283c"
   integrity sha512-CtGWH7IB0DA6BZOwcV9w9q3Ri6Yuo8qMjx05SmOGJ6X6E0Yo3y9E/gQ5tuNxg2dEt30tRnBoFTbvtmW9iEoyHA==
@@ -12758,6 +12769,13 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
+  dependencies:
+    find-up "^2.1.0"
+
 please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
@@ -14493,6 +14511,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+  integrity sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The basic idea is the same as https://github.com/vuejs/vue-cli/pull/3730, except that this time we use babel-plugin-module-resolve for aliasing instead of relying on webpack.