### PR TITLE
docs: Use `vue add @vue/eslint` instead of `vue add eslint`

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -2,7 +2,7 @@
 
 ## Using the Binary
 
-Inside a Vue CLI project, `@vue/cli-service` installs a binary named `vue-cli-service`. You can access the binary directly as `vue-cli-service` in npm scripts, or as `./node_modules/.bin/vue-cli-service` from the terminal.
+Inside a Vue CLI project, `@vue/cli-service` installs a binary named `vue-cli-service`. You can access the binary directly as `vue-cli-service` in npm scripts, or as `npx vue-cli-service` from the terminal.
 
 This is what you will see in the `package.json` of a project using the default preset:
 

--- a/docs/guide/plugins-and-presets.md
+++ b/docs/guide/plugins-and-presets.md
@@ -15,7 +15,7 @@ You can install and manage Plugins using the GUI with the `vue ui` command.
 Each CLI plugin ships with a generator (which creates files) and a runtime plugin (which tweaks the core webpack config and injects commands). When you use `vue create` to create a new project, some plugins will be pre-installed for you based on your feature selection. In case you want to install a plugin into an already created project, you can do so with the `vue add` command:
 
 ``` bash
-vue add eslint
+vue add @vue/eslint
 ```
 
 ::: tip


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

* `plugins-and-presets.md`: According to **line 29**, it should be `vue add @vue/eslint` instead of `vue add eslint`.
* `cli-service.md `: It's better to use `npx vue-cli-service` instead of `./node_modules/.bin/vue-cli-service` now.