### PR TITLE
chore!: add `@vue/cli` in `--version` output, to avoid confusion

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -21,7 +21,7 @@ function checkNodeVersion (wanted, id) {
   }
 }
 
-checkNodeVersion(requiredVersion, 'vue-cli')
+checkNodeVersion(requiredVersion, '@vue/cli')
 
 if (semver.satisfies(process.version, '9.x')) {
   console.log(chalk.red(
@@ -50,7 +50,7 @@ const program = require('commander')
 const loadCommand = require('../lib/util/loadCommand')
 
 program
-  .version(`Vue CLI ${require('../package').version}`)
+  .version(`@vue/cli ${require('../package').version}`)
   .usage('<command> [options]')
 
 program

--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -50,7 +50,7 @@ const program = require('commander')
 const loadCommand = require('../lib/util/loadCommand')
 
 program
-  .version(require('../package').version)
+  .version(`Vue CLI ${require('../package').version}`)
   .usage('<command> [options]')
 
 program


### PR DESCRIPTION
Sorry for the last-minute breaking change. But I do think it is important to make the branding clearer.
Including the name in the output is also a common practice in command-line tools,
such as `bash`, `brew`, etc. And this change only requires minimal effort for other tools to get the version number from the new output format.

Closes #4514

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
