### PR TITLE
fix(babel-migrator): transform babel preset regardless of plugin version

### DIFF
--- a/packages/@vue/cli-plugin-babel/migrator/index.js
+++ b/packages/@vue/cli-plugin-babel/migrator/index.js
@@ -1,14 +1,14 @@
 const { chalk } = require('@vue/cli-shared-utils')
 
 module.exports = (api) => {
+  api.transformScript('babel.config.js', require('../codemods/usePluginPreset'))
+
   if (api.fromVersion('^3')) {
     api.extendPackage({
       dependencies: {
         'core-js': '^3.1.2'
       }
     }, true)
-
-    api.transformScript('babel.config.js', require('../codemods/usePluginPreset'))
 
     // TODO: implement a codemod to migrate polyfills
     api.exitLog(`core-js has been upgraded from v2 to v3.


### PR DESCRIPTION
In older versions of v4 alpha & beta, we still use `@vue/app` as default babel preset. This should be fixed in the migrator. So we now do this transform regardless of the existing plugin version.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
