### PR TITLE
docs: serve command default entry value

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -63,7 +63,7 @@ The `vue-cli-service serve` command starts a dev server (based on [webpack-dev-s
 
 In addition to the command line flags, you can also configure the dev server using the [devServer](../config/#devserver) field in `vue.config.js`.
 
-`[entry]` in the CLI command is defined as *the entry file*, not *an additional entry file*. If you overwrite the entry in the CLI, then the entries from `config.pages` are no longer considered, which may cause an error. Defaults to [entryFile](../dev-guide/generator-api.html#entryfile).
+`[entry]` in the CLI command is defined as *the entry file* (default: `src/main.js` or `src/main.ts` in TypeScript project), not *an additional entry file*. If you overwrite the entry in the CLI, then the entries from `config.pages` are no longer considered, which may cause an error.
 
 ## vue-cli-service build
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

https://github.com/vuejs/vue-cli/issues/4485

Document [`vue-cli-service serve`](https://cli.vuejs.org/guide/cli-service.html#vue-cli-service-serve) command default serve entry.