### PR TITLE
fix(proxy): add connection keep-live option proxy

### DIFF
--- a/packages/@vue/cli-service/lib/util/prepareProxy.js
+++ b/packages/@vue/cli-service/lib/util/prepareProxy.js
@@ -17,7 +17,10 @@ const defaultConfig = {
   secure: false,
   changeOrigin: true,
   ws: true,
-  xfwd: true
+  xfwd: true,
+  headers: {
+    Connection: 'keep-alive'
+  }
 }
 
 module.exports = function prepareProxy (proxy, appPublicFolder) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

I faced a proxy issue for POST call with body contains more than 40.000 characters.

this the error I got:
```
[1] Proxy error: Could not proxy request /rest/v1/hello from localhost:8080 to http://localhost:4300/.
[1] See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ECONNRESET).
[1] [HPM] Error occurred while trying to proxy request /rest/v1/hello from localhost:8080 to http://localhost:4300/ (ECONNRESET) (https://nodejs.org/api/errors.html#errors_common_system_errors)
```

**Steps to reproduce**

vue.config.js
```js
module.exports = {
  publicPath: '.',
  devServer: {
    proxy: {
      '(/rest/.*|/v1/.*)': {
        target: 'http://localhost:4300',
        secure: false,
        logLevel: 'debug'
      }
    }
  }
};
```

server express
```js
const express = require('express');
const router = express.Router();
const app = express();

router
  .get('/rest/v1/hello', (req, res) => res.send({}));

app
  .use(router)
  .listen(4300, () => console.log('App listening at http://localhost:%s', 4300));
```

call from my vue.js application
```
const body = {};/*more than 40.000 characters*/
axios
  .post('/rest/v1/hello', body)
  .then(response => response.data)
  .then(test => commit({type: 'test', test}));
```

after debug, I remarked that the proxy request was "Connection: close" 

So I change it to 'Connection: keep-alive' it fixed this issue

I think this option should be add to proxy default value