### PR TITLE
[v3] Support sass-loader v8

### DIFF
--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -128,8 +128,9 @@ module.exports = {
       // pass options to sass-loader
       // @/ is an alias to src/
       // so this assumes you have a file named `src/variables.sass`
+      // Note: this option is named as "data" in sass-loader v7
       sass: {
-        data: `@import "~@/variables.sass"`
+        prependData: `@import "~@/variables.sass"`
       },
       // by default the `sass` option will apply to both syntaxes
       // because `scss` syntax is also processed by sass-loader underlyingly
@@ -137,7 +138,7 @@ module.exports = {
       // `scss` syntax requires an semicolon at the end of a statement, while `sass` syntax requires none
       // in that case, we can target the `scss` syntax separately using the `scss` option
       scss: {
-        data: `@import "~@/variables.scss";`
+        prependData: `@import "~@/variables.scss";`
       },
       // pass Less.js Options to less-loader
       less:{

--- a/docs/zh/guide/css.md
+++ b/docs/zh/guide/css.md
@@ -129,7 +129,8 @@ module.exports = {
       sass: {
         // @/ 是 src/ 的别名
         // 所以这里假设你有 `src/variables.sass` 这个文件
-        data: `@import "~@/variables.sass"`
+        // 注意：在 sass-loader v7 中，这个选项名是 "data"
+        prependData: `@import "~@/variables.sass"`
       },
       // 默认情况下 `sass` 选项会同时对 `sass` 和 `scss` 语法同时生效
       // 因为 `scss` 语法在内部也是由 sass-loader 处理的
@@ -137,7 +138,7 @@ module.exports = {
       // `scss` 语法会要求语句结尾必须有分号，`sass` 则要求必须没有分号
       // 在这种情况下，我们可以使用 `scss` 选项，对 `scss` 语法进行单独配置
       scss: {
-        data: `@import "~@/variables.scss";`
+        prependData: `@import "~@/variables.scss";`
       },
       // 给 less-loader 传递 Less.js 相关选项
       less:{

--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -191,7 +191,10 @@ test('css.loaderOptions', () => {
       css: {
         loaderOptions: {
           sass: {
-            prependData
+            prependData,
+            sassOptions: {
+              includePaths: ['./src/styles']
+            }
           }
         }
       }
@@ -200,12 +203,17 @@ test('css.loaderOptions', () => {
 
   expect(findOptions(config, 'scss', 'sass')).toMatchObject({
     prependData,
-    sourceMap: false
+    sourceMap: false,
+    sassOptions: {
+      includePaths: ['./src/styles']
+    }
   })
+  expect(findOptions(config, 'scss', 'sass').sassOptions).not.toHaveProperty('indentedSyntax')
   expect(findOptions(config, 'sass', 'sass')).toMatchObject({
     prependData,
     sassOptions: {
-      indentedSyntax: true
+      indentedSyntax: true,
+      includePaths: ['./src/styles']
     },
     sourceMap: false
   })

--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -231,7 +231,8 @@ test('scss loaderOptions', () => {
             prependData: sassData
           },
           scss: {
-            prependData: scssData
+            prependData: scssData,
+            webpackImporter: false
           }
         }
       }
@@ -249,6 +250,9 @@ test('scss loaderOptions', () => {
     },
     sourceMap: false
   })
+
+  // should not merge scss options into default sass config
+  expect(findOptions(config, 'sass', 'sass')).not.toHaveProperty('webpackImporter')
 })
 
 test('should use dart sass implementation whenever possible', () => {

--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -62,7 +62,12 @@ test('default loaders', () => {
     })
   })
   // sass indented syntax
-  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ indentedSyntax: true, sourceMap: false })
+  expect(findOptions(config, 'sass', 'sass')).toMatchObject({
+    sassOptions: {
+      indentedSyntax: true
+    },
+    sourceMap: false
+  })
 })
 
 test('production defaults', () => {
@@ -180,21 +185,30 @@ test('css-loader options', () => {
 })
 
 test('css.loaderOptions', () => {
-  const data = '$env: production;'
+  const prependData = '$env: production;'
   const config = genConfig({
     vue: {
       css: {
         loaderOptions: {
           sass: {
-            data
+            prependData
           }
         }
       }
     }
   })
 
-  expect(findOptions(config, 'scss', 'sass')).toMatchObject({ data, sourceMap: false })
-  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ data, indentedSyntax: true, sourceMap: false })
+  expect(findOptions(config, 'scss', 'sass')).toMatchObject({
+    prependData,
+    sourceMap: false
+  })
+  expect(findOptions(config, 'sass', 'sass')).toMatchObject({
+    prependData,
+    sassOptions: {
+      indentedSyntax: true
+    },
+    sourceMap: false
+  })
 })
 
 test('scss loaderOptions', () => {
@@ -206,24 +220,33 @@ test('scss loaderOptions', () => {
       css: {
         loaderOptions: {
           sass: {
-            sassData
+            prependData: sassData
           },
           scss: {
-            scssData
+            prependData: scssData
           }
         }
       }
     }
   })
 
-  expect(findOptions(config, 'scss', 'sass')).toMatchObject({ scssData, sourceMap: false })
-  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ sassData, indentedSyntax: true, sourceMap: false })
+  expect(findOptions(config, 'scss', 'sass')).toMatchObject({
+    prependData: scssData,
+    sourceMap: false
+  })
+  expect(findOptions(config, 'sass', 'sass')).toMatchObject({
+    prependData: sassData,
+    sassOptions: {
+      indentedSyntax: true
+    },
+    sourceMap: false
+  })
 })
 
 test('should use dart sass implementation whenever possible', () => {
   const config = genConfig()
-  expect(findOptions(config, 'scss', 'sass')).toMatchObject({ fiber: require('fibers'), implementation: require('sass') })
-  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ fiber: require('fibers'), implementation: require('sass') })
+  expect(findOptions(config, 'scss', 'sass')).toMatchObject({ implementation: require('sass') })
+  expect(findOptions(config, 'sass', 'sass')).toMatchObject({ implementation: require('sass') })
 })
 
 test('skip postcss-loader if no postcss config found', () => {

--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -37,16 +37,16 @@ module.exports = (api, options) => {
     const deps = {
       // TODO: remove 'sass' option in v4 or rename 'dart-sass' to 'sass'
       sass: {
-        'node-sass': '^4.9.0',
-        'sass-loader': '^7.1.0'
+        'node-sass': '^4.12.0',
+        'sass-loader': '^8.0.0'
       },
       'node-sass': {
-        'node-sass': '^4.9.0',
-        'sass-loader': '^7.1.0'
+        'node-sass': '^4.12.0',
+        'sass-loader': '^8.0.0'
       },
       'dart-sass': {
-        sass: '^1.18.0',
-        'sass-loader': '^7.1.0'
+        sass: '^1.19.0',
+        'sass-loader': '^8.0.0'
       },
       less: {
         'less': '^3.0.4',

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -1,5 +1,7 @@
 const fs = require('fs')
 const path = require('path')
+const semver = require('semver')
+const { warn } = require('@vue/cli-shared-utils')
 
 const findExisting = (context, files) => {
   for (const file of files) {
@@ -15,10 +17,21 @@ module.exports = (api, options) => {
     const shadowMode = !!process.env.VUE_CLI_CSS_SHADOW_MODE
     const isProd = process.env.NODE_ENV === 'production'
 
+    let sassLoaderVersion
+    try {
+      sassLoaderVersion = semver.major(require('sass-loader/package.json').version)
+    } catch (e) {}
+    if (sassLoaderVersion < 8) {
+      warn('sass-loader v8 is out, please consider upgrading your sass-loader version.')
+    }
+
     const defaultSassLoaderOptions = {}
     try {
       defaultSassLoaderOptions.implementation = require('sass')
-      defaultSassLoaderOptions.fiber = require('fibers')
+      // since sass-loader 8, fibers will be automatically detected and used
+      if (sassLoaderVersion < 8) {
+        defaultSassLoaderOptions.fiber = require('fibers')
+      }
     } catch (e) {}
 
     const {
@@ -169,13 +182,28 @@ module.exports = (api, options) => {
       defaultSassLoaderOptions,
       loaderOptions.scss || loaderOptions.sass
     ))
-    createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign(
-      defaultSassLoaderOptions,
-      {
-        indentedSyntax: true
-      },
-      loaderOptions.sass
-    ))
+    if (sassLoaderVersion < 8) {
+      createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign(
+        defaultSassLoaderOptions,
+        {
+          indentedSyntax: true
+        },
+        loaderOptions.sass
+      ))
+    } else {
+      createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign(
+        defaultSassLoaderOptions,
+        loaderOptions.sass,
+        {
+          sassOptions: Object.assign(
+            (loaderOptions.sass && loaderOptions.sass.sassOptions) || {},
+            {
+              indentedSyntax: true
+            }
+          )
+        }
+      ))
+    }
     createCSSRule('less', /\.less$/, 'less-loader', loaderOptions.less)
     createCSSRule('stylus', /\.styl(us)?$/, 'stylus-loader', Object.assign({
       preferPathResolver: 'webpack'

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -179,11 +179,13 @@ module.exports = (api, options) => {
     createCSSRule('css', /\.css$/)
     createCSSRule('postcss', /\.p(ost)?css$/)
     createCSSRule('scss', /\.scss$/, 'sass-loader', Object.assign(
+      {},
       defaultSassLoaderOptions,
       loaderOptions.scss || loaderOptions.sass
     ))
     if (sassLoaderVersion < 8) {
       createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign(
+        {},
         defaultSassLoaderOptions,
         {
           indentedSyntax: true
@@ -192,6 +194,7 @@ module.exports = (api, options) => {
       ))
     } else {
       createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign(
+        {},
         defaultSassLoaderOptions,
         loaderOptions.sass,
         {

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -196,7 +196,8 @@ module.exports = (api, options) => {
         loaderOptions.sass,
         {
           sassOptions: Object.assign(
-            (loaderOptions.sass && loaderOptions.sass.sassOptions) || {},
+            {},
+            loaderOptions.sass && loaderOptions.sass.sassOptions,
             {
               indentedSyntax: true
             }

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 const semver = require('semver')
-const { warn } = require('@vue/cli-shared-utils')
 
 const findExisting = (context, files) => {
   for (const file of files) {
@@ -21,9 +20,6 @@ module.exports = (api, options) => {
     try {
       sassLoaderVersion = semver.major(require('sass-loader/package.json').version)
     } catch (e) {}
-    if (sassLoaderVersion < 8) {
-      warn('sass-loader v8 is out, please consider upgrading your sass-loader version.')
-    }
 
     const defaultSassLoaderOptions = {}
     try {

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -84,9 +84,9 @@
     "vue-template-compiler": "^2.0.0"
   },
   "devDependencies": {
-    "fibers": "^3.1.1",
-    "sass": "^1.18.0",
-    "sass-loader": "^7.1.0",
+    "fibers": ">= 3.1.1 <5.0.0",
+    "sass": "^1.19.0",
+    "sass-loader": "^8.0.0",
     "vue": "^2.6.10",
     "vue-router": "^3.0.3",
     "vue-template-compiler": "^2.6.10",


### PR DESCRIPTION
The warning on the loader version was removed to avoid frustrations.
Users could postpone the sass-loader upgrade until they decide to move to Vue CLI v4.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
