### PR TITLE
feat(lint): add output file option (close #4849)

### DIFF
--- a/packages/@vue/cli-plugin-eslint/README.md
+++ b/packages/@vue/cli-plugin-eslint/README.md
@@ -15,6 +15,7 @@
     --no-fix             do not fix errors
     --max-errors         specify number of errors to make build failed (default: 0)
     --max-warnings       specify number of warnings to make build failed (default: Infinity)
+    --output-file        specify file to write report to
   ```
 
   Lints and fixes files. If no specific files are given, it lints all files in `src` and `test`.

--- a/packages/@vue/cli-plugin-eslint/README.md
+++ b/packages/@vue/cli-plugin-eslint/README.md
@@ -20,7 +20,7 @@
 
   Lints and fixes files. If no specific files are given, it lints all files in `src` and `test`.
 
-  Other [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options) are also supported.
+  Other [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options) are not supported.
 
 ## Configuration
 

--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -72,7 +72,9 @@ module.exports = (api, options) => {
         '--max-errors [limit]':
           'specify number of errors to make build failed (default: 0)',
         '--max-warnings [limit]':
-          'specify number of warnings to make build failed (default: Infinity)'
+          'specify number of warnings to make build failed (default: Infinity)',
+        '--output-file [file_path]':
+          'specify file to write report to'
       },
       details:
         'For more options, see https://eslint.org/docs/user-guide/command-line-interface#options'

--- a/packages/@vue/cli-plugin-eslint/lint.js
+++ b/packages/@vue/cli-plugin-eslint/lint.js
@@ -15,7 +15,8 @@ const renamedArgs = {
   rule: 'rules',
   eslintrc: 'useEslintrc',
   c: 'configFile',
-  config: 'configFile'
+  config: 'configFile',
+  'output-file': 'outputFile'
 }
 
 module.exports = function lint (args = {}, api) {
@@ -82,6 +83,16 @@ module.exports = function lint (args = {}, api) {
   process.cwd = processCwd
 
   const formatter = engine.getFormatter(args.format || 'codeframe')
+
+  if (config.outputFile) {
+    const outputFilePath = path.resolve(config.outputFile)
+    try {
+      fs.writeFileSync(outputFilePath, formatter(report.results))
+      log(`Lint results saved to ${chalk.blue(outputFilePath)}`)
+    } catch (err) {
+      log(`Error saving lint results to ${chalk.blue(outputFilePath)}: ${chalk.red(err)}`)
+    }
+  }
 
   if (config.fix) {
     CLIEngine.outputFixes(report)


### PR DESCRIPTION
Add an `output-file` option to the ESLint plugin that saves lint report results to the specified file path.

This mimics the [ESLint option](https://eslint.org/docs/user-guide/command-line-interface#options) of the same name

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Closes #4849