### PR TITLE
docs: fix readme of @vue/cli-plugin-eslint

### DIFF
--- a/packages/@vue/cli-plugin-eslint/README.md
+++ b/packages/@vue/cli-plugin-eslint/README.md
@@ -17,7 +17,7 @@
     --max-warnings       specify number of warnings to make build failed (default: Infinity)
   ```
 
-  Lints and fixes files. If no specific files are given, it lints all files in `src` and `test`.
+  Lints and fixes files. If no specific files are given, it lints all files in `src` and `tests`.
 
   Other [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options) are also supported.
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

The default target directories of `vue-cli-service lint` command was written as `src` and `test`, but I think that `src` and `tests` are correct. If my opinion is correct, please merge.

Related code here:
https://github.com/vuejs/vue-cli/blob/0380f226b9d5df188622c6bdb3d1b12f8b4e044c/packages/%40vue/cli-plugin-eslint/lint.js#L47-L61
