### PR TITLE
Added link to S3 deploy cleanup plugin

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -200,7 +200,7 @@ Learn more about setting up [redirects, rewrites](https://render.com/docs/redire
 
 ### Amazon S3
 
-See [vue-cli-plugin-s3-deploy](https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy).
+See [vue-cli-plugin-s3-deploy](https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy) and [vue-cli-plugin-s3-deploy-cleanup](https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup).
 
 ### Firebase
 


### PR DESCRIPTION
I wrote a companion to the S3 deployment plugin that helps to cleanup the S3 bucket after deploying by tagging all files in the deployment directory in S3 that are not on the local machine. Thus, any files with old hashes will be tagged and can be expired in a set number of days using S3 lifecycle rules.

This helps prevent the bucket from becoming filled with old files, making it difficult to tell which is the most current version of a given file.

I added a link to this new plugin to the deployment docs -- please let me know your thoughts!

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Other information:**
