### PR TITLE
[cli-plugin-e2e-nightwatch] fixing globals.js import

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/nightwatch.config.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/nightwatch.config.js
@@ -28,6 +28,7 @@ const defaultSettings = {
   page_objects_path: 'tests/e2e/page-objects',
   custom_assertions_path: 'tests/e2e/custom-assertions',
   custom_commands_path: 'tests/e2e/custom-commands',
+  globals_path: path.resolve('tests/e2e/globals.js'),
   test_workers: concurrentMode,
   test_settings: {
     default: {


### PR DESCRIPTION
I tried scaffolding a new vue-cli project with e2e tests with nightwatch, and it wasn't picking up changes in globals.js. After a bit of digging it seems that the globals.js that was added during the scaffolding wasn't actually being used. Adding this line fixed it.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
