### PR TITLE
Replace chalk.reset with stripAnsi in @vue/cli-shared-utils/lib/logger.js

### DIFF
--- a/packages/@vue/cli-shared-utils/lib/logger.js
+++ b/packages/@vue/cli-shared-utils/lib/logger.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk')
+const stripAnsi = require('strip-ansi');
 const readline = require('readline')
 const padStart = require('string.prototype.padstart')
 const EventEmitter = require('events')
@@ -19,7 +20,7 @@ const format = (label, msg) => {
   return msg.split('\n').map((line, i) => {
     return i === 0
       ? `${label} ${line}`
-      : padStart(line, chalk.reset(label).length)
+      : padStart(line, stripAnsi(label).length)
   }).join('\n')
 }
 

--- a/packages/@vue/cli-shared-utils/lib/logger.js
+++ b/packages/@vue/cli-shared-utils/lib/logger.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk')
-const stripAnsi = require('strip-ansi');
+const stripAnsi = require('strip-ansi')
 const readline = require('readline')
 const padStart = require('string.prototype.padstart')
 const EventEmitter = require('events')

--- a/packages/@vue/cli-shared-utils/package.json
+++ b/packages/@vue/cli-shared-utils/package.json
@@ -32,7 +32,7 @@
     "request-promise-native": "^1.0.7",
     "semver": "^6.1.0",
     "string.prototype.padstart": "^3.0.0",
-    "strip-ansi" : "^6.0.0",
+    "strip-ansi" : "^6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vue/cli-shared-utils/package.json
+++ b/packages/@vue/cli-shared-utils/package.json
@@ -31,7 +31,8 @@
     "request": "^2.87.0",
     "request-promise-native": "^1.0.7",
     "semver": "^6.1.0",
-    "string.prototype.padstart": "^3.0.0"
+    "string.prototype.padstart": "^3.0.0",
+    "strip-ansi" : "^6.0.0",
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
When logging multi-line logs, the logger uses chalk.reset in order to get the length of the tag for the log. This is to achieve an indented layout of multi-line logs. However, chalk.reset only replaces styles such as **bold** and *italic*, not color, see [GitHub issue](https://github.com/chalk/chalk/issues/62). When the tag contains colors, the result is not pretty. Replacing with stripAnsi gets the intended result.

I found this behavior when using the GeneratorApi.exitLog function, when building a custom preset for vue-cli. Any multi-line entry is not well-formatted, and adding multiple exitLog calls gets rather noisy, since the logger adds the preset name as the preceding tag.

**Note**: This introduces a new require of "strip-ansi". If that is okay or not for vue-cli, I am not sure. 