### PR TITLE
feat(cli-service) add stdin flag to build

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -37,7 +37,8 @@ module.exports = (api, options) => {
       '--report': `generate report.html to help analyze bundle content`,
       '--report-json': 'generate report.json to help analyze bundle content',
       '--skip-plugins': `comma-separated list of plugin names to skip for this run`,
-      '--watch': `watch for changes`
+      '--watch': `watch for changes`,
+      '--stdin': `close when stdin ends`
     }
   }, async (args, rawArgs) => {
     for (const key in defaults) {
@@ -153,6 +154,13 @@ async function build (args, api, options) {
     modifyConfig(webpackConfig, config => {
       config.watch = true
     })
+  }
+
+  if (args.stdin) {
+    process.stdin.on('end', () => {
+      process.exit(0)
+    })
+    process.stdin.resume()
   }
 
   // Expose advanced stats


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Mentioned in Issue #1597.

The `serve` command was addressed with PR #2411, this adds the same functionality to the `build` command, useful when watching in development (for example, a Elixir Phoenix watcher).

```
vue-cli-service build --mode development --watch --stdin
```

