### PR TITLE
feat: enable `bugfixes` option for babel by default

### DIFF
--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -59,6 +59,7 @@ module.exports = (context, options = {}) => {
     debug = false,
     useBuiltIns = 'usage',
     modules = false,
+    bugfixes = true,
     targets: rawTargets,
     spec,
     ignoreBrowserslistConfig = !!process.env.VUE_CLI_MODERN_BUILD,
@@ -137,6 +138,7 @@ module.exports = (context, options = {}) => {
   }
 
   const envOptions = {
+    bugfixes,
     corejs: useBuiltIns ? 3 : false,
     spec,
     loose,

--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -30,7 +30,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-jsx": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
-    "@babel/preset-env": "^7.8.4",
+    "@babel/preset-env": "^7.9.0",
     "@babel/runtime": "^7.8.4",
     "@vue/babel-preset-jsx": "^1.1.2",
     "babel-plugin-dynamic-import-node": "^2.3.0",


### PR DESCRIPTION
Per the discussion at https://github.com/babel/babel/pull/11083,
it should not be considered a breaking change.

Considering we started locking minor versions since v4.2, I believe we can ship this flag enabled by default in v4.3.

Closes #5301
Closes #4848

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
