### PR TITLE
fix: don't prepend publicPath with slash

### DIFF
--- a/packages/@vue/cli-service/__tests__/Service.spec.js
+++ b/packages/@vue/cli-service/__tests__/Service.spec.js
@@ -104,6 +104,16 @@ test('normalize publicPath when relative', () => {
   expect(service.projectOptions.publicPath).toBe('foo/bar/')
 })
 
+test('allow custom protocol in publicPath', () => {
+  mockPkg({
+    vue: {
+      publicPath: 'customprotocol://foo/bar'
+    }
+  })
+  const service = createMockService()
+  expect(service.projectOptions.publicPath).toBe('customprotocol://foo/bar/')
+})
+
 test('keep publicPath when empty', () => {
   mockPkg({
     vue: {

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -395,11 +395,8 @@ module.exports = class Service {
 }
 
 function ensureSlash (config, key) {
-  let val = config[key]
+  const val = config[key]
   if (typeof val === 'string') {
-    if (!/^https?:/.test(val)) {
-      val = val.replace(/^([^/.])/, '/$1')
-    }
     config[key] = val.replace(/([^/])$/, '$1/')
   }
 }


### PR DESCRIPTION
fixes #3338
fixes #4184

Actually I don't know why the slash was added in the first place, seems
extraneous to me.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
