### PR TITLE
feat(plugin-api): expose `inquirer` to prompts.js, allowing custom prompt types

### DIFF
--- a/__mocks__/inquirer.js
+++ b/__mocks__/inquirer.js
@@ -7,7 +7,7 @@ exports.prompt = prompts => {
 
   const answers = {}
   let skipped = 0
-  prompts.forEach((prompt, i) => {
+  prompts.forEach((prompt, index) => {
     if (prompt.when && !prompt.when(answers)) {
       skipped++
       return
@@ -25,7 +25,7 @@ exports.prompt = prompts => {
         : val
     }
 
-    const a = pendingAssertions[i - skipped]
+    const a = pendingAssertions[index - skipped]
     if (!a) {
       console.error(`no matching assertion for prompt:`, prompt)
       console.log(prompts)
@@ -86,6 +86,10 @@ exports.prompt = prompts => {
   pendingAssertions = null
 
   return Promise.resolve(answers)
+}
+
+exports.createPromptModule = () => {
+  return exports.prompt
 }
 
 exports.expectPrompts = assertions => {

--- a/packages/@vue/cli/lib/invoke.js
+++ b/packages/@vue/cli/lib/invoke.js
@@ -68,13 +68,15 @@ async function invoke (pluginName, options = {}, context = process.cwd()) {
   } else if (!Object.keys(pluginOptions).length) {
     let pluginPrompts = loadModule(`${id}/prompts`, context)
     if (pluginPrompts) {
+      const prompt = inquirer.createPromptModule()
+
       if (typeof pluginPrompts === 'function') {
-        pluginPrompts = pluginPrompts(pkg)
+        pluginPrompts = pluginPrompts(pkg, prompt)
       }
       if (typeof pluginPrompts.getPrompts === 'function') {
-        pluginPrompts = pluginPrompts.getPrompts(pkg)
+        pluginPrompts = pluginPrompts.getPrompts(pkg, prompt)
       }
-      pluginOptions = await inquirer.prompt(pluginPrompts)
+      pluginOptions = await prompt(pluginPrompts)
     }
   }
 


### PR DESCRIPTION
closes #5167
also closes #5124

Note: custom prompt types are not supported in the CLI UI

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
