### PR TITLE
Fix: stop ignoring --config-file cypress option

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/index.js
@@ -53,9 +53,10 @@ module.exports.defaultModes = {
 }
 
 function removeArg (rawArgs, argToRemove, offset = 1) {
-  const matchRE = new RegExp(`^--${argToRemove}`)
+  const matchRE = new RegExp(`^--${argToRemove}$`)
   const equalRE = new RegExp(`^--${argToRemove}=`)
-  const i = rawArgs.findIndex(arg => matchRE.test(arg))
+
+  const i = rawArgs.findIndex(arg => matchRE.test(arg) || equalRE.test(arg))
   if (i > -1) {
     rawArgs.splice(i, offset + (equalRE.test(rawArgs[i]) ? 0 : 1))
   }


### PR DESCRIPTION
Since we always call `removeArg(rawArgs, 'config')`, and since the `matchRE` matches `--config` as well as `--config-file`, we end up ignoring the `--config-file` option if it is provided (e.g. `--config-file my-config.json`).

This commit fixes this by ensuring that calling `removeArg('config')` removes `--config` without removing `--config-file`.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
