### PR TITLE
fix(babel-preset-app): avoid corejs warning when useBuiltIns is false

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -137,7 +137,7 @@ module.exports = (context, options = {}) => {
   }
 
   const envOptions = {
-    corejs: 3,
+    corejs: useBuiltIns ? 3 : false,
     spec,
     loose,
     debug,
@@ -204,7 +204,7 @@ module.exports = (context, options = {}) => {
       presets: [
         [require('@babel/preset-env'), {
           useBuiltIns,
-          corejs: 3
+          corejs: useBuiltIns ? 3 : false
         }]
       ]
     }]


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Fix #5235