### PR TITLE
fix(e2e-nightwatch): check for correct flag name

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/__tests__/nightwatchPlugin.spec.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/__tests__/nightwatchPlugin.spec.js
@@ -69,7 +69,7 @@ describe('nightwatch e2e plugin', () => {
   })
 
   test('should run single test with custom nightwatch.json and selenium server', async () => {
-    await project.run(`vue-cli-service test:e2e --headless --with-selenium -t tests/e2e/specs/test.js`)
+    await project.run(`vue-cli-service test:e2e --headless --use-selenium -t tests/e2e/specs/test.js`)
     let results = await project.read('test_results.json')
     results = JSON.parse(results)
 

--- a/packages/@vue/cli-plugin-e2e-nightwatch/index.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/index.js
@@ -65,7 +65,7 @@ module.exports = (api, options) => {
         rawArgs.push('--env', 'chrome')
       }
 
-      if (args['with-selenium']) {
+      if (args['use-selenium']) {
         process.env.VUE_NIGHTWATCH_USE_SELENIUM = '1'
       }
 


### PR DESCRIPTION
flag is documented as `--use-selenium` but we checked for `args['with-selenium']`
fix #5015

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
