### PR TITLE
feat: don't throw on console/debugger statements for `vue serve`

### DIFF
--- a/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
+++ b/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
@@ -112,6 +112,10 @@ module.exports = function createConfigPlugin (context, entry, asLib) {
                   ],
                   parserOptions: {
                     parser: 'babel-eslint'
+                  },
+                  rules: {
+                    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+                    'no-debugger': `process.env.NODE_ENV === 'production' ? 'error' : 'off'`
                   }
                 }
               }))


### PR DESCRIPTION
1. they're useful in development
2. to be in line with the default preset

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
