### PR TITLE
lock inquirer dependency, fixes #4177

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "globby": "^9.2.0",
     "graphql": "^14.3.1",
     "http-server": "^0.11.1",
-    "inquirer": "^6.3.1",
+    "inquirer": "~6.3.1",
     "jest": "^24.7.1",
     "lerna": "^3.13.4",
     "lerna-changelog": "^0.8.2",


### PR DESCRIPTION
This should revert the upstream bug identified here: https://github.com/SBoudrias/Inquirer.js/issues/811

It should fix https://github.com/vuejs/vue-cli/issues/4177