### PR TITLE
Add --port argument to 'vue serve' command

### DIFF
--- a/docs/guide/prototyping.md
+++ b/docs/guide/prototyping.md
@@ -20,9 +20,10 @@ serve a .js or .vue file in development mode with zero config
 
 Options:
 
-  -o, --open  Open browser
-  -c, --copy  Copy local url to clipboard
-  -h, --help  output usage information
+  -o, --open         Open browser
+  -c, --copy         Copy local url to clipboard
+  -p, --port <port>  Port used by the server (default: 8080 or next available port)
+  -h, --help         Output usage information
 ```
 
 All you need is an `App.vue` file:

--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -117,6 +117,7 @@ program
   .description('serve a .js or .vue file in development mode with zero config')
   .option('-o, --open', 'Open browser')
   .option('-c, --copy', 'Copy local url to clipboard')
+  .option('-p, --port <port>', 'Port used by the server (default: 8080 or next available port)')
   .action((entry, cmd) => {
     loadCommand('serve', '@vue/cli-service-global').serve(entry, cleanArgs(cmd))
   })


### PR DESCRIPTION
Thanks to webpack, this one line addition in `packages/@vue/cli/bin/vue.js` is sufficient and works perfectly ! 🎉 

![image](https://user-images.githubusercontent.com/17952318/61697411-83598780-ad37-11e9-9226-76c4ecd02220.png)
