### PR TITLE
docs: mention the precedence of `.vue` & `.ts(x)` extensions

### DIFF
--- a/docs/migrating-from-v3/README.md
+++ b/docs/migrating-from-v3/README.md
@@ -266,7 +266,7 @@ As in the cypress plugin, the support for legacy `vue-cli-service e2e` command h
 
 ### `@vue/cli-plugin-typescript`
 
-When using Typescript, the webpack resolve options now [prefer `ts(x)` file extensions over `js(x)` ones](https://github.com/vuejs/vue-cli/pull/3909).
+When importing a file without extension, the webpack resolve options now prefer [prefer `.ts(x)` files over `.js(x)` and `.vue` ones](https://github.com/vuejs/vue-cli/pull/3909). We strongly recommend you to always include the file extension when importing `.vue` files.
 
 ### `@vue/cli-plugin-unit-jest`
 


### PR DESCRIPTION
closes #4936

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
