### PR TITLE
use the specified port and not a ramdom port in range[port,highest port]

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -101,7 +101,7 @@ module.exports = (api, options) => {
     const useHttps = args.https || projectDevServerOptions.https || defaults.https
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
-     portfinder.basePort = Number(args.port || process.env.PORT || projectDevServerOptions.port || defaults.port)
+    portfinder.basePort = Number(args.port || process.env.PORT || projectDevServerOptions.port || defaults.port)
     portfinder.highestPort  = portfinder.basePort + 1
     const port = await portfinder.getPortPromise()
     const rawPublicUrl = args.public || projectDevServerOptions.public

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -101,7 +101,7 @@ module.exports = (api, options) => {
     const useHttps = args.https || projectDevServerOptions.https || defaults.https
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
-    portfinder.basePort = args.port || process.env.PORT || projectDevServerOptions.port || defaults.port
+     portfinder.basePort = Number(args.port || process.env.PORT || projectDevServerOptions.port || defaults.port)
     portfinder.highestPort  = portfinder.basePort + 1
     const port = await portfinder.getPortPromise()
     const rawPublicUrl = args.public || projectDevServerOptions.public

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -102,6 +102,7 @@ module.exports = (api, options) => {
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
     portfinder.basePort = args.port || process.env.PORT || projectDevServerOptions.port || defaults.port
+    portfinder.highestPort  = portfinder.basePort + 1
     const port = await portfinder.getPortPromise()
     const rawPublicUrl = args.public || projectDevServerOptions.public
     const publicUrl = rawPublicUrl


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
This PR allow to fix the port running "vue serve" related in https://stackoverflow.com/questions/57536785/vue-npm-run-serve-starts-on-random-port

portfinder give a ramdom port in the range [basePort,highestPort], so asking for port 8080 result to a random port between [8080 and 40000]
