### PR TITLE
feat(cli-service): add finalWebpack option

### DIFF
--- a/packages/@vue/cli-service/__tests__/Service.spec.js
+++ b/packages/@vue/cli-service/__tests__/Service.spec.js
@@ -286,6 +286,27 @@ test('api: configureWebpack preserve ruleNames', () => {
   expect(config.module.rules[0].__ruleNames).toEqual(['js'])
 })
 
+test('finalWebpack', () => {
+  const service = createMockService([{
+    id: 'test',
+    apply: api => {
+      api.configureWebpack(config => {
+        config.entry = {
+          page1: './src/page1.js',
+          page2: './src/page2.js'
+        }
+      })
+    }
+  }])
+  service.projectOptions.finalWebpack = config => {
+    config.entry.app = ['test']
+    return config
+  }
+  const config = service.resolveWebpackConfig()
+
+  expect(config.entry.app[0]).toBe('test')
+})
+
 test('internal: should correctly set VUE_CLI_ENTRY_FILES', () => {
   const service = createMockService([{
     id: 'test',

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -285,6 +285,8 @@ module.exports = class Service {
       process.env.VUE_CLI_ENTRY_FILES = JSON.stringify(entryFiles)
     }
 
+    config = this.projectOptions.finalWebpack(config)
+
     return config
   }
 
@@ -345,7 +347,6 @@ module.exports = class Service {
       resolved = this.inlineOptions || {}
       resolvedFrom = 'inline options'
     }
-
 
     if (resolved.css && typeof resolved.css.modules !== 'undefined') {
       if (typeof resolved.css.requireModuleExtension !== 'undefined') {

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -54,6 +54,7 @@ const schema = createSchema(joi => joi.object({
     joi.object(),
     joi.func()
   ),
+  finalWebpack: joi.func(),
 
   // known runtime options for built-in plugins
   lintOnSave: joi.any().valid([true, false, 'error', 'warning', 'default']),
@@ -139,5 +140,7 @@ exports.defaults = () => ({
     proxy: null, // string | Object
     before: app => {}
   */
-  }
+  },
+
+  finalWebpack: config => config
 })


### PR DESCRIPTION
The `finalWebpack` option can customize Webpack config in the end of its resolution.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Fixes #4272