### PR TITLE
docs: mention navigateFallback option for PWA App Shell caching

### DIFF
--- a/docs/core-plugins/pwa.md
+++ b/docs/core-plugins/pwa.md
@@ -31,6 +31,11 @@ file, or the `"vue"` field in `package.json`.
 
   These options are passed on through to the underlying `workbox-webpack-plugin`.
 
+  If you're using the App Shell pattern with the `GenerateSW` mode, you can configure your entry point like this to make sure all your pages load offline:
+  ```js
+  navigateFallback: 'index.html'
+  ```
+
   For more information on what values are supported, please see the guide for
   [`GenerateSW`](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#full_generatesw_config)
   or for [`InjectManifest`](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#full_injectmanifest_config).


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

The [navigateFallback](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#generateSW-navigateFallback) option is disabled by default but it is crucial to make an SPA work offline.

I was struggling to make my app work offline until I found this comment: https://github.com/vuejs/vue-cli/issues/717#issuecomment-382079361
So I believe this should be mentioned in the docs.

Feel free to update the wording.