### PR TITLE
Reference mochapack in README

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/README.md
+++ b/packages/@vue/cli-plugin-unit-mocha/README.md
@@ -6,7 +6,7 @@
 
 - **`vue-cli-service test:unit`**
 
-  Run unit tests with [mocha-webpack](https://github.com/zinserjan/mocha-webpack) + [chai](http://chaijs.com/).
+  Run unit tests with [mochapack](https://github.com/sysgears/mochapack) + [chai](http://chaijs.com/).
 
   **Note the tests are run inside Node.js with browser environment simulated with JSDOM.**
 
@@ -27,7 +27,7 @@
 
   Default files matches are: any files in `tests/unit` that end in `.spec.(ts|js)`.
 
-  All [mocha-webpack command line options](http://zinserjan.github.io/mocha-webpack/docs/installation/cli-usage.html) are also supported.
+  All [mochapack command line options](https://sysgears.github.io/mochapack/docs/installation/cli-usage.html) are also supported.
 
 ## Installing in an Already Created Project
 

--- a/packages/@vue/cli-service/generator/template/_gitignore
+++ b/packages/@vue/cli-service/generator/template/_gitignore
@@ -5,6 +5,8 @@ node_modules
 
 /tests/e2e/reports/
 selenium-debug.log
+chromedriver.log
+geckodriver.log
 <%_ } _%>
 <%_ if (rootOptions.plugins && rootOptions.plugins['@vue/cli-plugin-e2e-cypress']) { _%>
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

As of https://github.com/vuejs/vue-cli/commit/e08603bb1e8194de25a16124ee98bd041381d02b, this plugin uses mochapack instead of mocha-webpack. Updated the README to reflect this.

~~The Pull Request Template says to submit this PR to `master`, as it is a doc change, but this change currently doesn't exist on `master`, so submitting to `dev` instead.~~ **EDIT:** Just noticed this change is on `next`, rebased on to the branch.