### PR TITLE
fix: extendPackage object values should be string

### DIFF
--- a/packages/@vue/cli/__tests__/Generator.spec.js
+++ b/packages/@vue/cli/__tests__/Generator.spec.js
@@ -280,6 +280,30 @@ test('api: warn invalid dep range', async () => {
   })).toBe(true)
 })
 
+test('api: warn invalid dep range when non-string', async () => {
+  const generator = new Generator('/', { plugins: [
+    {
+      id: 'test1',
+      apply: api => {
+        api.extendPackage({
+          dependencies: {
+            foo: null
+          }
+        })
+      }
+    }
+  ] })
+
+  await generator.generate()
+
+  expect(logs.warn.some(([msg]) => {
+    return (
+      msg.match(/invalid version range for dependency "foo"/) &&
+      msg.match(/injected by generator "test1"/)
+    )
+  })).toBe(true)
+})
+
 test('api: extendPackage dependencies conflict', async () => {
   const generator = new Generator('/', { plugins: [
     {

--- a/packages/@vue/cli/lib/util/mergeDeps.js
+++ b/packages/@vue/cli/lib/util/mergeDeps.js
@@ -10,9 +10,10 @@ module.exports = function resolveDeps (generatorId, to, from, sources, forceNewV
   for (const name in from) {
     const r1 = to[name]
     const r2 = from[name]
+    const r2IsString = typeof r2 === 'string'
     const sourceGeneratorId = sources[name]
-    const isValidURI = r2.match(/^(?:file|git|git\+ssh|git\+http|git\+https|git\+file|https?):/) != null
-    const isValidGitHub = r2.match(/^[^/]+\/[^/]+/) != null
+    const isValidURI = r2IsString && r2.match(/^(?:file|git|git\+ssh|git\+http|git\+https|git\+file|https?):/) != null
+    const isValidGitHub = r2IsString && r2.match(/^[^/]+\/[^/]+/) != null
 
     // if they are the same, do nothing. Helps when non semver type deps are used
     if (r1 === r2) continue


### PR DESCRIPTION
Fixes the following issue:

```

🚀  Invoking generator for vue-cli-plugin-storybook...
 ERROR  TypeError: Cannot read property 'match' of undefined
TypeError: Cannot read property 'match' of undefined
    at resolveDeps (/home/circleci/vue-cli-plugin-storybook/node_modules/@vue/cli/lib/util/mergeDeps.js:14:27)
    at GeneratorAPI.extendPackage (/home/circleci/vue-cli-plugin-storybook/node_modules/@vue/cli/lib/GeneratorAPI.js:195:20)
    at module.exports (/home/circleci/vue-cli-plugin-storybook/tmp/node_modules/vue-cli-plugin-storybook/generator/index.js:9:7)
    at Generator.initPlugins (/home/circleci/vue-cli-plugin-storybook/node_modules/@vue/cli/lib/Generator.js:150:13)
    at Generator.generate (/home/circleci/vue-cli-plugin-storybook/node_modules/@vue/cli/lib/Generator.js:168:16)
    at runGenerator (/home/circleci/vue-cli-plugin-storybook/node_modules/@vue/cli/lib/invoke.js:124:19)
    at process._tickCallback (internal/process/next_tick.js:68:7)


```

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
