### PR TITLE
feat: enable postcss+autoprefixer by default internally, reducing boilerplate

### DIFF
--- a/.postcssrc
+++ b/.postcssrc
@@ -1,5 +1,0 @@
-{
-  "plugins": {
-    "autoprefixer": {}
-  }
-}

--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -14,11 +14,6 @@ module.exports = (api, options) => {
     devDependencies: {
       'vue-template-compiler': '^2.6.10'
     },
-    'postcss': {
-      'plugins': {
-        'autoprefixer': {}
-      }
-    },
     browserslist: [
       '> 1%',
       'last 2 versions'

--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -82,6 +82,14 @@ module.exports = (api, rootOptions) => {
       '.postcssrc.json'
     ]))
 
+    if (!hasPostCSSConfig) {
+      loaderOptions.postcss = {
+        plugins: [
+          require('autoprefixer')
+        ]
+      }
+    }
+
     // if building for production but not extracting CSS, we need to minimize
     // the embbeded inline CSS as they will not be going through the optimizing
     // plugin.
@@ -139,7 +147,7 @@ module.exports = (api, rootOptions) => {
           sourceMap,
           importLoaders: (
             1 + // stylePostLoader injected by vue-loader
-            (hasPostCSSConfig ? 1 : 0) +
+            1 + // postcss-loader
             (needInlineMinification ? 1 : 0)
           )
         }, loaderOptions.css)
@@ -168,12 +176,10 @@ module.exports = (api, rootOptions) => {
             })
         }
 
-        if (hasPostCSSConfig) {
-          rule
-            .use('postcss-loader')
-            .loader(require.resolve('postcss-loader'))
-            .options(Object.assign({ sourceMap }, loaderOptions.postcss))
-        }
+        rule
+          .use('postcss-loader')
+          .loader(require.resolve('postcss-loader'))
+          .options(Object.assign({ sourceMap }, loaderOptions.postcss))
 
         if (loader) {
           let resolvedLoader

--- a/packages/@vue/cli-ui-addon-webpack/.postcssrc
+++ b/packages/@vue/cli-ui-addon-webpack/.postcssrc
@@ -1,5 +1,0 @@
-{
-  "plugins": {
-    "autoprefixer": {}
-  }
-}

--- a/packages/@vue/cli-ui-addon-widgets/postcss.config.js
+++ b/packages/@vue/cli-ui-addon-widgets/postcss.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: {
-    autoprefixer: {}
-  }
-}

--- a/packages/@vue/cli-ui/.postcssrc
+++ b/packages/@vue/cli-ui/.postcssrc
@@ -1,5 +1,0 @@
-{
-  "plugins": {
-    "autoprefixer": {}
-  }
-}

--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -429,7 +429,7 @@ module.exports = class Creator extends EventEmitter {
         name: 'useConfigFiles',
         when: isManualMode,
         type: 'list',
-        message: 'Where do you prefer placing config for Babel, PostCSS, ESLint, etc.?',
+        message: 'Where do you prefer placing config for Babel, ESLint, etc.?',
         choices: [
           {
             name: 'In dedicated config files',


### PR DESCRIPTION
This also fixes the issue with Yarn PnP that requires `autoprefixer` to
be explicitly listed in the user's project dependency.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
