### PR TITLE
fix: fix support for some legacy registry servers

### DIFF
--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -248,7 +248,7 @@ class PackageManager {
 
     const headers = {}
     if (!full) {
-      headers.Accept = 'application/vnd.npm.install-v1+json'
+      headers.Accept = 'application/vnd.npm.install-v1+json;q=1.0, application/json;q=0.9, */*;q=0.8'
     }
 
     if (authToken) {


### PR DESCRIPTION
Some registry servers do not recognize `application/vnd.npm.install-v1+json`
in the Accept header, so here we add `application/json` as fallback.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
