### PR TITLE
fix: remove debugger

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -3,7 +3,6 @@ module.exports = (api, {
   tsLint,
   lintOn = []
 }, _, invoking) => {
-  debugger
   if (typeof lintOn === 'string') {
     lintOn = lintOn.split(',')
   }


### PR DESCRIPTION
A `debugger` instruction was left after https://github.com/vuejs/vue-cli/pull/4090