### PR TITLE
fix: should infer package manager from config if there's no lockfile in the project

### DIFF
--- a/packages/@vue/cli-shared-utils/lib/env.js
+++ b/packages/@vue/cli-shared-utils/lib/env.js
@@ -140,7 +140,7 @@ exports.hasProjectNpm = (cwd) => {
   }
 
   const lockFile = path.join(cwd, 'package-lock.json')
-  const result = fs.exists(lockFile)
+  const result = fs.existsSync(lockFile)
   _npmProjects.set(cwd, result)
   return result
 }

--- a/packages/@vue/cli-shared-utils/lib/env.js
+++ b/packages/@vue/cli-shared-utils/lib/env.js
@@ -130,6 +130,21 @@ function checkPnpm (result) {
   return result
 }
 
+const _npmProjects = new LRU({
+  max: 10,
+  maxAge: 1000
+})
+exports.hasProjectNpm = (cwd) => {
+  if (_npmProjects.has(cwd)) {
+    return true
+  }
+
+  const lockFile = path.join(cwd, 'package-lock.json')
+  const result = fs.exists(lockFile)
+  _npmProjects.set(cwd, result)
+  return result
+}
+
 // OS
 exports.isWindows = process.platform === 'win32'
 exports.isMacintosh = process.platform === 'darwin'

--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -18,6 +18,7 @@ const {
   hasPnpm3OrLater,
   hasPnpmVersionOrLater,
   hasProjectPnpm,
+  hasProjectNpm,
 
   isOfficialPlugin,
   resolvePluginId,
@@ -88,8 +89,17 @@ class PackageManager {
     if (forcePackageManager) {
       this.bin = forcePackageManager
     } else if (context) {
-      this.bin = hasProjectYarn(context) ? 'yarn' : hasProjectPnpm(context) ? 'pnpm' : 'npm'
-    } else {
+      if (hasProjectYarn(context)) {
+        this.bin = 'yarn'
+      } else if (hasProjectPnpm(context)) {
+        this.bin = 'pnpm'
+      } else if (hasProjectNpm(context)) {
+        this.bin = 'npm'
+      }
+    }
+
+    // if no package managers specified, and no lockfile exists
+    if (!this.bin) {
       this.bin = loadOptions().packageManager || (hasYarn() ? 'yarn' : hasPnpm3OrLater() ? 'pnpm' : 'npm')
     }
 


### PR DESCRIPTION
Fixed monorepo use cases.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
