### PR TITLE
fix `afterInvoke`/`onCreateComplete` callbacks in Migrator

### DIFF
--- a/packages/@vue/cli/lib/Migrator.js
+++ b/packages/@vue/cli/lib/Migrator.js
@@ -6,14 +6,14 @@ module.exports = class Migrator extends Generator {
     plugin,
 
     pkg = {},
-    completeCbs = [],
+    afterInvokeCbs = [],
     files = {},
     invoking = false
   } = {}) {
     super(context, {
       pkg,
       plugins: [],
-      completeCbs,
+      afterInvokeCbs,
       files,
       invoking
     })

--- a/packages/@vue/cli/lib/Upgrader.js
+++ b/packages/@vue/cli/lib/Upgrader.js
@@ -118,13 +118,13 @@ module.exports = class Upgrader {
       installed: options.installed
     }
 
-    const createCompleteCbs = []
+    const afterInvokeCbs = []
     const migrator = new Migrator(this.context, {
       plugin: plugin,
 
       pkg: this.pkg,
       files: await readFiles(this.context),
-      completeCbs: createCompleteCbs,
+      afterInvokeCbs,
       invoking: true
     })
 
@@ -146,9 +146,9 @@ module.exports = class Upgrader {
       await this.pm.install()
     }
 
-    if (createCompleteCbs.length) {
+    if (afterInvokeCbs.length) {
       logWithSpinner('⚓', `Running completion hooks...`)
-      for (const cb of createCompleteCbs) {
+      for (const cb of afterInvokeCbs) {
         await cb()
       }
       stopSpinner()


### PR DESCRIPTION
closes #4837

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
