### PR TITLE
:pencil: docs: Set base property of VueRouter when deploying to gh-pages

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -50,6 +50,16 @@ If you are using the PWA plugin, your app must be served over HTTPS so that [Ser
         : '/'
     }
     ```
+    
+    Also if you are using vue-router you want override the base property like:
+
+    ``` js
+    const router = new VueRouter({
+    ...,
+    base: '/my-project/',
+    ...,
+    })
+    ```
 
 2. Inside your project, create `deploy.sh` with the following content (with highlighted lines uncommented appropriately) and run it to deploy:
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -55,9 +55,9 @@ If you are using the PWA plugin, your app must be served over HTTPS so that [Ser
 
     ``` js
     const router = new VueRouter({
-    ...,
-    base: '/my-project/',
-    ...,
+      ...,
+      base: '/my-project/',
+      ...,
     })
     ```
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -51,7 +51,7 @@ If you are using the PWA plugin, your app must be served over HTTPS so that [Ser
     }
     ```
     
-    Also if you are using vue-router you want override the base property like:
+    Also if you are using vue-router you want to override the base property like:
 
     ``` js
     const router = new VueRouter({


### PR DESCRIPTION
When you use VueRouter and want to deploy to gh-pages (in a project) you have to set the base property of the VueRouter to the project's name

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
