### PR TITLE
fix: set timeout of openChrome.applescript

### DIFF
--- a/packages/@vue/cli-shared-utils/lib/openChrome.applescript
+++ b/packages/@vue/cli-shared-utils/lib/openChrome.applescript
@@ -13,43 +13,45 @@ property targetWindow: null
 on run argv
   set theURL to item 1 of argv
 
-  tell application "Chrome"
+  with timeout of 2 seconds
+    tell application "Chrome"
 
-    if (count every window) = 0 then
-      make new window
-    end if
+      if (count every window) = 0 then
+        make new window
+      end if
 
-    -- 1: Looking for tab running debugger
-    -- then, Reload debugging tab if found
-    -- then return
-    set found to my lookupTabWithUrl(theURL)
-    if found then
-      set targetWindow's active tab index to targetTabIndex
-      tell targetTab to reload
-      tell targetWindow to activate
-      set index of targetWindow to 1
-      return
-    end if
+      -- 1: Looking for tab running debugger
+      -- then, Reload debugging tab if found
+      -- then return
+      set found to my lookupTabWithUrl(theURL)
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        tell targetTab to reload
+        tell targetWindow to activate
+        set index of targetWindow to 1
+        return
+      end if
 
-    -- 2: Looking for Empty tab
-    -- In case debugging tab was not found
-    -- We try to find an empty tab instead
-    set found to my lookupTabWithUrl("chrome://newtab/")
-    if found then
-      set targetWindow's active tab index to targetTabIndex
-      set URL of targetTab to theURL
-      tell targetWindow to activate
-      return
-    end if
+      -- 2: Looking for Empty tab
+      -- In case debugging tab was not found
+      -- We try to find an empty tab instead
+      set found to my lookupTabWithUrl("chrome://newtab/")
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        set URL of targetTab to theURL
+        tell targetWindow to activate
+        return
+      end if
 
-    -- 3: Create new tab
-    -- both debugging and empty tab were not found
-    -- make a new tab with url
-    tell window 1
-      activate
-      make new tab with properties {URL:theURL}
+      -- 3: Create new tab
+      -- both debugging and empty tab were not found
+      -- make a new tab with url
+      tell window 1
+        activate
+        make new tab with properties {URL:theURL}
+      end tell
     end tell
-  end tell
+  end timeout
 end run
 
 -- Function:


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Sometimes the script "openBrowser" takes a lot of time, and during this period, dev server is blocked and cannot handle any request。

![image](https://user-images.githubusercontent.com/15151718/79315622-c860c200-7f35-11ea-88c6-dcecf3260e57.png)

![image](https://user-images.githubusercontent.com/15151718/79314976-04475780-7f35-11ea-8686-d547b0dfdb9a.png)

![image](https://user-images.githubusercontent.com/15151718/79830382-d4d29800-83d7-11ea-8ec7-474064fe9cf7.png)

