### PR TITLE
feat(service): Allow mocha unit tests debugger to be bound to a specified IP and port

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/index.js
@@ -37,8 +37,9 @@ module.exports = api => {
       `https://sysgears.github.io/mochapack/docs/installation/cli-usage.html`
     )
   }, (args, rawArgv) => {
-    const inspectPos = rawArgv.indexOf('--inspect-brk')
     let nodeArgs = []
+
+    const inspectPos = rawArgv.findIndex(arg => arg.startsWith('--inspect-brk'))
     if (inspectPos !== -1) {
       nodeArgs = rawArgv.splice(inspectPos, inspectPos + 1)
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
This change allows developers to specify a host and port to bind the node debugger to. This is helpful in my case where I am running my application in a docker container and need to allow the debugger to listen on an IP other than the default localhost