### PR TITLE
fix(GeneratorAPI): remove warning when using extendPackage with prune

### DIFF
--- a/packages/@vue/cli/__tests__/Generator.spec.js
+++ b/packages/@vue/cli/__tests__/Generator.spec.js
@@ -457,6 +457,9 @@ test('api: extendPackage + { prune: true }', async () => {
 
   await generator.generate()
 
+  // should not warn about the null versions
+  expect(logs.warn.length).toBe(0)
+
   const pkg = JSON.parse(fs.readFileSync('/package.json', 'utf-8'))
   expect(pkg).toEqual({
     version: '0.0.0',

--- a/packages/@vue/cli/lib/util/mergeDeps.js
+++ b/packages/@vue/cli/lib/util/mergeDeps.js
@@ -42,6 +42,7 @@ module.exports = function mergeDeps (
 
     if (prune && injectingRange == null) {
       delete result[depName]
+      continue
     }
 
     if (!isValidRange(injectingRange)) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Currently, if we use `api.extendPackage({foo: null}, {prune: true})` the dependency is removed but a warning is logged as the range is invalid:

```
 WARN  invalid version range for dependency "foo":

- null injected by generator "my-plugin"
```

This commit fixes it, by skipping the range check if we delete a dependency. 