### PR TITLE
fix: fix sassOptions merging for scss syntax in sass-loader v8

### DIFF
--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -307,7 +307,10 @@ test('css.loaderOptions', () => {
       css: {
         loaderOptions: {
           sass: {
-            prependData
+            prependData,
+            sassOptions: {
+              includePaths: ['./src/styles']
+            }
           }
         }
       }
@@ -316,12 +319,17 @@ test('css.loaderOptions', () => {
 
   expect(findOptions(config, 'scss', 'sass')).toMatchObject({
     prependData,
-    sourceMap: false
+    sourceMap: false,
+    sassOptions: {
+      includePaths: ['./src/styles']
+    }
   })
+  expect(findOptions(config, 'scss', 'sass').sassOptions).not.toHaveProperty('indentedSyntax')
   expect(findOptions(config, 'sass', 'sass')).toMatchObject({
     prependData,
     sassOptions: {
-      indentedSyntax: true
+      indentedSyntax: true,
+      includePaths: ['./src/styles']
     },
     sourceMap: false
   })

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -204,7 +204,8 @@ module.exports = (api, rootOptions) => {
         loaderOptions.sass,
         {
           sassOptions: Object.assign(
-            (loaderOptions.sass && loaderOptions.sass.sassOptions) || {},
+            {},
+            loaderOptions.sass && loaderOptions.sass.sassOptions,
             {
               indentedSyntax: true
             }


### PR DESCRIPTION
fixes #4630

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
