### PR TITLE
fix: do not install core plugins that have major version bumps

### DIFF
--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -131,7 +131,7 @@ module.exports = class Creator extends EventEmitter {
 
     if (
       // if the latest version contains breaking changes
-      semver.diff(current, latest).includes('major') ||
+      /major/.test(semver.diff(current, latest)) ||
       // or if using `next` branch of cli
       (semver.gte(current, latest) && semver.prerelease(current))
     ) {

--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -129,8 +129,13 @@ module.exports = class Creator extends EventEmitter {
     const { current, latest } = await getVersions()
     let latestMinor = `${semver.major(latest)}.${semver.minor(latest)}.0`
 
-    // if using `next` branch of cli
-    if (semver.gte(current, latest) && semver.prerelease(current)) {
+    if (
+      // if the latest version contains breaking changes
+      semver.diff(current, latest).includes('major') ||
+      // or if using `next` branch of cli
+      (semver.gte(current, latest) && semver.prerelease(current))
+    ) {
+      // fallback to the current cli version number
       latestMinor = current
     }
     // generate package.json with plugin dependencies


### PR DESCRIPTION
Same as the fix for v3: https://github.com/vuejs/vue-cli/pull/4712

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
