### PR TITLE
fix(serve): pass devServer sockPath properly to client

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -126,9 +126,10 @@ module.exports = (api, options) => {
 
     // inject dev & hot-reload middleware entries
     if (!isProduction) {
+      const sockPath = projectDevServerOptions.sockPath || '/sockjs-node'
       const sockjsUrl = publicUrl
         // explicitly configured via devServer.public
-        ? `?${publicUrl}/sockjs-node`
+        ? `?${publicUrl}&sockPath=${sockPath}`
         : isInContainer
           // can't infer public network url if inside a container...
           // use client-side inference (note this would break with non-root publicPath)
@@ -137,9 +138,8 @@ module.exports = (api, options) => {
           : `?` + url.format({
             protocol,
             port,
-            hostname: urls.lanUrlForConfig || 'localhost',
-            pathname: '/sockjs-node'
-          })
+            hostname: urls.lanUrlForConfig || 'localhost'
+          }) + `&sockPath=${sockPath}`
       const devClients = [
         // dev server client
         require.resolve(`webpack-dev-server/client`) + sockjsUrl,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

When you change the `devServer.sockPath` setting, one of the required `webpack-devserver-client` ignores the `sockPath` setting. This is visible in your developer console: the local sockjs url connects but the network sockjs fails.

This is caused by incorrectly providing the `sockPath` to the webpack client. It infers the host and port from the provided URL parameter but not the sockPath, which has to be specified as an additional parameter. This PR removes the path part from the `sockjsUrl` (as it does nothing) and adds the `sockPath` as additional param.

