### PR TITLE
feat(GeneratorAPI): allow passing options to `api.extendPackage`

### DIFF
--- a/packages/@vue/cli-plugin-babel/migrator/index.js
+++ b/packages/@vue/cli-plugin-babel/migrator/index.js
@@ -1,14 +1,20 @@
 const { chalk } = require('@vue/cli-shared-utils')
 
-module.exports = (api) => {
-  api.transformScript('babel.config.js', require('../codemods/usePluginPreset'))
+module.exports = api => {
+  api.transformScript(
+    'babel.config.js',
+    require('../codemods/usePluginPreset')
+  )
 
   if (api.fromVersion('^3')) {
-    api.extendPackage({
-      dependencies: {
-        'core-js': '^3.6.4'
-      }
-    }, true)
+    api.extendPackage(
+      {
+        dependencies: {
+          'core-js': '^3.6.4'
+        }
+      },
+      { warnIncompatibleVersions: false }
+    )
 
     // TODO: implement a codemod to migrate polyfills
     api.exitLog(`core-js has been upgraded from v2 to v3.

--- a/packages/@vue/cli-plugin-eslint/migrator/index.js
+++ b/packages/@vue/cli-plugin-eslint/migrator/index.js
@@ -54,7 +54,7 @@ module.exports = async (api) => {
       Object.assign(newDeps, getDeps(api, 'prettier'))
     }
 
-    api.extendPackage({ devDependencies: newDeps }, true)
+    api.extendPackage({ devDependencies: newDeps }, { warnIncompatibleVersions: false })
 
     // in case anyone's upgrading from the legacy `typescript-eslint-parser`
     if (api.hasPlugin('typescript')) {

--- a/packages/@vue/cli-plugin-typescript/migrator/index.js
+++ b/packages/@vue/cli-plugin-typescript/migrator/index.js
@@ -1,7 +1,10 @@
-module.exports = (api) => {
-  api.extendPackage({
-    devDependencies: {
-      typescript: require('../package.json').devDependencies.typescript
-    }
-  }, true)
+module.exports = api => {
+  api.extendPackage(
+    {
+      devDependencies: {
+        typescript: require('../package.json').devDependencies.typescript
+      }
+    },
+    { warnIncompatibleVersions: false }
+  )
 }

--- a/packages/@vue/cli/__tests__/Generator.spec.js
+++ b/packages/@vue/cli/__tests__/Generator.spec.js
@@ -73,6 +73,10 @@ fs.ensureDirSync(path.resolve(templateDir, '_vscode'))
 fs.writeFileSync(path.resolve(templateDir, '_vscode/config.json'), `{}`)
 fs.writeFileSync(path.resolve(templateDir, '_gitignore'), 'foo')
 
+beforeEach(() => {
+  logs.warn = []
+})
+
 test('api: extendPackage', async () => {
   const generator = new Generator('/', {
     pkg: {
@@ -374,6 +378,130 @@ test('api: extendPackage merge warn nonstrictly semver deps', async () => {
       msg.match(/Using version \(expressjs\/express\)/)
     )
   })).toBe(true)
+})
+
+test('api: extendPackage + { merge: false }', async () => {
+  const generator = new Generator('/', {
+    pkg: {
+      name: 'hello',
+      list: [1],
+      vue: {
+        foo: 1,
+        bar: 2
+      }
+    },
+    plugins: [{
+      id: 'test',
+      apply: api => {
+        api.extendPackage(
+          {
+            name: 'hello2',
+            list: [2],
+            vue: {
+              foo: 2,
+              baz: 3
+            }
+          },
+          { merge: false }
+        )
+      }
+    }]
+  })
+
+  await generator.generate()
+
+  const pkg = JSON.parse(fs.readFileSync('/package.json', 'utf-8'))
+  expect(pkg).toEqual({
+    name: 'hello2',
+    list: [2],
+    vue: {
+      foo: 2,
+      baz: 3
+    }
+  })
+})
+
+test('api: extendPackage + { prune: true }', async () => {
+  const generator = new Generator('/', {
+    pkg: {
+      name: 'hello',
+      version: '0.0.0',
+      dependencies: {
+        foo: '1.0.0'
+      },
+      vue: {
+        bar: 1,
+        baz: 2
+      }
+    },
+    plugins: [{
+      id: 'test',
+      apply: api => {
+        api.extendPackage(
+          {
+            name: null,
+            dependencies: {
+              foo: null,
+              qux: '2.0.0'
+            },
+            vue: {
+              bar: null,
+              baz: 3
+            }
+          },
+          { prune: true }
+        )
+      }
+    }]
+  })
+
+  await generator.generate()
+
+  const pkg = JSON.parse(fs.readFileSync('/package.json', 'utf-8'))
+  expect(pkg).toEqual({
+    version: '0.0.0',
+    dependencies: {
+      qux: '2.0.0'
+    },
+    vue: {
+      baz: 3
+    }
+  })
+})
+
+test('api: extendPackage + { warnIncompatibleVersions: false }', async () => {
+  const generator = new Generator('/', {
+    pkg: {
+      devDependencies: {
+        eslint: '^4.0.0'
+      }
+    },
+    plugins: [{
+      id: 'test',
+      apply: api => {
+        api.extendPackage(
+          {
+            devDependencies: {
+              eslint: '^6.0.0'
+            }
+          },
+          { warnIncompatibleVersions: false }
+        )
+      }
+    }]
+  })
+
+  await generator.generate()
+  const pkg = JSON.parse(fs.readFileSync('/package.json', 'utf-8'))
+
+  // should not warn about the version conflicts
+  expect(logs.warn.length).toBe(0)
+  // should use the newer version
+  expect(pkg).toEqual({
+    devDependencies: {
+      eslint: '^6.0.0'
+    }
+  })
 })
 
 test('api: render fs directory', async () => {


### PR DESCRIPTION
Currently, 3 options are implemented:

- options.prune (defaults to `false`) - Remove null or undefined
fields from the object after merging.
- options.merge (defaults to `true`) deep-merge nested fields, note
that dependency fields are always deep merged regardless of this option.
- options.warnIncompatibleVersions (defaults to `true`) Output warning
if two dependency version ranges don't intersect.

Closes #4779

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
