### PR TITLE
fix: pwa-plugin avoid generating manifest when path is an URL

### DIFF
--- a/packages/@vue/cli-plugin-pwa/README.md
+++ b/packages/@vue/cli-plugin-pwa/README.md
@@ -69,7 +69,7 @@ file, or the `"vue"` field in `package.json`.
 
   - Default: `'manifest.json'`
 
-    The path of app’s manifest.
+    The path of app’s manifest. If the path is an URL, the plugin won't generate a manifest.json in the dist directory during the build.
 
 - **pwa.manifestOptions**
 

--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -151,27 +151,29 @@ module.exports = class HtmlPwaPlugin {
       })
     })
 
-    compiler.hooks.emit.tapAsync(ID, (data, cb) => {
-      const {
-        name,
-        themeColor,
-        manifestPath,
-        manifestOptions
-      } = this.options
-      const publicOptions = {
-        name,
-        short_name: name,
-        theme_color: themeColor
-      }
-      const outputManifest = JSON.stringify(
-        Object.assign(publicOptions, defaultManifest, manifestOptions)
-      )
-      data.assets[manifestPath] = {
-        source: () => outputManifest,
-        size: () => outputManifest.length
-      }
-      cb(null, data)
-    })
+    if (!isHrefAbsoluteUrl(this.options.manifestPath)) {
+      compiler.hooks.emit.tapAsync(ID, (data, cb) => {
+        const {
+          name,
+          themeColor,
+          manifestPath,
+          manifestOptions
+        } = this.options
+        const publicOptions = {
+          name,
+          short_name: name,
+          theme_color: themeColor
+        }
+        const outputManifest = JSON.stringify(
+          Object.assign(publicOptions, defaultManifest, manifestOptions)
+        )
+        data.assets[manifestPath] = {
+          source: () => outputManifest,
+          size: () => outputManifest.length
+        }
+        cb(null, data)
+      })
+    }
   }
 }
 
@@ -185,8 +187,12 @@ function makeTag (tagName, attributes, closeTag = false) {
 
 function getTagHref (publicPath, href, assetsVersionStr) {
   let tagHref = `${href}${assetsVersionStr}`
-  if (!(/(http(s?)):\/\//gi.test(href))) {
+  if (!isHrefAbsoluteUrl(href)) {
     tagHref = `${publicPath}${tagHref}`
   }
   return tagHref
+}
+
+function isHrefAbsoluteUrl (href) {
+  return /(http(s?)):\/\//gi.test(href)
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

This PR is a bug fix which occure when you specify an URL inside the config's manifestPath option.

The bug is not blocking the `vue-cli-service build` command, but it throws a misleading error because it attemps to create a directory for the manifest, which is impossible when it is a full URL.