### PR TITLE
feat: specify babel runtime version

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -53,6 +53,7 @@ module.exports = (context, options = {}) => {
   }
 
   const runtimePath = path.dirname(require.resolve('@babel/runtime/package.json'))
+  const runtimeVersion = require('@babel/runtime/package.json').version
   const {
     polyfills: userPolyfills,
     loose = false,
@@ -78,7 +79,13 @@ module.exports = (context, options = {}) => {
     // However, this may cause hash inconsistency if the project is moved to another directory.
     // So here we allow user to explicit disable this option if hash consistency is a requirement
     // and the runtime version is sure to be correct.
-    absoluteRuntime = runtimePath
+    absoluteRuntime = runtimePath,
+
+    // https://babeljs.io/docs/en/babel-plugin-transform-runtime#version
+    // By default transform-runtime assumes that @babel/runtime@7.0.0-beta.0 is installed, which means helpers introduced later than 7.0.0-beta.0 will be inlined instead of imported.
+    // See https://github.com/babel/babel/issues/10261
+    // And https://github.com/facebook/docusaurus/pull/2111
+    version = runtimeVersion
   } = options
 
   // resolve targets
@@ -180,7 +187,9 @@ module.exports = (context, options = {}) => {
     helpers: useBuiltIns === 'usage',
     useESModules: !process.env.VUE_CLI_BABEL_TRANSPILE_MODULES,
 
-    absoluteRuntime
+    absoluteRuntime,
+
+    version
   }])
 
   return {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

`@babel/plugin-transform-runtime` has an option named [version](https://babeljs.io/docs/en/babel-plugin-transform-runtime#version).

By default `@babel/plugin-transform-runtime` assumes that `@babel/runtime@7.0.0-beta.0` is installed, which means helpers introduced later than `7.0.0-beta.0` will be **inlined** instead of **imported**. Which in turn leads to a larger bundle size.

See https://github.com/babel/babel/issues/10261 and https://github.com/facebook/docusaurus/pull/2111