### PR TITLE
fix(cli-ui): build task defaults should respect outputDir option from config file (fix #2639)

### DIFF
--- a/packages/@vue/cli-ui/ui-defaults/tasks.js
+++ b/packages/@vue/cli-ui/ui-defaults/tasks.js
@@ -279,7 +279,7 @@ module.exports = api => {
       {
         name: 'dest',
         type: 'input',
-        default: 'dist',
+        default: '',
         description: 'org.vue.vue-webpack.tasks.build.dest'
       },
       {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

fix #2649
