### PR TITLE
fix: fix config merging during `vue invoke` in Node.js v12

### DIFF
--- a/packages/@vue/cli/lib/util/configTransforms.js
+++ b/packages/@vue/cli/lib/util/configTransforms.js
@@ -13,7 +13,7 @@ const isObject = val => val && typeof val === 'object'
 const transformJS = {
   read: ({ filename, context }) => {
     try {
-      return loadModule(filename, context, true)
+      return loadModule(`./${filename}`, context, true)
     } catch (e) {
       return null
     }


### PR DESCRIPTION
The root cause here is the same as #4095
The failing `loadModule` call will return `undefined` for a js config
read operation, which later caused config being overwritten.