### PR TITLE
fix: fix severity config in ui

### DIFF
--- a/packages/@vue/cli-plugin-eslint/__tests__/ui.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/ui.spec.js
@@ -84,7 +84,7 @@ describe('getEslintPrompts', () => {
       extends: 'plugin:vue/recommended',
       rules: {
         'vue/lorem': ['error', ['asd']], // custom setting
-        'vue/ipsum': 'warning'
+        'vue/ipsum': 'warn'
       }
     }
   }
@@ -146,7 +146,7 @@ describe('getEslintPrompts', () => {
   })
 
   it('sets value on prompt item, if the rule was set in project\'s eslint config', () => {
-    expect(prompts[1].value).toBe('"warning"')
+    expect(prompts[1].value).toBe('"warn"')
     expect(prompts[2].value).toBe('["error",["asd"]]')
   })
 

--- a/packages/@vue/cli-plugin-eslint/ui/configDescriptor.js
+++ b/packages/@vue/cli-plugin-eslint/ui/configDescriptor.js
@@ -10,7 +10,7 @@ const CATEGORIES = [
 const DEFAULT_CATEGORY = 'essential'
 const RULE_SETTING_OFF = 'off'
 const RULE_SETTING_ERROR = 'error'
-const RULE_SETTING_WARNING = 'warning'
+const RULE_SETTING_WARNING = 'warn'
 const RULE_SETTINGS = [RULE_SETTING_OFF, RULE_SETTING_ERROR, RULE_SETTING_WARNING]
 
 const defaultChoices = [


### PR DESCRIPTION
closes #5175

I didn't change the choice name because it's used in translations; didn't change the constant name to keep consistency.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
