### PR TITLE
data is no longer a valid setting for sass-loader

### DIFF
--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -129,15 +129,15 @@ module.exports = {
       // @/ is an alias to src/
       // so this assumes you have a file named `src/variables.sass`
       sass: {
-        data: `@import "~@/variables.sass"`
+        prependData: `@import "~@/variables.sass"`
       },
       // by default the `sass` option will apply to both syntaxes
       // because `scss` syntax is also processed by sass-loader underlyingly
-      // but when configuring the `data` option
+      // but when configuring the `prependData` option
       // `scss` syntax requires an semicolon at the end of a statement, while `sass` syntax requires none
       // in that case, we can target the `scss` syntax separately using the `scss` option
       scss: {
-        data: `@import "~@/variables.scss";`
+        prependData: `@import "~@/variables.scss";`
       },
       // pass Less.js Options to less-loader
       less:{


### PR DESCRIPTION
When generating a new project with the vue-cli I got had issues configuring my` cssLoader` options due to the data option being deprecated and `prependData` being used instead. By using prependData I got my mixins and variables to import correctly.

prependData is now used to import your mixins, variables, etc. Please see https://webpack.js.org/loaders/sass-loader/#prependdata

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
