### PR TITLE
#4595 - Display public path rather than localhost:<port> message

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -254,8 +254,13 @@ module.exports = (api, options) => {
             console.log(chalk.yellow(`  explicitly specify the URL via ${chalk.blue(`devServer.public`)}.`))
             console.log()
           }
+
+          const devServerUrl = publicUrl
+            ? publicUrl
+            : '${protocol}://localhost:<your container\'s external mapped port>';
+
           console.log(chalk.yellow(`  Access the dev server via ${chalk.cyan(
-            `${protocol}://localhost:<your container's external mapped port>${options.publicPath}`
+            `${devServerUrl}${options.publicPath}`
           )}`))
         }
         console.log()


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

This PR simply fixes the message displayed at the end of `vue-cli-service serve` to use the value from `devServer.public` if it's provided rather than `localhost:<mapped container port>` when running it from within a container.