### PR TITLE
chore(cli-service-global): remove direct dependency on `@vue/babel-preset-app`

### DIFF
--- a/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
+++ b/packages/@vue/cli-service-global/lib/globalConfigPlugin.js
@@ -59,7 +59,7 @@ module.exports = function createConfigPlugin (context, entry, asLib) {
             .add(entry)
 
         const babelOptions = {
-          presets: [require.resolve('@vue/babel-preset-app')]
+          presets: [require.resolve('@vue/cli-plugin-babel/preset')]
         }
 
         // set inline babel options

--- a/packages/@vue/cli-service-global/package.json
+++ b/packages/@vue/cli-service-global/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-service-global#readme",
   "dependencies": {
-    "@vue/babel-preset-app": "^4.2.3",
     "@vue/cli-plugin-babel": "^4.2.3",
     "@vue/cli-plugin-eslint": "^4.2.3",
     "@vue/cli-service": "^4.2.3",


### PR DESCRIPTION
Eliminates the peer dependency warning.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
