### PR TITLE
fix: remove "[Beta]" from page title

### DIFF
--- a/packages/@vue/cli-ui/src/App.vue
+++ b/packages/@vue/cli-ui/src/App.vue
@@ -19,7 +19,7 @@ import ROUTE_REQUESTED from '@/graphql/app/routeRequested.gql'
 
 export default {
   metaInfo: {
-    titleTemplate: chunk => chunk ? `[Beta] ${chunk} - Vue CLI` : '[Beta] Vue CLI'
+    titleTemplate: chunk => chunk ? `${chunk} - Vue CLI` : 'Vue CLI'
   },
 
   computed: {


### PR DESCRIPTION
vue cli ui is not in beta anymore, is it?

![image](https://user-images.githubusercontent.com/15625235/69853909-7e46af00-12ba-11ea-9a67-be0ca4936fd5.png)

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:

Improvment?

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
