### PR TITLE
feat(nightwatch): check user's installed browser versions on scaffolding / before running tests

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/generator/index.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/generator/index.js
@@ -1,15 +1,29 @@
+const { installedBrowsers } = require('@vue/cli-shared-utils')
+
 module.exports = api => {
   api.render('./template', {
     hasTS: api.hasPlugin('typescript')
   })
+
+  // Use devDependencies to store latest version number so as to automate update
+  const devDeps = require('../package.json').devDependencies
+  const geckodriver = devDeps.geckodriver
+
+  // chromedriver major version bumps every 6 weeks following Chrome
+  // so there may be a mismatch between
+  // user's installed browser version and the default provided version
+  // fallback to the devDependencies version in case detection fails
+  const chromedriver = installedBrowsers.chrome
+    ? installedBrowsers.chrome.match(/^(\d+)\./)[1]
+    : devDeps.chromedriver
 
   api.extendPackage({
     scripts: {
       'test:e2e': 'vue-cli-service test:e2e'
     },
     devDependencies: {
-      chromedriver: '^76.0.1',
-      geckodriver: '^1.16.2'
+      chromedriver,
+      geckodriver
     }
   })
 }

--- a/packages/@vue/cli-plugin-e2e-nightwatch/nightwatch.config.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/nightwatch.config.js
@@ -3,7 +3,12 @@
 const path = require('path')
 const deepmerge = require('deepmerge')
 const chromedriver = require('chromedriver')
-const geckodriver = require('geckodriver')
+
+// user may have not installed geckodriver
+let geckodriver = {}
+try {
+  geckodriver = require('geckodriver')
+} catch (e) {}
 
 const userOptions = JSON.parse(process.env.VUE_NIGHTWATCH_USER_OPTIONS || '{}')
 const useSelenium = process.env.VUE_NIGHTWATCH_USE_SELENIUM === '1'
@@ -51,7 +56,7 @@ const defaultSettings = {
         }
       },
       webdriver: useSelenium ? {} : {
-        server_path: require('geckodriver').path,
+        server_path: geckodriver.path,
         port: 4444
       }
     }

--- a/packages/@vue/cli-plugin-e2e-nightwatch/package.json
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/package.json
@@ -42,6 +42,9 @@
   "peerDependenciesMeta": {
     "selenium-server": {
       "optional": true
+    },
+    "geckodriver": {
+      "optional": true
     }
   }
 }

--- a/packages/@vue/cli-plugin-e2e-nightwatch/prompts.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/prompts.js
@@ -1,0 +1,22 @@
+const { installedBrowsers } = require('@vue/cli-shared-utils')
+
+module.exports = [
+  {
+    name: 'webdrivers',
+    type: `checkbox`,
+    message: `Pick browsers to run end-to-end test on`,
+    choices: [
+      {
+        name: `Chrome`,
+        value: 'chrome',
+        checked: true
+      },
+      {
+        name: 'Firefox',
+        value: 'firefox',
+        // check the "Firefox" option if user has installed it
+        checked: !!installedBrowsers.firefox
+      }
+    ]
+  }
+]

--- a/packages/@vue/cli-shared-utils/lib/env.js
+++ b/packages/@vue/cli-shared-utils/lib/env.js
@@ -165,7 +165,7 @@ Object.defineProperty(exports, 'installedBrowsers', {
     }
     hasCheckedBrowsers = true
 
-    if (exports.isWindows) {
+    if (exports.isLinux) {
       browsers.chrome = getLinuxAppVersion('google-chrome')
       browsers.firefox = getLinuxAppVersion('firefox')
     } else if (exports.isMacintosh) {

--- a/packages/@vue/cli/lib/promptModules/__tests__/e2e.spec.js
+++ b/packages/@vue/cli/lib/promptModules/__tests__/e2e.spec.js
@@ -44,6 +44,11 @@ test('nightwatch', async () => {
       message: 'Pick a E2E testing solution',
       choices: ['Cypress', 'Nightwatch'],
       choose: 1
+    },
+    {
+      message: 'Pick browsers to run end-to-end test on',
+      choice: ['Chrome', 'Firefox'],
+      check: [0, 1]
     }
   ]
 

--- a/packages/@vue/cli/lib/promptModules/e2e.js
+++ b/packages/@vue/cli/lib/promptModules/e2e.js
@@ -1,3 +1,5 @@
+const { installedBrowsers } = require('@vue/cli-shared-utils')
+
 module.exports = cli => {
   cli.injectFeature({
     name: 'E2E Testing',
@@ -20,9 +22,29 @@ module.exports = cli => {
         short: 'Cypress'
       },
       {
-        name: 'Nightwatch (Selenium-based)',
+        name: 'Nightwatch (WebDriver-based)',
         value: 'nightwatch',
         short: 'Nightwatch'
+      }
+    ]
+  })
+
+  cli.injectPrompt({
+    name: 'webdrivers',
+    when: answers => answers.e2e === 'nightwatch',
+    type: `checkbox`,
+    message: `Pick browsers to run end-to-end test on`,
+    choices: [
+      {
+        name: `Chrome`,
+        value: 'chrome',
+        checked: true
+      },
+      {
+        name: 'Firefox',
+        value: 'firefox',
+        // check the "Firefox" option if user has installed it
+        checked: !!installedBrowsers.firefox
       }
     ]
   })


### PR DESCRIPTION
1. By checking for firefox installation, users can save the bandwith of
downloading the geckodriver package if they don't need it;
2. By detecting installed Chrome version, even if we failed to closely
follow up chromedriver's releases, users can still get the correct
version they need;
3. By comparing user's Chrome version with the installed chromedriver
version and output warnings, users can have a basic knowledge of what
actions to take if they accidentally updated to an incompatible
version of Chrome.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
