### PR TITLE
feat: names for local plugins

### DIFF
--- a/docs/dev-guide/plugin-dev.md
+++ b/docs/dev-guide/plugin-dev.md
@@ -456,7 +456,7 @@ or
 When using the object configuration, key `myCommands` becomes your local plugin `name` and the plugin options will be directly accessible as the third argument in `PluginAPI` if the plugin `name` corresponds to the key defined in `pluginOptions`.
 
 `pluginOptions` are defined in `vue.config.js` or in `vue` field in `package.json`:
-```json
+```js
 {
   pluginOptions: {
     myPlugin: {

--- a/docs/dev-guide/plugin-dev.md
+++ b/docs/dev-guide/plugin-dev.md
@@ -432,6 +432,49 @@ module.exports.defaultModes = {
 
 This is because the command's expected mode needs to be known before loading environment variables, which in turn needs to happen before loading user options / applying the plugins.
 
+### Local plugins
+
+If you need access to the plugin API in your project and don't want to create a full plugin for it, you can use the `vuePlugins.service` option in your `package.json` file:
+
+```json
+{
+  "vuePlugins": {
+    "service": ["my-local-plugin.js"]
+  }
+}
+```
+or
+```json
+{
+  "vuePlugins": {
+    "service": {
+      "myPlugin": "my-local-plugin.js"
+    }
+  }
+}
+```
+When using the object configuration, key `myCommands` becomes your local plugin `name` and the plugin options will be directly accessible as the third argument in `PluginAPI` if the plugin `name` corresponds to the key defined in `pluginOptions`.
+
+`pluginOptions` are defined in `vue.config.js` or in `vue` field in `package.json`:
+```json
+{
+  pluginOptions: {
+    myPlugin: {
+      foo: "bar",
+      baz: "quz"
+    }
+  }
+}
+```
+
+``` js
+// my-local-plugin.js
+module.exports = (api, options, { foo, baz }) => {
+  console.log(foo) // bar
+  console.log(baz) // quz
+}
+```
+
 ## Prompts
 
 Prompts are required to handle user choices when creating a new project or adding a new plugin to the existing one. All prompts logic is stored inside the `prompts.js` file. The prompts are presented using [inquirer](https://github.com/SBoudrias/Inquirer.js) under the hood.

--- a/docs/guide/plugins-and-presets.md
+++ b/docs/guide/plugins-and-presets.md
@@ -79,6 +79,16 @@ If you need access to the plugin API in your project and don't want to create a 
   }
 }
 ```
+or
+```json
+{
+  "vuePlugins": {
+    "service": {
+      "myCommands": "my-commands.js"
+    }
+  }
+}
+```
 
 Each file will need to export a function taking the plugin API as the first argument. For more information about the plugin API, check out the [Plugin Development Guide](../dev-guide/plugin-dev.md).
 

--- a/packages/@vue/cli-service/lib/PluginAPI.js
+++ b/packages/@vue/cli-service/lib/PluginAPI.js
@@ -12,7 +12,7 @@ class PluginAPI {
   /**
    * @param {string} id - Id of the plugin.
    * @param {Service} service - A vue-cli-service instance.
-   * @param {Object} options - optional access plugin options for named local plugins
+   * @param {Object} options - optional access to plugin options for named local plugins
    */
   constructor (id, service, options = {}) {
     this.id = id

--- a/packages/@vue/cli-service/lib/PluginAPI.js
+++ b/packages/@vue/cli-service/lib/PluginAPI.js
@@ -12,10 +12,12 @@ class PluginAPI {
   /**
    * @param {string} id - Id of the plugin.
    * @param {Service} service - A vue-cli-service instance.
+   * @param {Object} options - optional access plugin options for named local plugins
    */
-  constructor (id, service) {
+  constructor (id, service, options = {}) {
     this.id = id
     this.service = service
+    this.options = options
   }
 
   get version () {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
This PR tries to simplify getting plugin options when developing local plugins, utilising both the`vuePlugins.service` field in the `package.json` and `pluginOptions` in the `vue.config.js`.
Using `Object` instead of an `Array` for plugin registration, for example: 
```json
{
  "vuePlugins": {
    "service": {
      "myCommands": "my-commands.js"
    }
  }
}
```
key `myCommands` becomes the plugin `name`. If that same `name` is used as key in `pluginOptions` field, for example: 
```js
{
...
  "pluginOptions": {
    "myCommands": {
      "foo": "bar",
      "baz": "quz"
    }
  }
...
}
```
options for that plugin will become available as the third argument in the `PluginAPI`, for example: 
```js
// my-commands.js
module.exports = (api, options, { foo, baz }) => {
  console.log(foo) // bar
  console.log(baz) // quz
}
```

Also, this PRs tests now cover registration of local plugins in both cases. 