### PR TITLE
docs: changes vuepress link for master branch

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -50,7 +50,7 @@ module.exports = {
   themeConfig: {
     repo: 'vuejs/vue-cli',
     docsDir: 'docs',
-    docsBranch: 'docs',
+    docsBranch: 'master',
     editLinks: true,
     sidebarDepth: 3,
     algolia: {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [x] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Currently, our documentation for both next and current version has `Edit this page on GitHub` link leading to `docs` branch while we want docs PRs to target `next` or `master` branch respectively. This PR changes the Vuepress config to target `master` branch on links.