### PR TITLE
fix: remove the nonexistent `test` command from generated README

### DIFF
--- a/packages/@vue/cli/lib/util/generateReadme.js
+++ b/packages/@vue/cli/lib/util/generateReadme.js
@@ -2,7 +2,6 @@ const descriptions = {
   build: 'Compiles and minifies for production',
   serve: 'Compiles and hot-reloads for development',
   lint: 'Lints and fixes files',
-  test: 'Run your tests',
   'test:e2e': 'Run your end-to-end tests',
   'test:unit': 'Run your unit tests'
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

The generated README was mentionning:

    ### Run your tests
    ```
    npm run test
    ```

but `npm run test` throws:

    Error: no test specified

This removes the mention of this command from the generated README.