### PR TITLE
fix(cli-test-utils): fix can't create a project without a Git repository

### DIFF
--- a/packages/@vue/cli-test-utils/createTestProject.js
+++ b/packages/@vue/cli-test-utils/createTestProject.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const execa = require('execa')
 
-module.exports = function createTestProject (name, preset, cwd, initGit) {
+module.exports = function createTestProject (name, preset, cwd, initGit = true) {
   delete process.env.VUE_CLI_SKIP_WRITE
 
   cwd = cwd || path.resolve(__dirname, '../../test')
@@ -48,8 +48,7 @@ module.exports = function createTestProject (name, preset, cwd, initGit) {
     '--force',
     '--inlinePreset',
     JSON.stringify(preset),
-    '--git',
-    initGit ? 'init' : 'false'
+    initGit ? '--git' : '--no-git'
   ]
 
   const options = {


### PR DESCRIPTION
adjust args related to option 'initGit', use `--git`  `--no-git`

fix #4223