### PR TITLE
fix: fix an edge case that VUE_CLI_SERVICE_CONFIG_PATH might be ignored

### DIFF
--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -314,6 +314,7 @@ module.exports = class Service {
       const resolvedPath = p && path.resolve(this.context, p)
       if (resolvedPath && fs.existsSync(resolvedPath)) {
         fileConfigPath = resolvedPath
+        break
       }
     }
 


### PR DESCRIPTION
Though, it is still a bad practice to use `VUE_CLI_SERVICE_CONFIG_PATH`
in a project with `vue.config.js`

closes #5584

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
