### PR TITLE
feat: allow custom packageManager other than npm/yarn/pnpm

### DIFF
--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -78,6 +78,8 @@ class PackageManager {
     if (!SUPPORTED_PACKAGE_MANAGERS.includes(this.bin)) {
       throw new Error(`Unknown package manager: ${this.bin}`)
     }
+
+    this.execBin = process.env.VUE_CLI_PACKAGE_MANAGER_BIN || this.bin
   }
 
   // Any command that implemented registry-related feature should support
@@ -162,7 +164,7 @@ class PackageManager {
 
   async install () {
     const args = await this.addRegistryToArgs(PACKAGE_MANAGER_CONFIG[this.bin].install)
-    return executeCommand(this.bin, args, this.context)
+    return executeCommand(this.execBin, args, this.context)
   }
 
   async add (packageName, isDev = true) {
@@ -171,7 +173,7 @@ class PackageManager {
       packageName,
       ...(isDev ? ['-D'] : [])
     ])
-    return executeCommand(this.bin, args, this.context)
+    return executeCommand(this.execBin, args, this.context)
   }
 
   async upgrade (packageName) {
@@ -192,7 +194,7 @@ class PackageManager {
       ...PACKAGE_MANAGER_CONFIG[this.bin].add,
       packageName
     ])
-    return executeCommand(this.bin, args, this.context)
+    return executeCommand(this.execBin, args, this.context)
   }
 
   async remove (packageName) {
@@ -200,7 +202,7 @@ class PackageManager {
       ...PACKAGE_MANAGER_CONFIG[this.bin].remove,
       packageName
     ]
-    return executeCommand(this.bin, args, this.context)
+    return executeCommand(this.execBin, args, this.context)
   }
 }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Use `process.env.VUE_CLI_PACKAGE_MANAGER_BIN` to specify the bin used by `PackageManager`