### PR TITLE
fix: correctly shim @vue/compiler-sfc for fork-ts-checker-plugin

### DIFF
--- a/packages/@vue/cli-plugin-typescript/vue-compiler-sfc-shim.js
+++ b/packages/@vue/cli-plugin-typescript/vue-compiler-sfc-shim.js
@@ -2,6 +2,13 @@ const compilerSFC = require('@vue/compiler-sfc')
 
 module.exports = {
   parseComponent (content, options) {
-    return compilerSFC.parse(content, options)
+    const result = compilerSFC.parse(content, options)
+    const { script } = result.descriptor
+
+    // fork-ts-checker-webpack-plugin needs to use the `start` property,
+    // which doesn't present in the `@vue/compiler-sfc` parse result
+    if (script) {
+      script.start = script.loc.start.offset
+    }
   }
 }


### PR DESCRIPTION
Fixes the line padding to retain diagnostics location


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
