### PR TITLE
docs: remove run for yarn commands in readme

### DIFF
--- a/packages/@vue/cli/lib/util/generateReadme.js
+++ b/packages/@vue/cli/lib/util/generateReadme.js
@@ -12,7 +12,7 @@ function printScripts (pkg, packageManager) {
     return [
       `\n### ${descriptions[key]}`,
       '```',
-      `${packageManager} run ${key}`,
+      `${packageManager} ${packageManager !== 'yarn' ? 'run ' : ''}${key}`,
       '```',
       ''
     ].join('\n')


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Removes the `run` command for yarn, as it is useless. Keeps it for the other package managers. 