### PR TITLE
fix: comment eslint disable in cypress config

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/plugins/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/generator/template/tests/e2e/plugins/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable arrow-body-style */
 // https://docs.cypress.io/guides/guides/plugins-guide.html
 
 // if you need a custom webpack configuration you can uncomment the following import
@@ -5,7 +6,7 @@
 // as explained in the cypress docs
 // https://docs.cypress.io/api/plugins/preprocessors-api.html#Examples
 
-/* eslint-disable import/no-extraneous-dependencies, global-require, arrow-body-style */
+// /* eslint-disable import/no-extraneous-dependencies, global-require */
 // const webpack = require('@cypress/webpack-preprocessor')
 
 module.exports = (on, config) => {


### PR DESCRIPTION
The current cypress config has a global eslint-disable:

typescript
```
/* eslint-disable import/no-extraneous-dependencies, global-require, arrow-body-style */
// const webpack = require('@cypress/webpack-preprocessor')
```

But this assumes that `eslint-import-plugin` is present, whereas this is only true when the selected preset is the Airbnb one.
In other cases, this fails `yarn lint` right away with:

```
error: Definition for rule 'import/no-extraneous-dependencies' was not found (import/no-extraneous-dependencies) at tests/e2e/plugins/index.js
```

Even if using the Airbnb preset, the comment does not have any effect, as, by default, the `require` call is commented.

This commit now splits the rules disabling in two:

- one commented for the people using Airbnb and who will uncomment the require call below, as it is only useful for them.
- one activated that disables `arrow-body-style` as it will fail the linting for people using Airbnb preset with the current config.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
