### PR TITLE
fix(cli-service): fix duplicate webpack-dev-server/client

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -164,6 +164,8 @@ module.exports = (api, options) => {
     const server = new WebpackDevServer(compiler, Object.assign({
       logLevel: 'silent',
       clientLogLevel: 'silent',
+      // 'Inline mode (set to false to disable including client scripts like livereload)',
+      inline: false,
       historyApiFallback: {
         disableDotRule: true,
         rewrites: genHistoryApiFallbackRewrites(options.publicPath, options.pages)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

WebpackDevServer will add client scripts to entry by default, result in duplicate `webpack-dev-server/client`.

