### PR TITLE
Update cypress' list of supported browsers on e2e prompt

### DIFF
--- a/packages/@vue/cli/lib/promptModules/e2e.js
+++ b/packages/@vue/cli/lib/promptModules/e2e.js
@@ -17,7 +17,7 @@ module.exports = cli => {
     message: 'Pick an E2E testing solution:',
     choices: [
       {
-        name: 'Cypress (Chrome only)',
+        name: 'Cypress (Runs on Chrome, Edge and Firefox)',
         value: 'cypress',
         short: 'Cypress'
       },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [x] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Cypress recently added Edge and Firefox on its list of supported browsers, therefore the message `Chrome only` wasn't reflecting the actual context of Cypress support. 
