### PR TITLE
fix(cli-ui): fix detectLanguage function

### DIFF
--- a/packages/@vue/cli-ui/src/i18n.js
+++ b/packages/@vue/cli-ui/src/i18n.js
@@ -15,7 +15,7 @@ function detectLanguage () {
     const lang = (window.navigator.languages && window.navigator.languages[0]) ||
       window.navigator.language ||
       window.navigator.userLanguage
-    return [ lang, lang.toLowerCase(), lang.substr(0, 2) ]
+    return [ lang, lang.toLowerCase(), lang.substr(0, 2) ].map(lang => lang.replace('-', '_'))
   } catch (e) {
     return undefined
   }


### PR DESCRIPTION
This is because [vue-cli-locales/locales](https://unpkg.com/vue-cli-locales@3.7.0/locales/) use `_` to separate language and region name, while some browser use `-` to do so.
![image](https://user-images.githubusercontent.com/9370547/57384893-f5640b00-71e3-11e9-9dbf-184992991b7b.png)