### PR TITLE
feat: ease the default `no-console` severity to `warn`

### DIFF
--- a/packages/@vue/cli-plugin-eslint/eslintOptions.js
+++ b/packages/@vue/cli-plugin-eslint/eslintOptions.js
@@ -7,8 +7,8 @@ exports.config = (api, preset) => {
       ecmaVersion: 2020
     },
     rules: {
-      'no-console': makeJSOnlyValue(`process.env.NODE_ENV === 'production' ? 'error' : 'off'`),
-      'no-debugger': makeJSOnlyValue(`process.env.NODE_ENV === 'production' ? 'error' : 'off'`)
+      'no-console': makeJSOnlyValue(`process.env.NODE_ENV === 'production' ? 'warn' : 'off'`),
+      'no-debugger': makeJSOnlyValue(`process.env.NODE_ENV === 'production' ? 'warn' : 'off'`)
     }
   }
 

--- a/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
+++ b/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
@@ -114,8 +114,8 @@ module.exports = function createConfigPlugin (context, entry, asLib) {
                     parser: 'babel-eslint'
                   },
                   rules: {
-                    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-                    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+                    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+                    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
                   }
                 }
               }))

--- a/packages/@vue/cli-ui-addon-widgets/.eslintrc.js
+++ b/packages/@vue/cli-ui-addon-widgets/.eslintrc.js
@@ -8,8 +8,8 @@ module.exports = {
     '@vue/standard'
   ],
   rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
   },
   parserOptions: {
     parser: 'babel-eslint'


### PR DESCRIPTION
As ESLint 6 removes this rule from the recommended config
https://eslint.org/docs/user-guide/migrating-to-6.0.0#eslint-recommended-has-been-updated

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
