### PR TITLE
Fix Kubernetes container detection

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -345,10 +345,13 @@ function addDevClientToEntry (config, devClient) {
 
 // https://stackoverflow.com/a/20012536
 function checkInContainer () {
+  if ('CODESANDBOX_SSE' in process.env) {
+    return true
+  }
   const fs = require('fs')
   if (fs.existsSync(`/proc/1/cgroup`)) {
     const content = fs.readFileSync(`/proc/1/cgroup`, 'utf-8')
-    return /:\/(lxc|docker|kubepods)\//.test(content)
+    return /:\/(lxc|docker|kubepods(\.slice)?)\//.test(content)
   }
 }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

While configuring a new Kubernetes cluster for [CodeSandbox Containers](https://codesandbox.io/docs/environment#container-environment), I've noticed that HMR was not working (again, see #2795). The reason seems to be that cgroup naming has changed in recent Kubernetes versions, and the regex at https://github.com/vuejs/vue-cli/blob/11d60d537e7f748420bf69c086adcbda6769a0e8/packages/@vue/cli-service/lib/commands/serve.js#L300 doesn't match anymore. This PR fixes the regex to match the new cgroup name, adding an optional `.slice` after `kubepods`.

I also went ahead and added a special detection for CodeSandbox Containers, by checking if the `CODESANDBOX_SSE` environment variable is set, so that we can control detection regardless of future cgroup naming changes (or even containerization technology). We would appreciate getting this additional check in, however we can understand if you're hesitant to add 3rd party logic, so just let me know and I'll remove it.

Although it's hard to test the `checkInContainer()` function, you can see this PR working in our new cluster at https://4iycu.sse.codesandbox.stream/ (with `serve.js` manually patched inside `node_modules`).
