### PR TITLE
fix: run migrator in a separator process, fix require cache issues during upgrade

### DIFF
--- a/packages/@vue/cli/lib/Upgrader.js
+++ b/packages/@vue/cli/lib/Upgrader.js
@@ -130,6 +130,7 @@ module.exports = class Upgrader {
           },
           this.pkg
         )
+        return
       }
 
       const cliBin = path.resolve(__dirname, '../bin/vue.js')

--- a/packages/@vue/cli/lib/Upgrader.js
+++ b/packages/@vue/cli/lib/Upgrader.js
@@ -115,6 +115,7 @@ module.exports = class Upgrader {
       const cliBin = path.resolve(__dirname, '../bin/vue.js')
       // Run migrator in a separate process to avoid all kinds of require cache issues
       await execa('node', [cliBin, 'migrate', packageName, '--from', installed], {
+        cwd: this.context,
         stdio: 'inherit'
       })
     }


### PR DESCRIPTION
Sometimes there may still be errors like `Error: ENOENT: no such file or directory` after running `vue upgrade --all`.

This refactor fixes such issues.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
