### PR TITLE
fix: add missing dependencies to @vue/cli-upgrade

### DIFF
--- a/packages/@vue/cli-upgrade/package.json
+++ b/packages/@vue/cli-upgrade/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-upgrade#readme",
   "dependencies": {
+    "@vue/cli-shared-utils": "^4.0.0-alpha.0",
     "chalk": "^2.4.1",
     "cli-table": "^0.3.1",
     "execa": "^1.0.0",


### PR DESCRIPTION
fixes #3417
fixes #3222