### PR TITLE
feat: make the minimizer config available in all modes

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -187,5 +187,11 @@ module.exports = (api, options) => {
           additionalTransformers: [transformer],
           additionalFormatters: [formatter]
         }])
+
+    const TerserPlugin = require('terser-webpack-plugin')
+    const terserOptions = require('./terserOptions')
+    webpackConfig.optimization
+      .minimizer('terser')
+        .use(TerserPlugin, [terserOptions(options)])
   })
 }

--- a/packages/@vue/cli-service/lib/config/prod.js
+++ b/packages/@vue/cli-service/lib/config/prod.js
@@ -15,12 +15,6 @@ module.exports = (api, options) => {
       // disable optimization during tests to speed things up
       if (process.env.VUE_CLI_TEST) {
         webpackConfig.optimization.minimize(false)
-      } else {
-        const TerserPlugin = require('terser-webpack-plugin')
-        const terserOptions = require('./terserOptions')
-        webpackConfig.optimization
-          .minimizer('terser')
-            .use(TerserPlugin, [terserOptions(options)])
       }
     }
   })


### PR DESCRIPTION
As long as the `minimize` option is set to false (which is default in
production mode), the code won't be minimized regardless of the `minimizer` config's presence.

By exposing this config, users can simplify their custom config, by
removing the `process.env.NODE_ENV === 'production'` guard around their
custom minimizer configuration.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
