### PR TITLE
feat(cli): make globby includes dot files

### DIFF
--- a/packages/@vue/cli/lib/GeneratorAPI.js
+++ b/packages/@vue/cli/lib/GeneratorAPI.js
@@ -283,7 +283,7 @@ class GeneratorAPI {
       this._injectFileMiddleware(async (files) => {
         const data = this._resolveData(additionalData)
         const globby = require('globby')
-        const _files = await globby(['**/*'], { cwd: source })
+        const _files = await globby(['**/*'], { cwd: source, dot: true })
         for (const rawPath of _files) {
           const targetPath = rawPath.split('/').map(filename => {
             // dotfiles are ignored when published to npm, therefore in templates


### PR DESCRIPTION
https://cli.vuejs.org/zh/dev-guide/plugin-dev.html#generator

Although in this passage, it is suggested that we should change ".env" to "_env" to solve the problem of uploading npm packages. But there will also be such a demand, the files in `generator/template` are dynamically pulled from the git repository at runtime, and there may be `.env` files in the repository, so this pr can solve the problem here

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
