### PR TITLE
fix: add `sourceType: 'unambiguous'` to babel preset

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -184,6 +184,7 @@ module.exports = (context, options = {}) => {
   }])
 
   return {
+    sourceType: 'unambiguous',
     overrides: [{
       exclude: [/@babel[\/|\\\\]runtime/, /core-js/],
       presets,


### PR DESCRIPTION
Fixes #4773
The reasoning is stated at https://github.com/vuejs/vue-cli/issues/4773#issuecomment-548241889


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
