### PR TITLE
fix(@vue/cli-service): Update lodash.defaultsdeep

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -56,7 +56,7 @@
     "hash-sum": "^1.0.2",
     "html-webpack-plugin": "^3.2.0",
     "launch-editor-middleware": "^2.2.1",
-    "lodash.defaultsdeep": "^4.6.0",
+    "lodash.defaultsdeep": "^4.6.1",
     "lodash.mapvalues": "^4.6.0",
     "lodash.transform": "^4.6.0",
     "mini-css-extract-plugin": "^0.6.0",


### PR DESCRIPTION
Update `lodash.defaultsdeep` to version `^4.6.1`.

This is causing a high severity vulnerability in our repo.

Fixed in https://github.com/lodash/lodash/pull/4336.