### PR TITLE
fix: support custom Global Vue alias

### DIFF
--- a/packages/@vue/cli-service/__tests__/buildWc.spec.js
+++ b/packages/@vue/cli-service/__tests__/buildWc.spec.js
@@ -89,6 +89,57 @@ test('build as single wc', async () => {
   expect(h1Text).toMatch('Welcome to Your Vue.js App')
 })
 
+test('build as wc with custom Vue alias', async () => {
+  const project = await create('build-wc-custom-alias', defaultPreset)
+
+  const { stdout } = await project.run(`vue-cli-service build --alias $MyVueAlias --target wc **/*.vue --name wc-custom-alias`)
+  expect(stdout).toMatch('Build complete.')
+
+  expect(project.has('dist/demo.html')).toBe(true)
+  expect(project.has('dist/wc-custom-alias.js')).toBe(true)
+  expect(project.has('dist/wc-custom-alias.min.js')).toBe(true)
+
+  const port = await portfinder.getPortPromise()
+  server = createServer({ root: path.join(project.dir, 'dist') })
+
+  await new Promise((resolve, reject) => {
+    server.listen(port, err => {
+      if (err) return reject(err)
+      resolve()
+    })
+  })
+
+  const launched = await launchPuppeteer(`http://localhost:${port}/demo.html`)
+  browser = launched.browser
+  page = launched.page
+
+  const customAlias = await page.evaluate(() => {
+    return window['$MyVueAlias'] === window.Vue
+  })
+
+  expect(customAlias).toBe(true)
+
+  const styleCount = await page.evaluate(() => {
+    return document.querySelector('wc-custom-alias-app').shadowRoot.querySelectorAll('style').length
+  })
+  expect(styleCount).toBe(2) // should contain styles from both app and child
+
+  const h1Text = await page.evaluate(() => {
+    return document.querySelector('wc-custom-alias-app').shadowRoot.querySelector('h1').textContent
+  })
+  expect(h1Text).toMatch('Welcome to Your Vue.js App')
+
+  const childStyleCount = await page.evaluate(() => {
+    return document.querySelector('wc-custom-alias-hello-world').shadowRoot.querySelectorAll('style').length
+  })
+  expect(childStyleCount).toBe(1)
+
+  const h3Text = await page.evaluate(() => {
+    return document.querySelector('wc-custom-alias-hello-world').shadowRoot.querySelector('h3').textContent
+  })
+  expect(h3Text).toMatch('Installed CLI Plugins')
+})
+
 afterEach(async () => {
   if (browser) {
     await browser.close()

--- a/packages/@vue/cli-service/__tests__/buildWcAsync.spec.js
+++ b/packages/@vue/cli-service/__tests__/buildWcAsync.spec.js
@@ -59,7 +59,58 @@ test('build as wc in async mode', async () => {
   expect(h3Text).toMatch('Installed CLI Plugins')
 })
 
-afterAll(async () => {
+test('build as wc in async mode with custom alias', async () => {
+  const project = await create('build-wc-async-custom-alias', defaultPreset)
+
+  const { stdout } = await project.run(`vue-cli-service build --alias $MyVueAlias --target wc-async **/*.vue`)
+  expect(stdout).toMatch('Build complete.')
+
+  expect(project.has('dist/demo.html')).toBe(true)
+  expect(project.has('dist/build-wc-async-custom-alias.js')).toBe(true)
+  expect(project.has('dist/build-wc-async-custom-alias.min.js')).toBe(true)
+
+  // code-split chunks
+  expect(project.has('dist/build-wc-async-custom-alias.1.js')).toBe(true)
+  expect(project.has('dist/build-wc-async-custom-alias.1.min.js')).toBe(true)
+  expect(project.has('dist/build-wc-async-custom-alias.2.js')).toBe(true)
+  expect(project.has('dist/build-wc-async-custom-alias.2.min.js')).toBe(true)
+
+  const port = await portfinder.getPortPromise()
+  server = createServer({ root: path.join(project.dir, 'dist') })
+
+  await new Promise((resolve, reject) => {
+    server.listen(port, err => {
+      if (err) return reject(err)
+      resolve()
+    })
+  })
+
+  const launched = await launchPuppeteer(`http://localhost:${port}/demo.html`)
+  browser = launched.browser
+  page = launched.page
+
+  const styleCount = await page.evaluate(() => {
+    return document.querySelector('build-wc-async-custom-alias-app').shadowRoot.querySelectorAll('style').length
+  })
+  expect(styleCount).toBe(2) // should contain styles from both app and child
+
+  const h1Text = await page.evaluate(() => {
+    return document.querySelector('build-wc-async-custom-alias-app').shadowRoot.querySelector('h1').textContent
+  })
+  expect(h1Text).toMatch('Welcome to Your Vue.js App')
+
+  const childStyleCount = await page.evaluate(() => {
+    return document.querySelector('build-wc-async-custom-alias-hello-world').shadowRoot.querySelectorAll('style').length
+  })
+  expect(childStyleCount).toBe(1)
+
+  const h3Text = await page.evaluate(() => {
+    return document.querySelector('build-wc-async-custom-alias-hello-world').shadowRoot.querySelector('h3').textContent
+  })
+  expect(h3Text).toMatch('Installed CLI Plugins')
+})
+
+afterEach(async () => {
   if (browser) {
     await browser.close()
   }

--- a/packages/@vue/cli-service/lib/commands/build/demo-wc.html
+++ b/packages/@vue/cli-service/lib/commands/build/demo-wc.html
@@ -1,6 +1,11 @@
 <meta charset="utf-8">
 <title><%- htmlWebpackPlugin.options.libName %> demo</title>
 <script src="https://unpkg.com/vue"></script>
+<% if  (htmlWebpackPlugin.options.alias !== 'Vue') { %>
+<script>
+    window[<%= JSON.stringify(htmlWebpackPlugin.options.alias) %>] = Vue;
+</script>
+<% } %>
 <script src="./<%- htmlWebpackPlugin.options.libName %>.js"></script>
 
 <% for (const comp of htmlWebpackPlugin.options.components) { %>

--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -35,7 +35,8 @@ module.exports = (api, options) => {
       '--no-clean': `do not remove the dist directory before building the project`,
       '--report': `generate report.html to help analyze bundle content`,
       '--report-json': 'generate report.json to help analyze bundle content',
-      '--watch': `watch for changes`
+      '--watch': `watch for changes`,
+      '--alias': `use with --target 'wc' or 'wc-async' to externalize Vue under a custom alias, e.g. $MyVue`
     }
   }, async (args, rawArgs) => {
     for (const key in defaults) {

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -2,7 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const { resolveEntry, fileToComponentName } = require('./resolveWcEntry')
 
-module.exports = (api, { target, entry, name }) => {
+module.exports = (api, { target, entry, name, alias = 'Vue' }) => {
   // Disable CSS extraction and turn on CSS shadow mode for vue-style-loader
   process.env.VUE_CLI_CSS_SHADOW_MODE = true
 
@@ -58,7 +58,7 @@ module.exports = (api, { target, entry, name }) => {
     config
       .externals({
         ...config.get('externals'),
-        vue: process.env.VUE_EXTERNAL_NAME || 'Vue'
+        vue: alias
       })
 
     config
@@ -82,6 +82,7 @@ module.exports = (api, { target, entry, name }) => {
         .use(require('html-webpack-plugin'), [{
           template: path.resolve(__dirname, `./demo-wc.html`),
           inject: false,
+          alias,
           filename: 'demo.html',
           libName,
           components:

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -46,8 +46,8 @@ module.exports = (api, { target, entry, name }) => {
     // make sure not to transpile wc-wrapper
     config.module
       .rule('js')
-        .exclude
-          .add(/vue-wc-wrapper/)
+      .exclude
+      .add(/vue-wc-wrapper/)
 
     // only minify min entry
     if (!minify) {
@@ -58,39 +58,39 @@ module.exports = (api, { target, entry, name }) => {
     config
       .externals({
         ...config.get('externals'),
-        vue: 'Vue'
+        vue: process.env.VUE_EXTERNAL_NAME || 'Vue'
       })
 
     config
       .plugin('web-component-options')
-        .use(webpack.EnvironmentPlugin, [{
-          CUSTOM_ELEMENT_NAME: libName
-        }])
+      .use(webpack.EnvironmentPlugin, [{
+        CUSTOM_ELEMENT_NAME: libName
+      }])
 
     // enable shadow mode in vue-loader
     config.module
       .rule('vue')
-        .use('vue-loader')
-          .tap(options => {
-            options.shadowMode = true
-            return options
-          })
+      .use('vue-loader')
+      .tap(options => {
+        options.shadowMode = true
+        return options
+      })
 
     if (genHTML) {
       config
         .plugin('demo-html')
-          .use(require('html-webpack-plugin'), [{
-            template: path.resolve(__dirname, `./demo-wc.html`),
-            inject: false,
-            filename: 'demo.html',
-            libName,
-            components:
-              prefix === ''
-                ? [libName]
-                : resolvedFiles.map(file => {
-                  return fileToComponentName(prefix, file).kebabName
-                })
-          }])
+        .use(require('html-webpack-plugin'), [{
+          template: path.resolve(__dirname, `./demo-wc.html`),
+          inject: false,
+          filename: 'demo.html',
+          libName,
+          components:
+            prefix === ''
+              ? [libName]
+              : resolvedFiles.map(file => {
+                return fileToComponentName(prefix, file).kebabName
+              })
+        }])
     }
 
     // set entry/output last so it takes higher priority than user
@@ -99,7 +99,7 @@ module.exports = (api, { target, entry, name }) => {
     // set proxy entry for *.vue files
     config.resolve
       .alias
-        .set('~root', api.resolve('.'))
+      .set('~root', api.resolve('.'))
 
     const rawConfig = api.resolveWebpackConfig(config)
 


### PR DESCRIPTION
Adding support for customizing the Global Vue alias in WebComponent builds.
The reason for this is to avoid conflict with other components that may bundle Vue as part of their library. I am having this issue at present.