### PR TITLE
Support ESLint + Coffeescript

### DIFF
--- a/packages/@vue/cli-plugin-eslint/eslintOptions.js
+++ b/packages/@vue/cli-plugin-eslint/eslintOptions.js
@@ -25,6 +25,13 @@ function makeJSOnlyValue (str) {
 }
 
 const baseExtensions = ['.js', '.jsx', '.vue']
-exports.extensions = api => api.hasPlugin('typescript')
-  ? baseExtensions.concat('.ts', '.tsx')
-  : baseExtensions
+exports.extensions = api => {
+  let extensions = baseExtensions
+  if (api.hasPlugin('typescript')) {
+    extensions = extensions.concat('.ts', '.tsx')
+  }
+  if (api.hasPlugin('coffee')) {
+    extensions = extensions.concat('.coffee')
+  }
+  return extensions
+}

--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -41,7 +41,7 @@ module.exports = (api, options) => {
             .add(/node_modules/)
             .add(path.dirname(require.resolve('@vue/cli-service')))
             .end()
-          .test(/\.(vue|(j|t)sx?)$/)
+          .test(/\.(vue|(j|t)sx?|coffee)$/)
           .use('eslint-loader')
             .loader(require.resolve('eslint-loader'))
             .options({


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No (at least in theory I don't think it should have to, but may need clarification)

**Other information:**

Now that ESLint is legitimately supported for Coffeescript as of Coffeescript v2.5.0 (via [`eslint-plugin-coffee`](https://github.com/helixbass/eslint-plugin-coffee)), people using Coffeescript + Vue should be able to successfully run ESLint against their Coffeescript files

But there have been a few issues encountered (see https://github.com/helixbass/eslint-plugin-coffee/issues/27)

Specifically here, I needed to adjust the Vue CLI ESLint config to run against `.coffee` files

These changes (plus https://github.com/mysticatea/vue-eslint-parser/pull/62) got ESLint working with Coffeescript in an example Vue project: https://github.com/helixbass/vue-coffee-eslint-example

But I'm not sure if further refinement is needed here for this to be flexible enough eg for projects that include `.coffee` files but don't have ESLint configured for Coffeescript, or for "hybrid" projects that include both Coffeescript + JS?