### PR TITLE
feat(babel-preset-app): Bump jsx dependency version

### DIFF
--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/runtime": "^7.4.3",
     "@babel/runtime-corejs3": "^7.4.3",
-    "@vue/babel-preset-jsx": "^1.0.0-beta.3",
+    "@vue/babel-preset-jsx": "^1.0.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-module-resolver": "^3.2.0",
     "core-js": "^3.0.1",


### PR DESCRIPTION

@vue/babel-preset-jsx 1.0.0 has been released. It doesn't have any breaking changes from the latest beta that we included so far.