### PR TITLE
fix: fix css modules configuration in css-loader v3

### DIFF
--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -89,9 +89,10 @@ test('CSS Modules rules', () => {
   LANGS.forEach(lang => {
     const expected = {
       importLoaders: 1, // no postcss-loader
-      localIdentName: `[name]_[local]_[hash:base64:5]`,
       sourceMap: false,
-      modules: true
+      modules: {
+        localIdentName: `[name]_[local]_[hash:base64:5]`
+      }
     }
     // vue-modules rules
     expect(findOptions(config, lang, 'css', 0)).toEqual(expected)

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -127,8 +127,9 @@ module.exports = (api, options) => {
             localIdentName = '[name]_[local]_[hash:base64:5]'
           } = loaderOptions.css || {}
           Object.assign(cssLoaderOptions, {
-            modules,
-            localIdentName
+            modules: {
+              localIdentName
+            }
           })
         }
 


### PR DESCRIPTION
Fixes #4337

Backlog: maybe we should test for behaviors instead of configurations? But in that case, we'll have a very huge test suite…