### PR TITLE
fix(#4021): update import.meta to only run if in module script

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
+++ b/packages/@vue/cli-service/lib/commands/build/setPublicPath.js
@@ -6,8 +6,24 @@ if (typeof window !== 'undefined') {
   }
 
   var i
-  if ((i = window.document.currentScript) && (i = i.src.match(/(.+\/)[^/]+\.js(\?.*)?$/))) {
+  if (
+    (i = window.document.currentScript) &&
+    (i = i.src.match(/(.+\/)[^/]+\.js(\?.*)?$/))
+  ) {
     __webpack_public_path__ = i[1] // eslint-disable-line
+  }
+  // type="module" scripts use import.meta tag for sources
+  // document.currentScript is set to null
+  const getImportMeta = () => {
+    try {
+      // Need to run as new function or the whole script will fail in nomodule
+      return new Function('import.meta')
+    } catch (err) {
+      return null
+    }
+  }
+  if ((i = getImportMeta()) && (i = i.url.match(/(.+\/)[^/]+\.js(\?.*)?$/))) {
+    __webpack_require__.p = i[1] // eslint-disable-line
   }
 }
 


### PR DESCRIPTION
Tested with regular script tags and script tags with src.
new Function was needed to load the script in noModule and to catch the error if not available so everything else works as before.