### PR TITLE
fix(cli-service): process the webpack failed hook in the serve command

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -1,5 +1,6 @@
 const {
   info,
+  error,
   hasProjectYarn,
   hasProjectPnpm,
   openBrowser,
@@ -160,6 +161,12 @@ module.exports = (api, options) => {
 
     // create compiler
     const compiler = webpack(webpackConfig)
+
+    // handle compiler error
+    compiler.hooks.failed.tap('vue-cli-service serve', msg => {
+      error(msg)
+      process.exit(1)
+    })
 
     // create server
     const server = new WebpackDevServer(compiler, Object.assign({


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

#4891 

Vue CLI forgot to process the webpack failed hook in the serve command.
