### PR TITLE
feat: use @vue/compiler-sfc as a compiler for TS if available

### DIFF
--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -26,7 +26,7 @@
     "@types/webpack-env": "^1.15.1",
     "@vue/cli-shared-utils": "^4.2.3",
     "cache-loader": "^4.1.0",
-    "fork-ts-checker-webpack-plugin": "^1.5.1",
+    "fork-ts-checker-webpack-plugin": "^3.1.1",
     "globby": "^9.2.0",
     "thread-loader": "^2.1.3",
     "ts-loader": "^6.2.1",

--- a/packages/@vue/cli-plugin-typescript/vue-compiler-sfc-shim.js
+++ b/packages/@vue/cli-plugin-typescript/vue-compiler-sfc-shim.js
@@ -1,0 +1,7 @@
+const compilerSFC = require('@vue/compiler-sfc')
+
+module.exports = {
+  parseComponent (content, options) {
+    return compilerSFC.parse(content, options)
+  }
+}


### PR DESCRIPTION
Update: I'll let you decide but #5172 is probably a better alternative. See https://github.com/vuejs/vue-cli-plugin-vue-next/issues/5 for more context

The `fork-ts-checker-webpack-plugin` is using `vue-template-compiler` by default, and this compiler is not the correct one to pick for vue-next. This commit tries to load `@vue/compiler-sfc` and falls back to `vue-template-compiler` if it does not find it.

It also bumps the `fork-ts-checker-webpack-plugin` to use v3.1.3

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
