### PR TITLE
Explain when .env files are loaded.

### DIFF
--- a/docs/guide/mode-and-env.md
+++ b/docs/guide/mode-and-env.md
@@ -55,6 +55,8 @@ Loaded variables will become available to all `vue-cli-service` commands, plugin
 An env file for a specific mode (e.g. `.env.production`) will take higher priority than a generic one (e.g. `.env`).
 
 In addition, environment variables that already exist when Vue CLI is executed have the highest priority and will not be overwritten by `.env` files.
+
+`.env` files are loaded at the start of `vue-cli-service`. Restart the service after making changes.
 :::
 
 ### Example: Staging Mode


### PR DESCRIPTION
It appears that .env files are only loaded at the start of `vue-cli-service` and are not watched for hot reloads. 
**I am actually not sure this is the case for everyone, but is so for me.**

I think it is worth noting because the expectation is that a file at the root of the project would be watched for hot reloads.