### PR TITLE
fix docs `css.loaderOptions.css.localsConvention`

### DIFF
--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -112,9 +112,9 @@ module.exports = {
         // For Vue CLI v3 users, please refer to css-loader v1 documentations
         // https://github.com/webpack-contrib/css-loader/tree/v1.0.1
         modules: {
-          localIdentName: '[name]-[hash]',
-          localsConvention: 'camelCaseOnly'
-        }
+          localIdentName: '[name]-[hash]'
+        },
+        localsConvention: 'camelCaseOnly'
       }
     }
   }


### PR DESCRIPTION
Moved 'localsConvention' to the same level as 'modules'.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
I only tested on macOS.

logs from css-loader's

```
[Function: validate] {
  schema: {
    additionalProperties: false,
    properties: {
      url: [Object],
      import: [Object],
      modules: [Object],
      sourceMap: [Object],
      importLoaders: [Object],
      localsConvention: [Object],
      onlyLocals: [Object]
    },
    type: 'object'
  },
  errors: null,
  refs: {},
  refVal: [ [Circular] ],
  root: [Circular]
}
```