### PR TITLE
Update package.json

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/package.json
+++ b/packages/@vue/cli-plugin-e2e-cypress/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@vue/cli-shared-utils": "^4.0.0-alpha.5",
-    "cypress": "^3.3.1",
+    "cypress": "^3.4.0",
     "eslint-plugin-cypress": "^2.2.1"
   }
 }


### PR DESCRIPTION
Upped minor of cypress, which has a higher version of lodash without the Prototype Pollution vulnerability: https://www.npmjs.com/advisories/1065