### PR TITLE
Update ProjectPackageManager.js upgrade() method: manage multiple package names separated by spaces

### DIFF
--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -291,9 +291,9 @@ class PackageManager {
 
   async upgrade (packageName) {
     // manage multiple packages separated by spaces
-    const packageNamesArray = [];
+    const packageNamesArray = []
 
-    for (const packname of packageName.split(" ")) {
+    for (const packname of packageName.split(' ')) {
       const realname = stripVersion(packname)
       if (
         isTestOrDebug &&
@@ -304,11 +304,12 @@ class PackageManager {
         const dest = path.join(this.context, 'node_modules', realname)
         await fs.remove(dest)
         await fs.symlink(src, dest, 'dir')
+      } else {
+        packageNamesArray.push(packname)
       }
-      else packageNamesArray.push(packname)
     }
 
-    if(packageNamesArray.length) return await this.runCommand('add', packageNamesArray)
+    if (packageNamesArray.length) return await this.runCommand('add', packageNamesArray)
   }
 }
 

--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -290,20 +290,25 @@ class PackageManager {
   }
 
   async upgrade (packageName) {
-    const realname = stripVersion(packageName)
-    if (
-      isTestOrDebug &&
-      (packageName === '@vue/cli-service' || isOfficialPlugin(resolvePluginId(realname)))
-    ) {
-      // link packages in current repo for test
-      const src = path.resolve(__dirname, `../../../../${realname}`)
-      const dest = path.join(this.context, 'node_modules', realname)
-      await fs.remove(dest)
-      await fs.symlink(src, dest, 'dir')
-      return
+    // manage multiple packages separated by spaces
+    const packageNamesArray = [];
+
+    for (const packname of packageName.split(" ")) {
+      const realname = stripVersion(packname)
+      if (
+        isTestOrDebug &&
+        (packname === '@vue/cli-service' || isOfficialPlugin(resolvePluginId(realname)))
+      ) {
+        // link packages in current repo for test
+        const src = path.resolve(__dirname, `../../../../${realname}`)
+        const dest = path.join(this.context, 'node_modules', realname)
+        await fs.remove(dest)
+        await fs.symlink(src, dest, 'dir')
+      }
+      else packageNamesArray.push(packname)
     }
 
-    return await this.runCommand('add', [packageName])
+    if(packageNamesArray.length) return await this.runCommand('add', packageNamesArray)
   }
 }
 


### PR DESCRIPTION
Update ProjectPackageManager.js upgrade() method: manage multiple package names separated by spaces

This fixes https://github.com/vuejs/vue-cli/issues/5295

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Tested for both NPM and Yarn
Fixes https://github.com/vuejs/vue-cli/issues/5295