### PR TITLE
Enable HMR when extracting CSS in dev

### DIFF
--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -100,6 +100,7 @@ module.exports = (api, options) => {
             .use('extract-css-loader')
             .loader(require('mini-css-extract-plugin').loader)
             .options({
+              hmr: !isProd,
               publicPath: cssPublicPath
             })
         } else {


### PR DESCRIPTION
feat(compiler): enable hmr for 'mini-css-extract-plugin' in dev

since: https://github.com/webpack-contrib/mini-css-extract-plugin#hot-module-reloading-hmr

Solve #3751

