### PR TITLE
fix: prevent mixing up of lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ temp
 .version
 .versions
 .changelog
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools
- [ ] Other, please describe:

It is likely that people might use `npm` to install dependencies and commit `package-lock.json` while opening a PR. Ignore `package-lock` to avoid mixing up of lock files.
<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
N/A