### PR TITLE
feat(cli-service): add `plugins` option

### DIFF
--- a/packages/@vue/cli-service/__tests__/Service.spec.js
+++ b/packages/@vue/cli-service/__tests__/Service.spec.js
@@ -377,3 +377,22 @@ test('api: hasPlugin', () => {
     }
   ])
 })
+
+test('load project options from vue.config.js', () => {
+  process.env.VUE_CLI_SERVICE_CONFIG_PATH = `/vue-plugins.config.js`
+  fs.writeFileSync('/vue-plugins.config.js', ' ')
+  jest.mock('/vue-plugins.config.js', () => ({
+    plugins: [
+      {
+        id: 'vue-cli-plugin-foo',
+        apply: api => {
+          expect(api.hasPlugin('foo')).toBe(true)
+        }
+      }
+    ]
+  }), { virtual: true })
+  const service = createMockService()
+  fs.unlinkSync('/vue-plugins.config.js')
+  delete process.env.VUE_CLI_SERVICE_CONFIG_PATH
+  expect(service.projectOptions.plugins).toBeUndefined()
+})

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -72,6 +72,28 @@ module.exports = class Service {
 
     debug('vue:project-config')(this.projectOptions)
 
+    if (this.projectOptions.plugins) {
+      const plugins = this.projectOptions.plugins || []
+      delete this.projectOptions.plugins
+      this.plugins = this.plugins.concat(plugins.map(id => {
+        if (id && typeof id === 'string') {
+          let apply = () => {}
+          try {
+            apply = require(id)
+          } catch (e) {
+            warn(`projectOptions.plugins ${id} is not installed.`)
+          }
+          return { id, apply }
+        }
+        return id
+      }))
+
+      // refresh
+      this.modes = this.plugins.reduce((modes, { apply: { defaultModes }}) => {
+        return Object.assign(modes, defaultModes)
+      }, {})
+    }
+
     // apply plugins.
     this.plugins.forEach(({ id, apply }) => {
       if (this.pluginsToSkip.has(id)) return

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -60,7 +60,9 @@ const schema = createSchema(joi => joi.object({
   pwa: joi.object(),
 
   // 3rd party plugin options
-  pluginOptions: joi.object()
+  pluginOptions: joi.object(),
+  // local plugins
+  plugins: joi.array()
 }))
 
 exports.validate = (options, cb) => {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

我想通过 `process.env.VUE_CLI_SERVICE_CONFIG_PATH` 加载一些插件，不再希望依赖 package.json.
因为有些插件和配置文件是在另一个项目中，我想依赖另一个项目去加载相应的配置，不需要维护多个配置文件。