### PR TITLE
fix(cli-plugin-babel): roperly exports the babel preset

### DIFF
--- a/packages/@vue/cli-plugin-babel/generator.js
+++ b/packages/@vue/cli-plugin-babel/generator.js
@@ -7,7 +7,7 @@ module.exports = api => {
 
   api.extendPackage({
     babel: {
-      presets: ['@vue/app']
+      presets: ['@vue/cli-plugin-babel/preset']
     },
     dependencies: {
       'core-js': '^3.1.2'

--- a/packages/@vue/cli-plugin-babel/preset.js
+++ b/packages/@vue/cli-plugin-babel/preset.js
@@ -1,0 +1,1 @@
+module.exports = require('@vue/babel-preset-app')

--- a/packages/@vue/cli-plugin-typescript/__tests__/tsGenerator.spec.js
+++ b/packages/@vue/cli-plugin-typescript/__tests__/tsGenerator.spec.js
@@ -60,7 +60,7 @@ test('use with Babel', async () => {
     }
   ])
 
-  expect(files['babel.config.js']).toMatch(`presets: [\n    '@vue/app'\n  ]`)
+  expect(files['babel.config.js']).toMatch(`presets: [\n    '@vue/cli-plugin-babel/preset'\n  ]`)
   expect(files['tsconfig.json']).toMatch(`"target": "esnext"`)
 })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Other information:**

The current setup relies on the hoisting for `babel.config.js` to be able to access `@vue/babel-preset-app`, since it's not actually part of the package dependencies. This change re-exports it from `@vue/cli-plugin-babel`, which is an actual dependency.

Ref https://github.com/yarnpkg/berry/issues/368
