### PR TITLE
fix: indexPath should also affect non-production builds (#2327)

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -123,7 +123,12 @@ async function build (args, api, options) {
     }
   }
 
-  const targetDir = api.resolve(args.dest || options.outputDir)
+  if (args.dest) {
+    // Override outputDir before resolving webpack config as config relies on it (#2327)
+    options.outputDir = args.dest
+  }
+
+  const targetDir = api.resolve(options.outputDir)
   const isLegacyBuild = args.target === 'app' && args.modern && !args.modernBuild
 
   // resolve raw webpack config
@@ -141,14 +146,6 @@ async function build (args, api, options) {
 
   // check for common config errors
   validateWebpackConfig(webpackConfig, api, options, args.target)
-
-  // apply inline dest path after user configureWebpack hooks
-  // so it takes higher priority
-  if (args.dest) {
-    modifyConfig(webpackConfig, config => {
-      config.output.path = targetDir
-    })
-  }
 
   if (args.watch) {
     modifyConfig(webpackConfig, config => {

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -92,20 +92,20 @@ module.exports = (api, options) => {
       }
     }
 
-    if (isProd) {
-      // handle indexPath
-      if (options.indexPath !== 'index.html') {
-        // why not set filename for html-webpack-plugin?
-        // 1. It cannot handle absolute paths
-        // 2. Relative paths causes incorrect SW manifest to be generated (#2007)
-        webpackConfig
-          .plugin('move-index')
-          .use(require('../webpack/MovePlugin'), [
-            path.resolve(outputDir, 'index.html'),
-            path.resolve(outputDir, options.indexPath)
-          ])
-      }
+    // handle indexPath
+    if (options.indexPath !== 'index.html') {
+      // why not set filename for html-webpack-plugin?
+      // 1. It cannot handle absolute paths
+      // 2. Relative paths causes incorrect SW manifest to be generated (#2007)
+      webpackConfig
+        .plugin('move-index')
+        .use(require('../webpack/MovePlugin'), [
+          path.resolve(outputDir, 'index.html'),
+          path.resolve(outputDir, options.indexPath)
+        ])
+    }
 
+    if (isProd) {
       Object.assign(htmlOptions, {
         minify: {
           removeComments: true,


### PR DESCRIPTION
This patch fixes two related problems:
 1. `indexPath` is not respected for non-production builds #2327
 2. `build --dest` is applied after generating webpack config despite a number of elements in that config already setting values based on `outputDir`

I attempted to make it possible for `--dest` to override even user webpack config but it was far too complicated, not just in regard to `indexPath` but also other parts that rely on it. It might still be desirable if someone wants to have a go. This patch at least improves things in the mean time, as users are already instructed in the docs to set `outputDir` in config rather than overriding webpack settings themselves.