### PR TITLE
feat(babel-preset): set target to node whenever NODE_ENV === 'test'

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/index.js
@@ -9,7 +9,7 @@ module.exports = api => {
       `All jest command line options are supported.\n` +
       `See https://facebook.github.io/jest/docs/en/cli.html for more details.`
   }, (args, rawArgv) => {
-    // for @vue/babel-preset-app
+    // for @vue/babel-preset-app <= v4.0.0-rc.7
     process.env.VUE_CLI_BABEL_TARGET_NODE = true
     process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true
     require('jest').run(rawArgv)

--- a/packages/@vue/cli-plugin-unit-mocha/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/index.js
@@ -42,7 +42,7 @@ module.exports = api => {
     if (inspectPos !== -1) {
       nodeArgs = rawArgv.splice(inspectPos, inspectPos + 1)
     }
-    // for @vue/babel-preset-app
+    // for @vue/babel-preset-app <= v4.0.0-rc.7
     process.env.VUE_CLI_BABEL_TARGET_NODE = true
     // start runner
     const { execa } = require('@vue/cli-shared-utils')


### PR DESCRIPTION
Typically only unit test frameworks do so.

This change will improve the interoperability with Jest editor extensions, etc.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
