### PR TITLE
fix: support `parser` option for codemods, and enable ts parsing by default

### DIFF
--- a/packages/@vue/cli/__tests__/Generator.spec.js
+++ b/packages/@vue/cli/__tests__/Generator.spec.js
@@ -23,6 +23,7 @@ new Vue({
 }).$mount('#app')
 `.trim())
 fs.writeFileSync(path.resolve(templateDir, 'empty-entry.js'), `;`)
+fs.writeFileSync(path.resolve(templateDir, 'main.ts'), `const a: string = 'hello';`)
 fs.writeFileSync(path.resolve(templateDir, 'hello.vue'), `
 <template>
   <p>Hello, {{ msg }}</p>
@@ -528,6 +529,23 @@ test('api: injectImports to empty file', async () => {
 
   await generator.generate()
   expect(fs.readFileSync('/main.js', 'utf-8')).toMatch(/import foo from 'foo'\r?\nimport bar from 'bar'/)
+})
+
+test('api: injectImports to typescript file', async () => {
+  const generator = new Generator('/', { plugins: [
+    {
+      id: 'test',
+      apply: api => {
+        api.injectImports('main.ts', `import foo from 'foo'`)
+        api.render({
+          'main.ts': path.join(templateDir, 'main.ts')
+        })
+      }
+    }
+  ] })
+
+  await generator.generate()
+  expect(fs.readFileSync('/main.ts', 'utf-8')).toMatch(/import foo from 'foo'/)
 })
 
 test('api: addEntryDuplicateImport', async () => {

--- a/packages/@vue/cli/lib/util/runCodemod.js
+++ b/packages/@vue/cli/lib/util/runCodemod.js
@@ -1,6 +1,30 @@
-const jscodeshift = require('jscodeshift')
 const adapt = require('vue-jscodeshift-adapter')
+let jscodeshift = require('jscodeshift')
 
-module.exports = function runCodemod (transform, fileInfo, options) {
-  return adapt(transform)(fileInfo, { jscodeshift }, options || {})
+module.exports = function runCodemod (transformModule, fileInfo, options = {}) {
+  const transform = typeof transformModule.default === 'function'
+    ? transformModule.default
+    : transformModule
+
+  let parser = transformModule.parser || options.parser
+  if (!parser) {
+    if (fileInfo.path.endsWith(('.ts'))) {
+      parser = 'ts'
+    } else if (fileInfo.path.endsWith('.tsx')) {
+      parser = 'tsx'
+    }
+  }
+
+  if (parser) {
+    jscodeshift = jscodeshift.withParser(parser)
+  }
+
+  const api = {
+    jscodeshift,
+    j: jscodeshift,
+    stats: () => {},
+    report: () => {}
+  }
+
+  return adapt(transform)(fileInfo, api, options)
 }


### PR DESCRIPTION
fixes #4861
closes #4835

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
