### PR TITLE
fix(unit-jest): fix .vue coverage report when babel plugin is not enabled

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/__tests__/jestPlugin.spec.js
+++ b/packages/@vue/cli-plugin-unit-jest/__tests__/jestPlugin.spec.js
@@ -66,6 +66,10 @@ test('should work without Babel', async () => {
     useConfigFiles: true
   })
   await project.run(`vue-cli-service test:unit`)
+
+  await project.run(`vue-cli-service test:unit --coverage --collectCoverageFrom="src/**/*.{js,vue}"`)
+  const appCoverage = await project.read('coverage/lcov-report/App.vue.html')
+  expect(appCoverage).toBeTruthy()
 })
 
 test('should work with tsx', async () => {

--- a/packages/@vue/cli-plugin-unit-jest/presets/no-babel/jest-preset.js
+++ b/packages/@vue/cli-plugin-unit-jest/presets/no-babel/jest-preset.js
@@ -13,7 +13,7 @@ module.exports = deepmerge(
     globals: {
       'vue-jest': {
         babelConfig: {
-          plugins: [require('babel-plugin-transform-es2015-modules-commonjs')]
+          plugins: ['babel-plugin-transform-es2015-modules-commonjs']
         }
       }
     }


### PR DESCRIPTION
fixes #5441

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
