### PR TITLE
chore: upgrade webpack-chain to v6

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -74,7 +74,7 @@
     "vue-loader": "^15.7.0",
     "webpack": ">=4 < 4.29",
     "webpack-bundle-analyzer": "^3.3.2",
-    "webpack-chain": "^5.2.4",
+    "webpack-chain": "^6.0.0",
     "webpack-dev-server": "^3.3.1",
     "webpack-merge": "^4.2.1",
     "yorkie": "^2.0.0"


### PR DESCRIPTION
See: https://github.com/neutrinojs/webpack-chain/blob/master/CHANGELOG.md#v600

New feature: extended DevServer method

Also dropped support for Node.js v6. It is not a breaking change for Vue
CLI, though, as Node.js v6 was never officially supported.