### PR TITLE
refactor!: use DefinePlugin (again) instead of EnvironmentPlugin

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -55,10 +55,8 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
 
     config
       .plugin('web-component-options')
-        .use(require('webpack/lib/DefinePlugin'), [{
-          'process.env': {
-            CUSTOM_ELEMENT_NAME: JSON.stringify(libName)
-          }
+        .use(require('webpack').DefinePlugin, [{
+          'process.env.CUSTOM_ELEMENT_NAME': JSON.stringify(libName)
         }])
 
     // enable shadow mode in vue-loader

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const webpack = require('webpack')
 const { resolveEntry, fileToComponentName } = require('./resolveWcEntry')
 
 module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
@@ -56,8 +55,10 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
 
     config
       .plugin('web-component-options')
-        .use(webpack.EnvironmentPlugin, [{
-          CUSTOM_ELEMENT_NAME: libName
+        .use(require('webpack/lib/DefinePlugin'), [{
+          'process.env': {
+            CUSTOM_ELEMENT_NAME: JSON.stringify(libName)
+          }
         }])
 
     // enable shadow mode in vue-loader

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -98,7 +98,7 @@ module.exports = (api, options) => {
             files: assets,
             options: pluginOptions
           }
-        }, resolveClientEnv(options))
+        }, resolveClientEnv(options, true /* raw */))
       }
     }
 

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -1,5 +1,3 @@
-const webpack = require('webpack')
-
 module.exports = (api, options) => {
   api.chainWebpack(webpackConfig => {
     const isLegacyBundle = process.env.VUE_CLI_MODERN_MODE && !process.env.VUE_CLI_MODERN_BUILD
@@ -155,7 +153,7 @@ module.exports = (api, options) => {
         // prevent webpack from injecting useless setImmediate polyfill because Vue
         // source contains it (although only uses it if it's native).
         setImmediate: false,
-        // process is injected via EnvironmentPlugin, although some 3rd party
+        // process is injected via DefinePlugin, although some 3rd party
         // libraries may require a mock to work properly (#934)
         process: 'mock',
         // prevent webpack from injecting mocks to Node native modules
@@ -169,8 +167,8 @@ module.exports = (api, options) => {
 
     const resolveClientEnv = require('../util/resolveClientEnv')
     webpackConfig
-      .plugin('process-env')
-        .use(webpack.EnvironmentPlugin, [
+      .plugin('define')
+        .use(require('webpack/lib/DefinePlugin'), [
           resolveClientEnv(options)
         ])
 

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -168,7 +168,7 @@ module.exports = (api, options) => {
     const resolveClientEnv = require('../util/resolveClientEnv')
     webpackConfig
       .plugin('define')
-        .use(require('webpack/lib/DefinePlugin'), [
+        .use(require('webpack').DefinePlugin, [
           resolveClientEnv(options)
         ])
 

--- a/packages/@vue/cli-service/lib/util/resolveClientEnv.js
+++ b/packages/@vue/cli-service/lib/util/resolveClientEnv.js
@@ -9,5 +9,14 @@ module.exports = function resolveClientEnv (options, raw) {
   })
   env.BASE_URL = options.publicPath
 
-  return env
+  if (raw) {
+    return env
+  }
+
+  for (const key in env) {
+    env[key] = JSON.stringify(env[key])
+  }
+  return {
+    'process.env': env
+  }
 }


### PR DESCRIPTION
Fixes #4658

The reasoning behind the previous change was stated at #3579.

But after a closer look at the webpack documentation, I see that webpack is only against the `process: { env: { NODE_ENV: JSON.stringify('production') } }` style, which would break the `process` object mock, while, in Vue CLI's base config, only `process.env` is replaced, which has a much smaller impact.

By providing the whole `process.env` object, use cases such as the abovementioned destructuring of `process.env` are now supported, which is more intuitive IMO.

What might be problematic is how users customize their env vars that not started with `VUE_APP`. If they follow our example, they may accidentally override the `process.env` object - we've made that mistake too https://github.com/vuejs/vue-cli/blob/02859cf29a3337cdf17926f6b88ac35952faf5c3/packages/%40vue/cli-service/lib/commands/build/resolveWcConfig.js#L56-L62

Letting users tap into our base config is not ideal, either. Because such configuration is very tedious and tends to break between major versions like we already have done.
For this issue, we can later add a section in the documentation guiding them on how to correctly define a custom environment variable - by adding another `DefinePlugin` instance and use the `'process.env.SOME_NAME': '"somevalue"'` syntax.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
