### PR TITLE
fix "Vue packages version mismatch" error caused by other global packages

### DIFF
--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -53,6 +53,7 @@
     "shortid": "^2.2.15",
     "slash": "^3.0.0",
     "validate-npm-package-name": "^3.0.0",
+    "vue": "^2.6.11",
     "vue-jscodeshift-adapter": "^2.0.2",
     "yaml-front-matter": "^3.4.1"
   },


### PR DESCRIPTION
closes #5161

The root cause of such issues:

`vue-jscodeshift-adapter` requires `vue-template-compiler`.
`vue-template-compiler` tries to require the `vue` package and check
its version on startup.

Normally, there's no `vue` package in the dependency tree of `@vue/cli`,
so this check will just skip.

But if the user has installed some other global package that depend on
`vue`, and hoists it to the root `node_modules`, `vue-template-compiler`
would successfully require it and check against that `vue` version,
which sometimes may be outdated, thus failing the bootstrap process.

So by adding a "vue" dependency to the `@vue/cli` package, we can make sure the `vue-template-compiler` package in the dependency tree can always get the up-to-date version number and pass the test.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
