### PR TITLE
Recommend npx instead of global env corruption

### DIFF
--- a/docs/guide/prototyping.md
+++ b/docs/guide/prototyping.md
@@ -8,7 +8,7 @@ npm install -g @vue/cli-service-global
 yarn global add @vue/cli-service-global
 ```
 
-The drawback of `vue serve` is that it relies on globally installed dependencies which may be inconsistent on different machines. Therefore this is only recommended for rapid prototyping.
+The drawback of `vue serve` is that it relies on globally installed dependencies which may be inconsistent on different machines. You can get around this by using your [npx](https://www.npmjs.com/package/npx) command to call vue instead.
 
 ### vue serve
 


### PR DESCRIPTION
There is no downside to using 
```
npm init
npm install @vue/cli
npx vue create
```