### PR TITLE
chore: use a gitflow-like workflow for the project

### DIFF
--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -56,6 +56,8 @@ A commit message consists of a **header**, **body** and **footer**.  The header 
 
 The **header** is mandatory and the **scope** of the header is optional.
 
+A `!` MAY be appended prior to the `:` in the type/scope prefix, to further draw attention to breaking changes. `BREAKING CHANGE:` description MUST also be included in the body or footer, along with the `!` in the prefix.
+
 ### Revert
 
 If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 The Git workflow used in this project is largely inspired by [Gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
 
 There are two main branches: `master` and `next`, corresponding to the npm `dist-tag`s with the same names.
-The documentation website <https://cli.vuejs.org> is deployed from the `master` branch, with <https://next.cli.vuejs.org/> from `next`.
+The documentation website for the current CLI version <https://cli.vuejs.org> is deployed from the `master` branch, while documentation for new features <https://next.cli.vuejs.org/> is deployed from `next` branch.
 
 When sending documentation pull requests, please fork your branches from these two branches.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,17 @@
+## Workflow
+
+The Git workflow used in this project is largely inspired by [Gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+
+There are two main branches: `master` and `next`, corresponding to the npm `dist-tag`s with the same names.
+The documentation website <https://cli.vuejs.org> is deployed from the `master` branch, with <https://next.cli.vuejs.org/> from `next`.
+
+When sending documentation pull requests, please fork your branches from these two branches.
+
+The development branch is `dev`.
+And there are several version branches for archiving old versions of Vue CLI, such as `v2`, `v3`.
+
+Pull requests that touches the code should be forked from `dev`, unless it's only targeting an old version.
+
 ## Development Setup
 
 This project uses a monorepo setup that requires using [Yarn](https://yarnpkg.com) because it relies on [Yarn workspaces](https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- Please don't delete this template -->
+
+<!-- PULL REQUEST TEMPLATE -->
+<!-- (Update "[ ]" to "[x]" to check a box) -->
+
+**What kind of change does this PR introduce?** (check at least one)
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update
+- [ ] Refactor
+- [ ] Docs
+- [ ] Underlying tools
+- [ ] Other, please describe:
+
+<!--
+Note:
+When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
+When submitting coding PRs, please target the `dev` branch.
+-->
+
+**Does this PR introduce a breaking change?** (check one)
+
+- [ ] Yes
+- [ ] No
+
+**Other information:**


### PR DESCRIPTION
Now that we do v3 & v4 releases in parallel (even after v4 stable release, v3 will continue to receive bug fixes), I'd like to tweak the git workflow a little bit to make it easier.

So, inspired by Gitflow, I propose that we have two production-ready branches - `master` & `next`. `master` is for the `latest` `dist-tag` version on npm, and `next` for `next` `dist-tag` (pre-release versions). It's not only used for v4 betas, but we can also have prereleases for feature releases in the future.

I've also set up Netlify to deploy https://next.cli.vuejs.org from the `next` branch so that users can preview documentation for the new features.

In the past, the website is deployed from the `docs` branch. It seems not so obvious for many users. Many documentation PRs are targeting the `dev` branch. So I now explicitly clarified this in the contributing guide and PR template. Also, the target branch is changed to `master` or `next` so that the code and documentation are in sync, no longer need to cherry-pick & merge across multiple branches.

Though our documentation currently covers features in both v3 & v4, with version-related notes, it may change over time. So I'd also like to set up version-specific documentation, deployed directly from the version archive branch (e.g. `v3.cli.vuejs.org` deployed from `v3` branch).