### PR TITLE
fix(e2e-cypress): make --headless work with --browser chrome

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/index.js
@@ -14,7 +14,6 @@ module.exports = (api, options) => {
       `All Cypress CLI options are also supported:\n` +
       chalk.yellow(`https://docs.cypress.io/guides/guides/command-line.html#cypress-run`)
   }, async (args, rawArgs) => {
-    removeArg(rawArgs, 'headless', 0)
     removeArg(rawArgs, 'mode')
     removeArg(rawArgs, 'url')
     removeArg(rawArgs, 'config')

--- a/packages/@vue/cli-plugin-e2e-cypress/package.json
+++ b/packages/@vue/cli-plugin-e2e-cypress/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@vue/cli-shared-utils": "^4.1.2",
-    "cypress": "^3.3.1",
+    "cypress": "^3.8.0",
     "eslint-plugin-cypress": "^2.7.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

When running vue-cli-service test:e2e,w e currently use the -headless flag to distinguish wether to run `cypress run` (headless) or `cypress open` (interactive mode). Therefore, we remove the `--headless` flag from the args before passing them on to cypress: we expect `cypress run` to run headless anyway by default.

Since then, Cypress.io added the possibility to have `cypress run` execute with a Chrome window open, but not in interactive mode like `cypress open`.

So now when you run `cypress run --browser chrome` (b< calling `vue-ci-service test:e2e --browser chrome`) the tests run automatically, but not headless anymore. To make cypress run chrome truly headless, we have to pass the --headless flag explictily.

This PR allows for that but at the same time, it prevents users from running with an open chrome window (except in interactive mode of course).

It think this makes sense as a fix for now nontheless, as it ensures that people running `--headless` get that behaviour wether or not they have defined `--browser chrome`. 

But for the next **major version**, we should consider changing this plugin's cli API to allow to get all posible cypress behaviours.