### PR TITLE
feat: create projects with @vue/test-utils beta 31

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -8,7 +8,7 @@ module.exports = (api, _, __, invoking) => {
       'test:unit': 'vue-cli-service test:unit'
     },
     devDependencies: {
-      '@vue/test-utils': '1.0.0-beta.29'
+      '@vue/test-utils': '1.0.0-beta.31'
     },
     jest: {
       preset: api.hasPlugin('babel')

--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -40,7 +40,7 @@
     "vue-jest": "^3.0.5"
   },
   "devDependencies": {
-    "@vue/test-utils": "1.0.0-beta.29"
+    "@vue/test-utils": "1.0.0-beta.31"
   },
   "peerDependencies": {
     "@vue/cli-service": "^3.0.0 || ^4.0.0-0"

--- a/packages/@vue/cli-plugin-unit-mocha/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/generator/index.js
@@ -5,7 +5,7 @@ module.exports = (api, _, __, invoking) => {
 
   api.extendPackage({
     devDependencies: {
-      '@vue/test-utils': '1.0.0-beta.29',
+      '@vue/test-utils': '1.0.0-beta.31',
       'chai': '^4.1.2'
     },
     scripts: {

--- a/packages/@vue/cli-plugin-unit-mocha/package.json
+++ b/packages/@vue/cli-plugin-unit-mocha/package.json
@@ -29,7 +29,7 @@
     "mochapack": "^1.1.13"
   },
   "devDependencies": {
-    "@vue/test-utils": "1.0.0-beta.29",
+    "@vue/test-utils": "1.0.0-beta.31",
     "chai": "^4.1.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,6 +2806,15 @@
     dom-event-types "^1.0.0"
     lodash "^4.17.4"
 
+"@vue/test-utils@1.0.0-beta.31":
+  version "1.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.31.tgz#580d6e45f07452e497d69807d80986e713949b73"
+  integrity sha512-IlhSx5hyEVnbvDZ3P98R1jNmy88QAd/y66Upn4EcvxSD5D4hwOutl3dIdfmSTSXs4b9DIMDnEVjX7t00cvOnvg==
+  dependencies:
+    dom-event-types "^1.0.0"
+    lodash "^4.17.15"
+    pretty "^2.0.0"
+
 "@vue/ui@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@vue/ui/-/ui-0.9.2.tgz#d0db33f5133f93cb71e44bcd1ed71caa405ded25"
@@ -14410,7 +14419,7 @@ pretty-time@^1.1.0:
   resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"
   integrity sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==
 
-pretty@2.0.0:
+pretty@2.0.0, pretty@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
   integrity sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=


### PR DESCRIPTION
See changelog at https://github.com/vuejs/vue-test-utils/blob/v1.0.0-beta.31/CHANGELOG.md#100-beta31-2020-01-18

New projects will be created with this new version.

There are a few breaking changes since beta.29. So we can't automatically migrate existing projects to this new version. Users can upgrade at their own will.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
