### PR TITLE
fix: correctly ignore html templates in copy-webpack-plugin

### DIFF
--- a/packages/@vue/cli-service/__tests__/multiPage.spec.js
+++ b/packages/@vue/cli-service/__tests__/multiPage.spec.js
@@ -15,7 +15,12 @@ async function makeProjectMultiPage (project) {
         index: { entry: 'src/main.js' },
         foo: { entry: 'src/foo.js' },
         bar: { entry: 'src/bar.js' },
-        foobar: { entry: ['src/foobar.js'] }
+        foobar: { entry: ['src/foobar.js'] },
+        baz: {
+          entry: 'src/main.js',
+          template: 'public/baz.html',
+          filename: 'qux.html'
+        }
       },
       chainWebpack: config => {
         const splitOptions = config.optimization.get('splitChunks')
@@ -25,6 +30,7 @@ async function makeProjectMultiPage (project) {
       }
     }
   `)
+  await project.write('public/baz.html', await project.read('public/index.html'))
   await project.write('src/foo.js', `
     import Vue from 'vue'
     new Vue({
@@ -95,6 +101,11 @@ test('build w/ multi page', async () => {
   expect(project.has('dist/index.html')).toBe(true)
   expect(project.has('dist/foo.html')).toBe(true)
   expect(project.has('dist/bar.html')).toBe(true)
+
+  // should properly ignore the template file
+  expect(project.has('dist/baz.html')).toBe(false)
+  // should respect the `filename` field in a multi-page config
+  expect(project.has('dist/qux.html')).toBe(true)
 
   const assertSharedAssets = file => {
     // should split and preload vendor chunk

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -158,6 +158,11 @@ module.exports = (api, options) => {
         ? htmlPath
         : defaultHtmlPath
 
+      publicCopyIgnore.push({
+        glob: path.relative(api.resolve('public'), api.resolve(htmlOptions.template)),
+        matchBase: false
+      })
+
       webpackConfig
         .plugin('html')
           .use(HTMLPlugin, [htmlOptions])
@@ -214,14 +219,16 @@ module.exports = (api, options) => {
 
         // resolve page index template
         const hasDedicatedTemplate = fs.existsSync(api.resolve(template))
-        if (hasDedicatedTemplate) {
-          publicCopyIgnore.push(template)
-        }
         const templatePath = hasDedicatedTemplate
           ? template
           : fs.existsSync(htmlPath)
             ? htmlPath
             : defaultHtmlPath
+
+        publicCopyIgnore.push({
+          glob: path.relative(api.resolve('public'), api.resolve(templatePath)),
+          matchBase: false
+        })
 
         // inject html plugin for the page
         const pageHtmlOptions = Object.assign(


### PR DESCRIPTION
Fixes #3597.
Fixes #4299.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
