### PR TITLE
fix: make webpack `use` values consistent

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -143,7 +143,7 @@ module.exports = (api, options) => {
             .use('raw')
               .loader('raw-loader')
               .end()
-            .use('pug-plain')
+            .use('pug-plain-loader')
               .loader('pug-plain-loader')
               .end()
             .end()


### PR DESCRIPTION
The use key is `pug-plain` despite a similar item above it using the key `pug-plain-loader`. This just makes them consistent.

This has a small chance of breaking projects that already override that particular loader config. So feel free to ignore this if it isn't worth it.