### PR TITLE
feat(eslint-generator): upgrade @vue/eslint-config-prettier to v5.0.0

### DIFF
--- a/packages/@vue/cli-plugin-eslint/generator/index.js
+++ b/packages/@vue/cli-plugin-eslint/generator/index.js
@@ -56,7 +56,9 @@ module.exports = (api, { config, lintOn = [] }, _, invoking) => {
   } else if (config === 'prettier') {
     eslintConfig.extends.push('@vue/prettier')
     Object.assign(pkg.devDependencies, {
-      '@vue/eslint-config-prettier': '^4.0.1'
+      '@vue/eslint-config-prettier': '^5.0.0',
+      'eslint-plugin-prettier': '^3.1.0',
+      prettier: '^1.18.2'
     })
     // prettier & default config do not have any style rules
     // so no need to generate an editorconfig file


### PR DESCRIPTION
See changelog at https://github.com/vuejs/eslint-config-prettier/blob/master/CHANGELOG.md#500-2019-07-22

This only affects newly generated projects so it's not considered a
breaking change.

Fixes #4310

(In the long run, we should implement [install-peerdeps](https://github.com/nathanhleung/install-peerdeps/)-like API, to avoid maintaining peer dependencies in the generator)