### PR TITLE
warn only production builds output service workers

### DIFF
--- a/docs/guide/mode-and-env.md
+++ b/docs/guide/mode-and-env.md
@@ -28,6 +28,11 @@ When you are running `vue-cli-service build`, your `NODE_ENV` should always be s
 If you have a default `NODE_ENV` in your environment, you should either remove it or explicitly set `NODE_ENV` when running `vue-cli-service` commands.
 :::
 
+::: warning service worker
+A side effect of the current mode is what service worker you will get.
+A service worker file is output only in `production` mode.
+:::
+
 ## Environment Variables
 
 You can specify env variables by placing the following files in your project root:


### PR DESCRIPTION
Let people know that a side effect of specifying the mode determines what you'll get for a service worker. I was surprised when I deployed a development build to a private QA server and my `service-worker.js` file was missing.

My suggested changes can use some improvement. I'm hoping someone can help make it more thorough by listing what to expect for service worker output, for each mode.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
