### PR TITLE
chore: add cwd option when calling globby

### DIFF
--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -61,7 +61,7 @@ module.exports = function lint (args = {}, api) {
   ]
     .filter(pattern =>
       globby
-        .sync(path.join(cwd, pattern))
+        .sync(pattern, { cwd, absolute: true })
         .some(p => !engine.isPathIgnored(p))
     )
 

--- a/packages/@vue/cli-ui/apollo-server/connectors/locales.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/locales.js
@@ -36,7 +36,7 @@ function reset (context) {
 }
 
 function _loadFolder (root, context) {
-  const paths = globby.sync([path.join(root, './locales/*.json')])
+  const paths = globby.sync(['./locales/*.json'], { cwd: root, absolute: true })
   paths.forEach(file => {
     const basename = path.basename(file)
     const lang = basename.substr(0, basename.indexOf('.'))

--- a/packages/@vue/cli-ui/apollo-server/resolvers.js
+++ b/packages/@vue/cli-ui/apollo-server/resolvers.js
@@ -1,5 +1,4 @@
 const { withFilter } = require('graphql-subscriptions')
-const path = require('path')
 const globby = require('globby')
 const merge = require('lodash.merge')
 const { GraphQLJSON } = require('graphql-type-json')
@@ -90,7 +89,7 @@ const resolvers = [{
 }]
 
 // Load resolvers in './schema'
-const paths = globby.sync([path.join(__dirname, './schema/*.js')])
+const paths = globby.sync(['./schema/*.js'], { cwd: __dirname, absolute: true })
 paths.forEach(file => {
   const { resolvers: r } = require(file)
   r && resolvers.push(r)

--- a/packages/@vue/cli-ui/apollo-server/type-defs.js
+++ b/packages/@vue/cli-ui/apollo-server/type-defs.js
@@ -1,5 +1,4 @@
 const gql = require('graphql-tag')
-const path = require('path')
 const globby = require('globby')
 
 const typeDefs = [gql`
@@ -86,7 +85,7 @@ type Subscription {
 `]
 
 // Load types in './schema'
-const paths = globby.sync([path.join(__dirname, './schema/*.js')])
+const paths = globby.sync(['./schema/*.js'], { cwd: __dirname, absolute: true })
 paths.forEach(file => {
   const { types } = require(file)
   types && typeDefs.push(types)


### PR DESCRIPTION
split parent path from patterns and add cwd option, make globby working as expected when project path contains parentheses.
close #4417 .

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
