### PR TITLE
fix: do not generate empty file

### DIFF
--- a/packages/@vue/cli-plugin-typescript/__tests__/tsGenerator.spec.js
+++ b/packages/@vue/cli-plugin-typescript/__tests__/tsGenerator.spec.js
@@ -17,6 +17,8 @@ test('generate files', async () => {
   expect(files['src/main.ts']).toBeTruthy()
   expect(files['src/main.js']).toBeFalsy()
   expect(files['src/App.vue']).toMatch('<script lang="ts">')
+  // checks that the Home.vue file has not been created, even empty
+  expect(files.hasOwnProperty('src/views/Home.vue')).toBeFalsy()
 })
 
 test('classComponent', async () => {
@@ -60,6 +62,22 @@ test('use with Babel', async () => {
 
   expect(files['babel.config.js']).toMatch(`presets: [\n    '@vue/app'\n  ]`)
   expect(files['tsconfig.json']).toMatch(`"target": "esnext"`)
+})
+
+test('use with router', async () => {
+  const { files } = await generateWithPlugin([
+    {
+      id: '@vue/cli-plugin-router',
+      apply: require('@vue/cli-plugin-router/generator'),
+      options: {}
+    },
+    {
+      id: 'ts',
+      apply: require('../generator'),
+      options: {}
+    }
+  ])
+  expect(files['src/views/Home.vue']).toMatch('<div class=\"home\">')
 })
 
 test('lint', async () => {

--- a/packages/@vue/cli/lib/GeneratorAPI.js
+++ b/packages/@vue/cli/lib/GeneratorAPI.js
@@ -429,7 +429,7 @@ function renderFile (name, data, ejsOptions) {
     // if evaluated to falsy value, return early to avoid extra cost for extend expression
     const result = ejs.render(finalTemplate, data, ejsOptions)
     if (!result) {
-      return
+      return ''
     }
   }
 


### PR DESCRIPTION
The recent refactoring in #4330 introduced a regression where a `Home.vue` file was generated if using the TS plugin even without the router plugin. This happened because the result from the ejs rendering was `undefined`. This fixes the issue by returning an empty string instead, which will not be written.