### PR TITLE
feat(pwa): improve compatibility with v3 plugin usage

### DIFF
--- a/packages/@vue/cli-plugin-pwa/index.js
+++ b/packages/@vue/cli-plugin-pwa/index.js
@@ -1,4 +1,20 @@
+const fs = require('fs')
+const { chalk, warn } = require('@vue/cli-shared-utils')
+
 module.exports = (api, options) => {
+  const userOptions = options.pwa || {}
+
+  const manifestPath = api.resolve('public/manifest.json')
+  if (fs.existsSync(manifestPath)) {
+    if (!userOptions.manifestOptions) {
+      userOptions.manifestOptions = require(manifestPath)
+    } else {
+      warn(
+        `The ${chalk.red('public/manifest.json')} file will be ignored in favor of ${chalk.cyan('pwa.manifestOptions')}`
+      )
+    }
+  }
+
   api.chainWebpack(webpackConfig => {
     const target = process.env.VUE_CLI_BUILD_TARGET
     if (target && target !== 'app') {
@@ -6,7 +22,6 @@ module.exports = (api, options) => {
     }
 
     const name = api.service.pkg.name
-    const userOptions = options.pwa || {}
 
     // the pwa plugin hooks on to html-webpack-plugin
     // and injects icons, manifest links & other PWA related tags into <head>


### PR DESCRIPTION
1. `public/manifest.json` will be used when no `pwa.manifestOptions`
present;
2. warn user when there are both the file & the config field present.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
