### PR TITLE
fix: use `yarn --version` to detect yarn

### DIFF
--- a/packages/@vue/cli-shared-utils/lib/env.js
+++ b/packages/@vue/cli-shared-utils/lib/env.js
@@ -24,7 +24,7 @@ exports.hasYarn = () => {
     return _hasYarn
   }
   try {
-    execSync('yarnpkg --version', { stdio: 'ignore' })
+    execSync('yarn --version', { stdio: 'ignore' })
     return (_hasYarn = true)
   } catch (e) {
     return (_hasYarn = false)


### PR DESCRIPTION
- We never referred to `yarnpkg` anywhere else in the codebase
- For the rare case that `yarn` binary is overridden by Hadoop YARN,
`yarn --version` will throw (it only supports `yarn version`), therefore
it won't pass this check.

Fixes #3941.
Closes #3942.