### PR TITLE
types(router): added router array type for Array RouteConfig

### DIFF
--- a/packages/@vue/cli-plugin-router/generator/index.js
+++ b/packages/@vue/cli-plugin-router/generator/index.js
@@ -10,7 +10,8 @@ module.exports = (api, options = {}) => {
 
   api.render('./template', {
     historyMode: options.historyMode,
-    doesCompile: api.hasPlugin('babel') || api.hasPlugin('typescript')
+    doesCompile: api.hasPlugin('babel') || api.hasPlugin('typescript'),
+    hasTypeScript: api.hasPlugin('typescript')
   })
 
   if (api.invoking) {

--- a/packages/@vue/cli-plugin-router/generator/template/src/router/index.js
+++ b/packages/@vue/cli-plugin-router/generator/template/src/router/index.js
@@ -1,10 +1,16 @@
 import Vue from 'vue'
+<%_ if (hasTypeScript) { _%>
+import VueRouter, { RouteConfig } from 'vue-router'
+<%_ } else { _%>
 import VueRouter from 'vue-router'
+<%_ } _%>
 import Home from '../views/Home.vue'
 
-Vue.use(VueRouter)
-
-const routes = [
+<%_ if (hasTypeScript) { _%>
+  const routes = <Array<RouteConfig>>[
+<%_ } else { _%>
+  const routes = [
+<%_ } _%>
   {
     path: '/',
     name: 'home',
@@ -25,6 +31,8 @@ const routes = [
     <%_ } _%>
   }
 ]
+
+Vue.use(VueRouter)
 
 const router = new VueRouter({
   <%_ if (historyMode) { _%>

--- a/packages/@vue/cli-plugin-router/generator/template/src/router/index.js
+++ b/packages/@vue/cli-plugin-router/generator/template/src/router/index.js
@@ -6,6 +6,8 @@ import VueRouter from 'vue-router'
 <%_ } _%>
 import Home from '../views/Home.vue'
 
+Vue.use(VueRouter)
+
 <%_ if (hasTypeScript) { _%>
   const routes: Array<RouteConfig> = [
 <%_ } else { _%>
@@ -31,8 +33,6 @@ import Home from '../views/Home.vue'
     <%_ } _%>
   }
 ]
-
-Vue.use(VueRouter)
 
 const router = new VueRouter({
   <%_ if (historyMode) { _%>

--- a/packages/@vue/cli-plugin-router/generator/template/src/router/index.js
+++ b/packages/@vue/cli-plugin-router/generator/template/src/router/index.js
@@ -7,7 +7,7 @@ import VueRouter from 'vue-router'
 import Home from '../views/Home.vue'
 
 <%_ if (hasTypeScript) { _%>
-  const routes = <Array<RouteConfig>>[
+  const routes: Array<RouteConfig> = [
 <%_ } else { _%>
   const routes = [
 <%_ } _%>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
This PR adds the type annotation to the const routes in router/index.ts when vue-router and TypeScript are selected in the CLI.
❌If you use the @vue/composition-api with both, router and TS selected, and error will pop up in the console as a shown in this image: [https://i.imgur.com/NXugrHy.png](https://i.imgur.com/NXugrHy.png)

✅ After you add the annotation as stated in this PR there is no error shown in the console: 
[https://i.imgur.com/rq0S34U.png](https://i.imgur.com/rq0S34U.png)

**Note:** ❌ If you add the annotation type like `const routes:<Array<RouteConfig>>` an error will occur and won't accept the error:  [https://i.imgur.com/5gytWju.png](https://i.imgur.com/5gytWju.png)