### PR TITLE
refactor: use createRequire to load/resolve modules

### DIFF
--- a/packages/@vue/cli-shared-utils/lib/module.js
+++ b/packages/@vue/cli-shared-utils/lib/module.js
@@ -52,23 +52,25 @@ exports.resolveModule = function (request, context) {
   let resolvedPath
   try {
     try {
-      resolvedPath = createRequire(context).resolve(request)
+      resolvedPath = createRequire(path.resolve(context, 'package.json')).resolve(request)
     } catch (e) {
-      resolvedPath = resolve(request, {
-        paths: [context]
-      })
+      resolvedPath = resolve(request, { paths: [context] })
     }
   } catch (e) {}
   return resolvedPath
 }
 
 exports.loadModule = function (request, context, force = false) {
-  const resolvedPath = exports.resolveModule(request, context)
-  if (resolvedPath) {
-    if (force) {
-      clearRequireCache(resolvedPath)
+  try {
+    return createRequire(path.resolve(context, 'package.json'))(request)
+  } catch (e) {
+    const resolvedPath = exports.resolveModule(request, context)
+    if (resolvedPath) {
+      if (force) {
+        clearRequireCache(resolvedPath)
+      }
+      return require(resolvedPath)
     }
-    return require(resolvedPath)
   }
 }
 

--- a/packages/@vue/cli-shared-utils/lib/module.js
+++ b/packages/@vue/cli-shared-utils/lib/module.js
@@ -1,18 +1,34 @@
+const Module = require('module')
+const path = require('path')
+
 const semver = require('semver')
 
+// https://github.com/benmosher/eslint-plugin-import/pull/1591
+// https://github.com/benmosher/eslint-plugin-import/pull/1602
+// Polyfill Node's `Module.createRequireFromPath` if not present (added in Node v10.12.0)
+// Use `Module.createRequire` if available (added in Node v12.2.0)
+const createRequire = Module.createRequire || Module.createRequireFromPath || function (filename) {
+  const mod = new Module(filename, null)
+  mod.filename = filename
+  mod.paths = Module._nodeModulePaths(path.dirname(filename))
+
+  mod._compile(`module.exports = require;`, filename)
+
+  return mod.exports
+}
+
 function resolveFallback (request, options) {
-  const Module = require('module')
   const isMain = false
   const fakeParent = new Module('', null)
 
   const paths = []
 
   for (let i = 0; i < options.paths.length; i++) {
-    const path = options.paths[i]
-    fakeParent.paths = Module._nodeModulePaths(path)
+    const p = options.paths[i]
+    fakeParent.paths = Module._nodeModulePaths(p)
     const lookupPaths = Module._resolveLookupPaths(request, fakeParent, true)
 
-    if (!paths.includes(path)) paths.push(path)
+    if (!paths.includes(p)) paths.push(p)
 
     for (let j = 0; j < lookupPaths.length; j++) {
       if (!paths.includes(lookupPaths[j])) paths.push(lookupPaths[j])
@@ -35,9 +51,13 @@ const resolve = semver.satisfies(process.version, '>=10.0.0')
 exports.resolveModule = function (request, context) {
   let resolvedPath
   try {
-    resolvedPath = resolve(request, {
-      paths: [context]
-    })
+    try {
+      resolvedPath = createRequire(context).resolve(request)
+    } catch (e) {
+      resolvedPath = resolve(request, {
+        paths: [context]
+      })
+    }
   } catch (e) {}
   return resolvedPath
 }


### PR DESCRIPTION
See https://github.com/benmosher/eslint-plugin-import/pull/1591 and https://github.com/benmosher/eslint-plugin-import/pull/1602

As far as I understand, `createRequire` is the only semantically correct way to resolve modules from a different context.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
