### PR TITLE
disable noop service worker when production mode is enabled

### DIFF
--- a/packages/@vue/cli-plugin-pwa/index.js
+++ b/packages/@vue/cli-plugin-pwa/index.js
@@ -52,8 +52,10 @@ module.exports = (api, options) => {
   })
 
   // install dev server middleware for resetting service worker during dev
-  const createNoopServiceWorkerMiddleware = require('./lib/noopServiceWorkerMiddleware')
-  api.configureDevServer(app => {
-    app.use(createNoopServiceWorkerMiddleware())
-  })
+  if (process.env.NODE_ENV !== 'production') {
+    const createNoopServiceWorkerMiddleware = require('./lib/noopServiceWorkerMiddleware')
+    api.configureDevServer(app => {
+      app.use(createNoopServiceWorkerMiddleware())
+    })
+  }
 }


### PR DESCRIPTION
according to https://cli.vuejs.org/guide/mode-and-env.html#modes , and what is said in the pwa plugin readme : 

> Instead, in the development mode the noopServiceWorker.js is included. This service worker file is effectively a 'no-op' that will reset any previous service worker registered for the same host:port combination.

> If you need to test a service worker locally, build the application and run a simple HTTP-server from your build directory. It's recommended to use a browser incognito window to avoid complications with your browser cache.

... we should be able to run the webpack dev server with prod mode without having the "noop service worker" enabled.
This commit just add a check to prevent the registering of the noop service worker middleware.

Why is this useful ? Because it eases the service worker debugging process which is already complex enough (need for https and valid cert, except if you are using localhost or 127.X.X.X url).

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Other information:**
