### PR TITLE
fix pwa installability when using noopServiceWorker "Page does not work offline"

### DIFF
--- a/packages/@vue/cli-plugin-pwa/lib/noopServiceWorker.js
+++ b/packages/@vue/cli-plugin-pwa/lib/noopServiceWorker.js
@@ -12,6 +12,8 @@
 
 self.addEventListener('install', () => self.skipWaiting())
 
+self.addEventListener('fetch', () => {})
+
 self.addEventListener('activate', () => {
   self.clients.matchAll({ type: 'window' }).then(windowClients => {
     for (const windowClient of windowClients) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information:**

Hi,
currently Google Chrome prevents installing local pwa due to the error: "Page does not work offline". The reason is service worker has to listen to `fetch` event. Since in localhost we serve `noopServiceWorker` we should not cache any requests thus fetch listener should be an empty function.

The reason why i think this change is important is, pwa technologies are quite complex and there are already lots of debugging involved, so being able to quickly see (+) install icon in google chrome will prevent early giving up on pwa by new comers.

Unfortunately I couldnt find docs explaining why `fetch` listener is needed, the solution is taken from this [stackoverflow answer](https://stackoverflow.com/a/49989382). I did check that empty `fetch` listener doesnt have any side effects besides installability, as implementing any form of request interception is done via `event.respondWith` [[1]](https://developers.google.com/web/ilt/pwa/caching-files-with-service-worker#on_network_response) [[2]](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith)
