### PR TITLE
Update @vue/unit-mocha install instructions

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/README.md
+++ b/packages/@vue/cli-plugin-unit-mocha/README.md
@@ -32,5 +32,5 @@
 ## Installing in an Already Created Project
 
 ``` sh
-vue add unit-mocha
+vue add @vue/unit-mocha
 ```


### PR DESCRIPTION
Similar to [this comment](https://github.com/vuejs/vue-cli/issues/4294#issuecomment-511510600) addressing vue-jest install issues, the install instructions for `@vue/unit-mocha` have also changed and need to be updated too.

#### Before change:

_Instructions currently read, and produce:_

```bash
vue add unit-mocha

📦  Installing vue-cli-plugin-unit-mocha...

npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/vue-cli-plugin-unit-mocha - Not found
npm ERR! 404 
```

#### After change

_Instructions that current work, and should read/produce:_

```bash
vue add @vue/unit-mocha

📦  Installing @vue/cli-plugin-unit-mocha...

+ @vue/cli-plugin-unit-mocha@3.11.0
added 70 packages from 505 contributors and audited 29226 packages in 17.477s
```

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
