### PR TITLE
feat(babel-preset-app): pass full config to @babel/preset-env

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -209,3 +209,18 @@ test('should inject polyfills / helpers using "import" statements for an es modu
   expect(code).toMatch('import "core-js/modules/es.promise"')
   expect(code).not.toMatch('require(')
 })
+
+test('should not inject excluded polyfills', () => {
+  const { code } = babel.transformSync(`
+    new Promise()
+  `.trim(), {
+    babelrc: false,
+    presets: [[preset, {
+      exclude: ['es.promise'],
+      polyfills: ['es.array.iterator', 'es.object.assign']
+    }]],
+    filename: 'test-entry-file.js'
+  })
+
+  expect(code).not.toMatch('es.promise')
+})

--- a/packages/@vue/babel-preset-app/index.js
+++ b/packages/@vue/babel-preset-app/index.js
@@ -246,10 +246,7 @@ module.exports = (context, options = {}) => {
       // https://github.com/babel/babel/issues/9903
       include: [/@babel[\/|\\\\]runtime/],
       presets: [
-        [require('@babel/preset-env'), {
-          useBuiltIns,
-          corejs: useBuiltIns ? require('core-js/package.json').version : false
-        }]
+        [require('@babel/preset-env'), envOptions]
       ]
     }]
   }


### PR DESCRIPTION
Pass not just the useBuiltIns and corejs options, but the whole envOptions object, into the @babel/preset-env preset that is used to transform @babel/runtime, just like for the @babel/preset-env that is used for the application source code. This allows users to also specify other options, such as `exclude` and `polyfills`, and have them apply here too.

In particular, this can be used to exclude the Promise polyfill, e. g. if Promise is already polyfilled in some other way. Previously,

```js
exclude: ['es.promise'],
polyfills: ['es.array.iterator', 'es.object.assign'],
```

could be used to configure the preset for the application source code, but the babel runtime would be transformed without those options, and so es.promise would still end up being included.

Closes #5208

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No (I think)

**Other information:**
