### PR TITLE
fix(lib): replace "url" module with simple string split (close #4667)

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/formatStats.js
+++ b/packages/@vue/cli-service/lib/commands/build/formatStats.js
@@ -21,7 +21,7 @@ module.exports = function formatStats (stats, dir, api) {
   const isMinJS = val => /\.min\.js$/.test(val)
   assets = assets
     .map(a => {
-      a.name = a.name.split(`?`)[0]
+      a.name = a.name.split('?')[0]
       return a
     })
     .filter(a => {

--- a/packages/@vue/cli-service/lib/commands/build/formatStats.js
+++ b/packages/@vue/cli-service/lib/commands/build/formatStats.js
@@ -4,7 +4,6 @@ module.exports = function formatStats (stats, dir, api) {
   const zlib = require('zlib')
   const chalk = require('chalk')
   const ui = require('cliui')({ width: 80 })
-  const url = require('url')
 
   const json = stats.toJson({
     hash: false,
@@ -22,7 +21,7 @@ module.exports = function formatStats (stats, dir, api) {
   const isMinJS = val => /\.min\.js$/.test(val)
   assets = assets
     .map(a => {
-      a.name = url.parse(a.name).pathname
+      a.name = a.name.split(`?`)[0]
       return a
     })
     .filter(a => {


### PR DESCRIPTION
Fixes issue #4667 by implementing the proposal https://github.com/vuejs/vue-cli/issues/4667#issuecomment-548464520 (I opened that issue and checked if this change really fixes the issue I had - it does)
Also gets rid of a node module by using simpler code for removing eventual GET parameters

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
