### PR TITLE
chore: prefer .tsx? files over .jsx? file extensions

### DIFF
--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -15,7 +15,8 @@ module.exports = (api, options) => {
 
     config.resolve
       .extensions
-        .merge(['.ts', '.tsx'])
+        .prepend('.ts')
+        .prepend('.tsx')
 
     const tsRule = config.module.rule('ts').test(/\.ts$/)
     const tsxRule = config.module.rule('tsx').test(/\.tsx$/)


### PR DESCRIPTION
When using Typescript, the webpack resolve options should prefer ts? file extensions over js? ones.

Strictly speaking, this is a breaking change, so we can ship this with v4 I think.

close #3898 