### PR TITLE
fixed --inspect-brk flag clobbering other values

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/index.js
@@ -41,7 +41,7 @@ module.exports = api => {
 
     const inspectPos = rawArgv.findIndex(arg => arg.startsWith('--inspect-brk'))
     if (inspectPos !== -1) {
-      nodeArgs = rawArgv.splice(inspectPos, inspectPos + 1)
+      nodeArgs = rawArgv.splice(inspectPos, 1)
     }
     // for @vue/babel-preset-app <= v4.0.0-rc.7
     process.env.VUE_CLI_BABEL_TARGET_NODE = true


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
The `Array.splice()` method was implemented wrong, removing a number of flags or parameters based on the position of `--inspect-brk` rather than just that flag itself.