### PR TITLE
fix: remove self-assignment

### DIFF
--- a/packages/@vue/cli-ui-addon-webpack/src/util/assets.js
+++ b/packages/@vue/cli-ui-addon-webpack/src/util/assets.js
@@ -49,7 +49,7 @@ export function buildSortedAssets (assets, sizeField) {
         speeds: getSpeeds(size)
       }
     })
-    list = list.sort((a, b) => {
+    list.sort((a, b) => {
       if (a.secondary === b.secondary) {
         return b.size - a.size
       } else if (a.secondary && !b.secondary) {

--- a/packages/@vue/cli-ui/apollo-server/connectors/tasks.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/tasks.js
@@ -129,7 +129,7 @@ async function list ({ file = null, api = true } = {}, context) {
       if (index !== -1) return index
       return Infinity
     }
-    list = list.sort((a, b) => getSortScore(a) - getSortScore(b))
+    list.sort((a, b) => getSortScore(a) - getSortScore(b))
 
     tasks.set(file, list)
   }

--- a/packages/@vue/cli-ui/ui-defaults/utils/audit.js
+++ b/packages/@vue/cli-ui/ui-defaults/utils/audit.js
@@ -54,7 +54,7 @@ exports.auditProject = async function (cwd) {
         }
       }
 
-      auditAdvisories = auditAdvisories.sort((a, b) => severity[a.data.advisory.severity] - severity[b.data.advisory.severity])
+      auditAdvisories.sort((a, b) => severity[a.data.advisory.severity] - severity[b.data.advisory.severity])
 
       let id = 0
       for (const { data: { advisory } } of auditAdvisories) {

--- a/packages/@vue/cli-ui/ui-defaults/utils/modules.js
+++ b/packages/@vue/cli-ui/ui-defaults/utils/modules.js
@@ -17,7 +17,7 @@ exports.buildSortedModules = function (modules, sizeField) {
         size
       }
     })
-    list = list.sort((a, b) => b.size - a.size)
+    list.sort((a, b) => b.size - a.size)
   }
   return list
 }
@@ -47,7 +47,7 @@ exports.buildDepModules = function (modules) {
     }
   }
   let list = Array.from(deps.values())
-  list = list.sort((a, b) => b.size - a.size)
+  list.sort((a, b) => b.size - a.size)
   if (list.length) {
     const max = list[0].size
     for (const dep of list) {


### PR DESCRIPTION
This PR removes the useless self-assignments of `Array.sort`.