### PR TITLE
fix: the translation of  the scaffold

### DIFF
--- a/docs/zh/guide/README.md
+++ b/docs/zh/guide/README.md
@@ -10,8 +10,8 @@ sidebarDepth: 0
 
 Vue CLI 是一个基于 Vue.js 进行快速开发的完整系统，提供：
 
-- 通过 `@vue/cli` 搭建交互式的项目脚手架。
-- 通过 `@vue/cli` + `@vue/cli-service-global` 快速开始零配置原型开发。
+- 通过 `@vue/cli` 实现的交互式的项目脚手架。
+- 通过 `@vue/cli` + `@vue/cli-service-global` 实现的零配置原型开发。
 - 一个运行时依赖 (`@vue/cli-service`)，该依赖：
   - 可升级；
   - 基于 webpack 构建，并带有合理的默认配置；
@@ -28,7 +28,7 @@ Vue CLI 有几个独立的部分——如果你看到了我们的[源代码](htt
 
 ### CLI
 
-CLI (`@vue/cli`) 是一个全局安装的 npm 包，提供了终端里的 `vue` 命令。它可以通过 `vue create` 快速创建一个新项目的脚手架，或者直接通过 `vue serve` 构建新想法的原型。你也可以通过 `vue ui` 通过一套图形化界面管理你的所有项目。我们会在接下来的指南中逐章节深入介绍。
+CLI (`@vue/cli`) 是一个全局安装的 npm 包，提供了终端里的 `vue` 命令。它可以通过 `vue create` 快速搭建一个新项目，或者直接通过 `vue serve` 构建新想法的原型。你也可以通过 `vue ui` 通过一套图形化界面管理你的所有项目。我们会在接下来的指南中逐章节深入介绍。
 
 ### CLI 服务
 


### PR DESCRIPTION
scaffold 用做动词时，翻译为搭建更合适，而不是脚手架。
When scaffold is used as a verb, it is more appropriate to translate it to 搭建(similar to create) rather than 脚手架(scaffolding)。
脚手架(scaffolding)只是个名词，没有搭建的意思。
Scaffolding is just a noun, there is no meaning of 搭建(similar to create)

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
