### PR TITLE
Add note about vue-cli-plugin-gh-pages to deployment docs

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -80,6 +80,8 @@ If you are using the PWA plugin, your app must be served over HTTPS so that [Ser
 
     cd -
     ```
+    
+Also checkout [vue-cli-plugin-gh-pages](https://github.com/JaZo/vue-cli-plugin-gh-pages).
 
 #### Using Travis CI for automatic updates
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

I'm the author of [vue-cli-plugin-gh-pages](https://github.com/JaZo/vue-cli-plugin-gh-pages), a Vue CLI plugin wrapping [gh-pages](https://github.com/tschaub/gh-pages). It would be helpfull for users if a link to this plugin is added to the documentation about deployments.