### PR TITLE
feat: Webpack 5 Support

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -1,3 +1,5 @@
+const isWP5 = parseInt(require('webpack').version, 10) === 5
+
 module.exports = (api, options) => {
   api.chainWebpack(webpackConfig => {
     const isLegacyBundle = process.env.VUE_CLI_MODERN_MODE && !process.env.VUE_CLI_MODERN_BUILD
@@ -171,8 +173,10 @@ module.exports = (api, options) => {
             .end()
 
     // shims
+    if (isWP5) {
 
-    webpackConfig.node
+    } else {
+      webpackConfig.node
       .merge({
         // prevent webpack from injecting useless setImmediate polyfill because Vue
         // source contains it (although only uses it if it's native).
@@ -188,7 +192,7 @@ module.exports = (api, options) => {
         tls: 'empty',
         child_process: 'empty'
       })
-
+    }
     const resolveClientEnv = require('../util/resolveClientEnv')
     webpackConfig
       .plugin('define')

--- a/packages/@vue/cli-service/lib/config/prod.js
+++ b/packages/@vue/cli-service/lib/config/prod.js
@@ -1,3 +1,5 @@
+const isWP5 = parseInt(require('webpack').version, 10) === 5
+
 module.exports = (api, options) => {
   api.chainWebpack(webpackConfig => {
     if (process.env.NODE_ENV === 'production') {
@@ -6,11 +8,15 @@ module.exports = (api, options) => {
         .devtool(options.productionSourceMap ? 'source-map' : false)
 
       // keep module.id stable when vendor modules does not change
-      webpackConfig
-        .plugin('hash-module-ids')
+      if (isWP5) {
+        webpackConfig.optimization.moduleIds = 'hashed'
+      } else {
+        webpackConfig
+          .plugin('hash-module-ids')
           .use(require('webpack/lib/HashedModuleIdsPlugin'), [{
             hashDigest: 'hex'
           }])
+      }
 
       // disable optimization during tests to speed things up
       if (process.env.VUE_CLI_TEST) {


### PR DESCRIPTION


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Initial implementation to support Webpack 5, not sure about dev mode - but this works for my needs. Preloading turned off because some hooks need to be updated, other than that if you use yarn resolution to override webpack with v5, builds are successful under my configuration. 

This can serve as a starting point. I'm not a Vue user but do have some builds still in Vue. Will PR project to the extent I require for Module Federation to be operable. 

Its recommended that the community progress this source as this is a good-faith PR. Yarn patching works for me