### PR TITLE
fix(nightwatch): compat with legacy presets without `webdrivers` field

### DIFF
--- a/packages/@vue/cli-plugin-e2e-nightwatch/generator/index.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/generator/index.js
@@ -11,6 +11,13 @@ module.exports = (api, { webdrivers }) => {
   // Use devDependencies to store latest version number so as to automate update
   const pluginDeps = require('../package.json').devDependencies
 
+  // In some legacy presets, they may forget to add a `webdrivers` field
+  // (which works fine before PR #5528).
+  // So we should add both drivers by default in that circumstance.
+  if (typeof webdrivers === 'undefined') {
+    webdrivers = ['firefox', 'chrome']
+  }
+
   if (webdrivers && webdrivers.includes('firefox')) {
     devDependencies.geckodriver = pluginDeps.geckodriver
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
