### PR TITLE
Add a variant for `config get registry`

### DIFF
--- a/packages/@vue/cli/lib/util/shouldUseTaobao.js
+++ b/packages/@vue/cli/lib/util/shouldUseTaobao.js
@@ -38,9 +38,19 @@ module.exports = async function shouldUseTaobao (command) {
     return val
   }
 
-  const userCurrent = (await execa(command, ['config', 'get', 'registry'])).stdout
-  const defaultRegistry = registries[command]
+  let userCurrent
+  try {
+    userCurrent = (await execa(command, ['config', 'get', 'registry'])).stdout
+  } catch (error) {
+    try {
+      // Yarn 2 uses `npmRegistryServer` instead of `registry`
+      userCurrent = (await execa(command, ['config', 'get', 'npmRegistryServer'])).stdout
+    } catch (error) {
+      return save(false)
+    }
+  }
 
+  const defaultRegistry = registries[command]
   if (removeSlash(userCurrent) !== removeSlash(defaultRegistry)) {
     // user has configured custom registry, respect that
     return save(false)

--- a/packages/@vue/cli/lib/util/shouldUseTaobao.js
+++ b/packages/@vue/cli/lib/util/shouldUseTaobao.js
@@ -41,11 +41,11 @@ module.exports = async function shouldUseTaobao (command) {
   let userCurrent
   try {
     userCurrent = (await execa(command, ['config', 'get', 'registry'])).stdout
-  } catch (error) {
+  } catch (registryError) {
     try {
       // Yarn 2 uses `npmRegistryServer` instead of `registry`
       userCurrent = (await execa(command, ['config', 'get', 'npmRegistryServer'])).stdout
-    } catch (error) {
+    } catch (npmRegistryServerError) {
       return save(false)
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**Other information:**

We've done a large work to make our configuration more uniform, and some configuration keys have changed. One such key is `registry`, which is now called `npmRegistryServer`.

I've also made this code resilient to unforeseen failures.

Ref https://github.com/yarnpkg/berry/issues/368