### PR TITLE
refactor: improve the polyfill importing logic of modern mode

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -52,37 +52,48 @@ test('modern mode always skips unnecessary polyfills', () => {
   process.env.VUE_CLI_MODERN_BUILD = true
   let { code } = babel.transformSync(`
     const a = new Map()
+    console.log(globalThis)
   `.trim(), {
     babelrc: false,
     presets: [[preset, {
-      targets: { ie: 9, chrome: 5 },
+      targets: { ie: 9, safari: '12' },
       useBuiltIns: 'usage'
     }]],
     filename: 'test-entry-file.js'
   })
   // default includes that are supported in all modern browsers should be skipped
   expect(code).not.toMatch('es.assign')
-  // according to the compat table, es.promise is fully supported in only chrome >= 67
-  // which is greater than both the minimum version supporting `module` (61) and the user-specified version (5)
-  // so it's still required
-  expect(code).toMatch('es.promise')
+  // though es.promise is not supported in all modern browsers
+  // (modern: safari >= 10.1, es.promise: safrai >= 11)
+  // the custom configuration only expects to support safari >= 12
+  // so it can be skipped
+  expect(code).not.toMatch('es.promise"')
+  // es.promise.finally is supported in safari >= 13.0.3
+  // so still needs to be included
+  expect(code).toMatch('es.promise.finally')
+
   // usage-based detection
-  expect(code).not.toMatch('"core-js/modules/es.map"')
+  // Map is supported in all modern browsers
+  expect(code).not.toMatch('es.map')
+  // globalThis is not supported until safari 12.1
+  expect(code).toMatch('es.global-this')
 
   ;({ code } = babel.transformSync(`
     const a = new Map()
   `.trim(), {
     babelrc: false,
     presets: [[preset, {
-      targets: { ie: 9, chrome: 5 },
+      targets: { ie: 9, safari: '12' },
       useBuiltIns: 'entry'
     }]],
     filename: 'test-entry-file.js'
   }))
   // default includes
-  expect(code).not.toMatch(getAbsolutePolyfill('es.promise'))
+  expect(code).not.toMatch('es.promise"')
+  expect(code).not.toMatch('es.promise.finally')
   // usage-based detection
   expect(code).not.toMatch('"core-js/modules/es.map"')
+  expect(code).not.toMatch('es.global-this')
   delete process.env.VUE_CLI_MODERN_BUILD
 })
 

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -139,7 +139,7 @@ module.exports = (context, options = {}) => {
 
   const envOptions = {
     bugfixes,
-    corejs: useBuiltIns ? 3 : false,
+    corejs: useBuiltIns ? require('core-js/package.json').version : false,
     spec,
     loose,
     debug,
@@ -206,7 +206,7 @@ module.exports = (context, options = {}) => {
       presets: [
         [require('@babel/preset-env'), {
           useBuiltIns,
-          corejs: useBuiltIns ? 3 : false
+          corejs: useBuiltIns ? require('core-js/package.json').version : false
         }]
       ]
     }]

--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -38,6 +38,12 @@
     "core-js-compat": "^3.6.5"
   },
   "peerDependencies": {
-    "@babel/core": "*"
+    "@babel/core": "*",
+    "core-js": "^3"
+  },
+  "peerDependenciesMeta": {
+    "core-js": {
+      "optional": true
+    }
   }
 }

--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -35,7 +35,8 @@
     "@vue/babel-preset-jsx": "^1.1.2",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "core-js": "^3.6.5",
-    "core-js-compat": "^3.6.5"
+    "core-js-compat": "^3.6.5",
+    "semver": "^6.1.0"
   },
   "peerDependencies": {
     "@babel/core": "*",

--- a/packages/@vue/babel-preset-app/polyfillsPlugin.js
+++ b/packages/@vue/babel-preset-app/polyfillsPlugin.js
@@ -2,6 +2,9 @@ const { addSideEffect } = require('@babel/helper-module-imports')
 
 // slightly modifiled from @babel/preset-env/src/utils
 // use an absolute path for core-js modules, to fix conflicts of different core-js versions
+// TODO: remove the `useAbsolutePath` option in v5,
+// because `core-js` is sure to be present in newer projects;
+// we only need absolute path for babel runtime helpers, not for polyfills
 function getModulePath (mod, useAbsolutePath) {
   const modPath =
     mod === 'regenerator-runtime'


### PR DESCRIPTION
It is both a bugfix and refactoring.

Fixes #5507.

Fixed:
- Should also apply the `polyfills` option to the modern mode target

Improved:
- Should provide the exact version of core-js instead of a vague `3` to `@babel/preset-env`, making the polyfills more accurate and up-to-date
- By calculating the intersection of modern browsers and browserslist targets, we may come to a much narrower range of browsers, thus greatly reducing the final bundle size. It may even yield a better result than the `bugfixes` option of `@babel/preset-env`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
