### PR TITLE
chore(eslint): bump minimum required eslint-loader version to support ESLint 6

### DIFF
--- a/packages/@vue/cli-plugin-eslint/package.json
+++ b/packages/@vue/cli-plugin-eslint/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@vue/cli-shared-utils": "^4.2.3",
-    "eslint-loader": "^2.1.2",
+    "eslint-loader": "^2.2.1",
     "globby": "^9.2.0",
     "inquirer": "^6.3.1",
     "webpack": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7324,7 +7324,7 @@ eslint-import-resolver-webpack@^0.11.1:
     resolve "^1.10.0"
     semver "^5.3.0"
 
-eslint-loader@^2.1.2:
+eslint-loader@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-2.2.1.tgz#28b9c12da54057af0845e2a6112701a2f6bf8337"
   integrity sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
eslint-loader >= 2.2.0 is supported ESLint 6.  
https://github.com/webpack-contrib/eslint-loader/releases/tag/v2.2.0  

However, package.json `"eslint-loader": "^2.1.2"`.  
If locked version 2.1.2 by user `yarn.lock` or `package-lock.json`, continue to use not supported version.