### PR TITLE
chore!: upgrade to copy-webpack-plugin v5

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -41,7 +41,7 @@
     "cli-highlight": "^2.1.0",
     "clipboardy": "^2.0.0",
     "cliui": "^5.0.0",
-    "copy-webpack-plugin": "^4.6.0",
+    "copy-webpack-plugin": "^5.0.3",
     "css-loader": "^2.1.1",
     "cssnano": "^4.1.10",
     "current-script-polyfill": "^1.0.0",


### PR DESCRIPTION
BREAKING CHANGE:
See https://github.com/webpack-contrib/copy-webpack-plugin/blob/master/CHANGELOG.md#500-2019-02-20