### PR TITLE
fix: fix "lint on commit" projects generation error

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -42,7 +42,7 @@ module.exports = (api, {
     if (lintOn.includes('commit')) {
       api.extendPackage({
         devDependencies: {
-          'lint-staged': '^8.1.5'
+          'lint-staged': '^9.4.2'
         },
         gitHooks: {
           'pre-commit': 'lint-staged'

--- a/packages/@vue/cli-ui/package.json
+++ b/packages/@vue/cli-ui/package.json
@@ -78,7 +78,7 @@
     "cross-env": "^5.1.5",
     "eslint": "^5.16.0",
     "eslint-plugin-graphql": "^3.0.3",
-    "lint-staged": "^8.1.5",
+    "lint-staged": "^9.4.2",
     "lodash.debounce": "^4.0.8",
     "portal-vue": "^1.3.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
Fix the "ENOENT: no such file or directory … debugnode_module/sms/index.js" error.

The problem are caused by 2 issues:
1. The `lint-staged` packages introduced an old version of debug,
causing node_module deduping, thus changing the node_module layout
2. The dependencies required in the cached `lint` module is no longer at
its originial position, thus the "ENOENT" error.

This change still does not fix the PNPM 4 issue, considering its smaller
user base, we'll fix it later.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
