### PR TITLE
fix: do not use fork-ts-checker-webpack-plugin for vue-next

### DIFF
--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -76,9 +76,17 @@ module.exports = (api, projectOptions) => {
       return options
     })
 
-    if (!process.env.VUE_CLI_TEST) {
+    let isUsingNextCompiler = true
+    try {
+      require('@vue/compiler-sfc')
+    } catch (e) {
+      isUsingNextCompiler = false
+    }
+    if (!process.env.VUE_CLI_TEST && !isUsingNextCompiler) {
       // this plugin does not play well with jest + cypress setup (tsPluginE2e.spec.js) somehow
       // so temporarily disabled for vue-cli tests
+      // it also does not play well with `@vue/compiler-sfc`
+      // so we also disable it if the project is built with Vue 3
       config
         .plugin('fork-ts-checker')
           .use(require('fork-ts-checker-webpack-plugin'), [{


### PR DESCRIPTION
Probably a better alternative to #5170 

As the `fork-ts-checker-webpack-plugin` tries to load the compiler, it does not play well at the moment with the vue-next compiler `@vue/compiler-sfc`. This disables the plugin if we are building a vue-next project.

See https://github.com/vuejs/vue-cli-plugin-vue-next/issues/5 for context.


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
