### PR TITLE
refactor!: [wip] make workbox-webpack-plugin a peer dependency

### DIFF
--- a/packages/@vue/cli-plugin-pwa/generator/index.js
+++ b/packages/@vue/cli-plugin-pwa/generator/index.js
@@ -2,6 +2,9 @@ module.exports = api => {
   api.extendPackage({
     dependencies: {
       'register-service-worker': '^1.6.2'
+    },
+    devDependencies: {
+      'workbox-webpack-plugin': '^4.3.1'
     }
   })
   api.injectImports(api.entryFile, `import './registerServiceWorker'`)

--- a/packages/@vue/cli-plugin-pwa/package.json
+++ b/packages/@vue/cli-plugin-pwa/package.json
@@ -27,7 +27,8 @@
     "webpack": "^4.0.0"
   },
   "devDependencies": {
-    "register-service-worker": "^1.6.2"
+    "register-service-worker": "^1.6.2",
+    "workbox-webpack-plugin": "^4.3.1"
   },
   "peerDependencies": {
     "@vue/cli-service": "^3.0.0 || ^4.0.0-0",

--- a/packages/@vue/cli-plugin-pwa/package.json
+++ b/packages/@vue/cli-plugin-pwa/package.json
@@ -24,13 +24,13 @@
   },
   "dependencies": {
     "@vue/cli-shared-utils": "^4.0.0-rc.3",
-    "webpack": "^4.0.0",
-    "workbox-webpack-plugin": "^4.3.1"
+    "webpack": "^4.0.0"
   },
   "devDependencies": {
     "register-service-worker": "^1.6.2"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
+    "@vue/cli-service": "^3.0.0 || ^4.0.0-0",
+    "workbox-webpack-plugin": "^4.3.1"
   }
 }


### PR DESCRIPTION
Update: I'm very hesitant about this refactor. Will give it another look next week.

TODOs:
- [ ] implement a migrator for `vue upgrade` to automate the migration
- [ ] ~~implement a `postinstall` script for prerelease users who don't use `vue upgrade` to upgrade this plugin.~~ Adding a `postinstall` script does not make sense as we've got migrators already. I think adding a strong and explicit is enough.

Considering workbox team is preparing a v5 release.
It's likely that in the early-to-middle stage of Vue CLI v4 lifecycle that a major version bump of workbox may happen.
By making it a peer dep we could have more flexibility on version strategies.

We should do the similar to the unit-jest plugin.
IMO these are our last two remaining issues before an official v4 release.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
