### PR TITLE
feat: add `vue outdated` command & make `vue upgrade` interactive

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -167,6 +167,14 @@ program
   })
 
 program
+  .command('outdated')
+  .description('(experimental) check for outdated vue cli service / plugins')
+  .option('--next', 'Also check for alpha / beta / rc versions when upgrading')
+  .action((cmd) => {
+    require('../lib/outdated')(cleanArgs(cmd))
+  })
+
+program
   .command('upgrade [plugin-name]')
   .description('(experimental) upgrade vue cli service / plugins')
   .option('-t, --to <version>', 'upgrade <package-name> to a version that is not latest')

--- a/packages/@vue/cli/lib/Upgrader.js
+++ b/packages/@vue/cli/lib/Upgrader.js
@@ -257,8 +257,6 @@ module.exports = class Upgrader {
       console.log('  ' + fields.map((x, i) => x.padEnd(pads[i])).join(''))
     }
 
-    console.log(`Run ${chalk.yellow('vue upgrade --all')} to upgrade all the above plugins`)
-
     return upgradable
   }
 }

--- a/packages/@vue/cli/lib/outdated.js
+++ b/packages/@vue/cli/lib/outdated.js
@@ -1,0 +1,17 @@
+const { error } = require('@vue/cli-shared-utils')
+
+const Upgrader = require('./Upgrader')
+
+async function outdated (options, context = process.cwd()) {
+  const upgrader = new Upgrader(context)
+  return upgrader.checkForUpdates(options.next)
+}
+
+module.exports = (...args) => {
+  return outdated(...args).catch(err => {
+    error(err)
+    if (!process.env.VUE_CLI_TEST) {
+      process.exit(1)
+    }
+  })
+}

--- a/packages/@vue/cli/lib/upgrade.js
+++ b/packages/@vue/cli/lib/upgrade.js
@@ -1,3 +1,4 @@
+const inquirer = require('inquirer')
 const { error } = require('@vue/cli-shared-utils')
 
 const Upgrader = require('./Upgrader')
@@ -20,7 +21,23 @@ async function upgrade (packageName, options, context = process.cwd()) {
       return upgrader.upgradeAll(options.next)
     }
 
-    return upgrader.checkForUpdates(options.next)
+    const upgradable = await upgrader.checkForUpdates(options.next)
+    if (upgradable) {
+      const { ok } = await inquirer.prompt([
+        {
+          name: 'ok',
+          type: 'confirm',
+          message: 'Continue to upgrade these plugins?',
+          default: false
+        }
+      ])
+
+      if (ok) {
+        return upgrader.upgradeAll(options.next)
+      }
+    }
+
+    return
   }
 
   return upgrader.upgrade(packageName, options)

--- a/packages/@vue/cli/lib/upgrade.js
+++ b/packages/@vue/cli/lib/upgrade.js
@@ -28,7 +28,7 @@ async function upgrade (packageName, options, context = process.cwd()) {
           name: 'ok',
           type: 'confirm',
           message: 'Continue to upgrade these plugins?',
-          default: false
+          default: true
         }
       ])
 


### PR DESCRIPTION
It feels a little weird to use `vue upgrade` to check for updates only, so I now move this functionality to a new command `vue outdated`, and `vue upgrade` is interactive now.

![image](https://user-images.githubusercontent.com/3277634/63639859-7976cb80-c6cb-11e9-99bd-ca08c7d27774.png)


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
