### PR TITLE
fix(eslint): eslint should override env

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -82,7 +82,7 @@ module.exports = (api, _, __, invoking) => {
       eslintConfig: {
         overrides: [
           {
-            files: ['**/__tests__/*.js', '**/__tests__/*.jsx', '**/__tests__/*.ts', '**/__tests__/*.tsx'],
+            files: ['**/__tests__/*.{j,t}s?(x)'],
             env: {
               jest: true
             }

--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -77,6 +77,19 @@ module.exports = (api, _, __, invoking) => {
 
   if (api.hasPlugin('eslint')) {
     applyESLint(api)
+
+    api.extendPackage({
+      eslintConfig: {
+        overrides: [
+          {
+            files: ['**/__tests__/*.js', '**/__tests__/*.jsx', '**/__tests__/*.ts', '**/__tests__/*.tsx'],
+            env: {
+              jest: true
+            }
+          }
+        ]
+      }
+    })
   }
 }
 

--- a/packages/@vue/cli-plugin-unit-mocha/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/generator/index.js
@@ -19,7 +19,7 @@ module.exports = (api, _, __, invoking) => {
       eslintConfig: {
         overrides: [
           {
-            files: ['**/__tests__/*.js', '**/__tests__/*.jsx', '**/__tests__/*.ts', '**/__tests__/*.tsx'],
+            files: ['**/__tests__/*.{j,t}s?(x)'],
             env: {
               mocha: true
             }

--- a/packages/@vue/cli-plugin-unit-mocha/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/generator/index.js
@@ -15,6 +15,18 @@ module.exports = (api, _, __, invoking) => {
 
   if (api.hasPlugin('eslint')) {
     applyESLint(api)
+    api.extendPackage({
+      eslintConfig: {
+        overrides: [
+          {
+            files: ['**/__tests__/*.js', '**/__tests__/*.jsx', '**/__tests__/*.ts', '**/__tests__/*.tsx'],
+            env: {
+              mocha: true
+            }
+          }
+        ]
+      }
+    })
   }
 
   if (api.hasPlugin('typescript')) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

The unit test packages support tests in /tests/unit and \*/\_\_tests\_\_/ folders, but eslint config for jest/mocha  was only applied to the former

This PR adds overrides to the eslint config for files in the latter type of folder so eslint can successfully detect and lint jest/mocha globals