### PR TITLE
fix(eslint): autofix code style after scaffolding on older versions of cli

### DIFF
--- a/packages/@vue/cli-plugin-eslint/generator/index.js
+++ b/packages/@vue/cli-plugin-eslint/generator/index.js
@@ -101,6 +101,18 @@ module.exports = (api, { config, lintOn = [] }, _, invoking) => {
       require('@vue/cli-plugin-unit-jest/generator').applyESLint(api)
     }
   }
+
+  // lint & fix after create to ensure files adhere to chosen config
+  // for older versions that do not support the `hooks` feature
+  try {
+    api.assertCliVersion('^4.0.0-beta.0')
+  } catch (e) {
+    if (config && config !== 'base') {
+      api.onCreateComplete(() => {
+        require('../lint')({ silent: true }, api)
+      })
+    }
+  }
 }
 
 // In PNPM v4, due to their implementation of the module resolution mechanism,


### PR DESCRIPTION
For Vue CLI v3.0 - v3.12.0

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
