### PR TITLE
fix: @vue/cli-plugin-eslint upgrade prompt eslint need to upgrade fro…

### DIFF
--- a/packages/@vue/cli-plugin-eslint/migrator/index.js
+++ b/packages/@vue/cli-plugin-eslint/migrator/index.js
@@ -21,14 +21,14 @@ module.exports = async (api) => {
   }
 
   const localESLintMajor = semver.major(
-    semver.maxSatisfying(['4.99.0', '5.99.0', '6.99.0'], localESLintRange) ||
+    semver.maxSatisfying(['4.99.0', '5.99.0', '6.99.0', '7.99.0'], localESLintRange) ||
       // in case the user does not specify a typical caret range;
       // it is used as **fallback** because the user may have not previously
       // installed eslint yet, such as in the case that they are from v3.0.x
       require('eslint/package.json').version
   )
 
-  if (localESLintMajor === 6) {
+  if (localESLintMajor >= 6) {
     return
   }
 
@@ -37,7 +37,7 @@ module.exports = async (api) => {
     type: 'confirm',
     message:
     `Your current ESLint version is v${localESLintMajor}.\n` +
-    `The lastest major version is v6.\n` +
+    `The latest major version which supported by vue-cli is v6.\n` +
     `Do you want to upgrade? (May contain breaking changes)\n`
   }])
 


### PR DESCRIPTION
When upgrading @vue/cli-plugin-eslint, migration will regard 6.x.x eslint as the latest major version, although the latest is 7.x.x now. 

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
