### PR TITLE
fix jscodeshift peer dependency error

### DIFF
--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -24,6 +24,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@babel/preset-env": "^7.9.6",
     "@vue/cli-shared-utils": "^4.4.5",
     "@vue/cli-ui": "^4.4.5",
     "@vue/cli-ui-addon-webpack": "^4.4.5",
@@ -44,7 +45,7 @@
     "isbinaryfile": "^4.0.6",
     "javascript-stringify": "^1.6.0",
     "js-yaml": "^3.13.1",
-    "jscodeshift": "^0.9.0",
+    "jscodeshift": "^0.10.0",
     "leven": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
     "lru-cache": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11640,6 +11640,31 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
+jscodeshift@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.10.0.tgz#d77cc57dd9a4d24ebcf569468fb04ee36d4632ec"
+  integrity sha512-xpH2FVSEepXoNr6+cPlPHzPzBY1W9bPulufhCHOShzk8+CTCzAOQKytuOXT0b/9PvmO4biRi0g/ZIylVew815w==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/parser" "^7.1.6"
+    "@babel/plugin-proposal-class-properties" "^7.1.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.1.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.1.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.1.0"
+    "@babel/preset-flow" "^7.0.0"
+    "@babel/preset-typescript" "^7.1.0"
+    "@babel/register" "^7.0.0"
+    babel-core "^7.0.0-bridge.0"
+    colors "^1.1.2"
+    flow-parser "0.*"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    neo-async "^2.5.0"
+    node-dir "^0.1.17"
+    recast "^0.18.1"
+    temp "^0.8.1"
+    write-file-atomic "^2.3.0"
+
 jscodeshift@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.9.0.tgz#672025658e868a63e24d6a6f4c44af9edb6e55f3"


### PR DESCRIPTION
Fixes #5612

TODO: @babel/preset-env can be removed when we switch over from
jscodeshift to vue-codemod

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
