### PR TITLE
fix(eslint): invalidate the cache when `.eslintignore` changes

### DIFF
--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -25,6 +25,7 @@ module.exports = (api, options) => {
         '.eslintrc.yml',
         '.eslintrc.json',
         '.eslintrc',
+        '.eslintignore',
         'package.json'
       ]
     )


### PR DESCRIPTION
add the .eslintignore file to the cache generation algorithm

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

`eslint-loader` 运行时会生成 `cache` ，再次运行时，会检查 `cache` 是否可用

理论上 `.eslintignore` 发生变化时， `cache` 应该失效，重新运行

但 `@vue/cli-plugin-eslint` 没有把该文件加入 `cache` 的生成算法中

从而导致了当  `.eslintignore` 发生变化时，`cache`没有失效，`eslint` 忽略规则没有生效

所以需要将 `.eslintignore` 文件加入到 `cache` 处理中
