### PR TITLE
fix(cli-service): avoid opening browser twice

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -86,6 +86,10 @@ module.exports = (api, options) => {
         : `${protocol}://${rawPublicUrl}`
       : null
 
+    const openOption = projectDevServerOptions.open
+    // always disable dev-server open option and handle it ourself
+    projectDevServerOptions.open = false
+
     const urls = prepareURLs(
       protocol,
       host,
@@ -246,7 +250,7 @@ module.exports = (api, options) => {
           }
           console.log()
 
-          if (args.open || projectDevServerOptions.open) {
+          if (args.open || openOption) {
             const pageUri = (projectDevServerOptions.openPage && typeof projectDevServerOptions.openPage === 'string')
               ? projectDevServerOptions.openPage
               : ''


### PR DESCRIPTION
Always disable dev-server open option and handle it in vue-cli, it will close #4088 #4129.