### PR TITLE
修复chunkFilename带有查询字符串?xxx时build不展示文件的问题

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/formatStats.js
+++ b/packages/@vue/cli-service/lib/commands/build/formatStats.js
@@ -4,6 +4,7 @@ module.exports = function formatStats (stats, dir, api) {
   const zlib = require('zlib')
   const chalk = require('chalk')
   const ui = require('cliui')({ width: 80 })
+  const url  = require('url');
 
   const json = stats.toJson({
     hash: false,
@@ -20,6 +21,10 @@ module.exports = function formatStats (stats, dir, api) {
   const isCSS = val => /\.css$/.test(val)
   const isMinJS = val => /\.min\.js$/.test(val)
   assets = assets
+    .map(a => {
+      a.name = url.parse(a.name).pathname
+      return a
+    })
     .filter(a => {
       if (seenNames.has(a.name)) {
         return false


### PR DESCRIPTION
修复：`vue.config.js`中如果设置`config.output.chunkFilename("jsi/[name].js?v=xxx")`，打包时不展示相应文件的问题