### PR TITLE
Added 'pnpm-debug.log' to '_gitignore'

### DIFF
--- a/packages/@vue/cli-service/generator/template/_gitignore
+++ b/packages/@vue/cli-service/generator/template/_gitignore
@@ -22,6 +22,7 @@ geckodriver.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
 
 # Editor directories and files
 .idea


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:

I have just added an entry for `pnpm-debug.log` to the `_gitignore` generator file, it is the pnpm equivalent of the debug logs for `npm` and `yarn`, which are already present.

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
