### PR TITLE
docs: add more explanation at prompts

### DIFF
--- a/docs/dev-guide/plugin-dev.md
+++ b/docs/dev-guide/plugin-dev.md
@@ -430,7 +430,56 @@ This is because the command's expected mode needs to be known before loading env
 
 Prompts are required to handle user choices when creating a new project or adding a new plugin to the existing one. All prompts logic is stored inside the `prompts.js` file. The prompts are presented using [inquirer](https://github.com/SBoudrias/Inquirer.js) under the hood.
 
-When user initialize the plugin by calling `vue invoke`, if the plugin contains a `prompts.js` in its root directory, it will be used during invocation. The file should export an array of [Questions](https://github.com/SBoudrias/Inquirer.js#question) that will be handled by Inquirer.js. The resolved answers object will be passed to the plugin's generator as options.
+When user initialize the plugin by calling `vue invoke`, if the plugin contains a `prompts.js` in its root directory, it will be used during invocation. The file should export an array of [Questions](https://github.com/SBoudrias/Inquirer.js#question) that will be handled by Inquirer.js. 
+
+You should export directly array of questions, or export function that return those.
+
+e.g. directly array of questions:
+```js
+// prompts.js
+
+module.exports = [
+  {
+    type: 'input',
+    name: 'locale',
+    message: 'The locale of project localization.',
+    validate: input => !!input,
+    default: 'en'
+  }, 
+  // ...
+]
+```
+
+e.g. function that return array of questions:
+```js
+// prompts.js
+
+// pass `package.json` of project to function argument
+module.exports = pkg => {
+  const prompts = [
+    {
+      type: 'input',
+      name: 'locale',
+      message: 'The locale of project localization.',
+      validate: input => !!input,
+      default: 'en'
+    }
+  ]
+
+  // add dynamically propmpt
+  if ('@vue/cli-plugin-eslint' in (pkg.devDependencies || {})) {
+    prompts.push({
+      type: 'confirm',
+      name: 'useESLintPluginVueI18n',
+      message: 'ESLint plugin for Vue I18n ?'
+    })
+  }
+
+  return prompts
+}
+```
+
+The resolved answers object will be passed to the plugin's generator as options.
 
 Alternatively, the user can skip the prompts and directly initialize the plugin by passing options via the command line, e.g.:
 

--- a/docs/dev-guide/plugin-dev.md
+++ b/docs/dev-guide/plugin-dev.md
@@ -471,7 +471,7 @@ module.exports = pkg => {
     prompts.push({
       type: 'confirm',
       name: 'useESLintPluginVueI18n',
-      message: 'ESLint plugin for Vue I18n ?'
+      message: 'Use ESLint plugin for Vue I18n ?'
     })
   }
 


### PR DESCRIPTION
I've added it because it was not mentioned in the document about the details of prompts export.

See more details the commit:
https://github.com/vuejs/vue-cli/commit/e33b04c306bd539303812a1c6a2cffbae61acad4