### PR TITLE
feat: add `skipLibCheck` option in the TS template (defaults to `true`)

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -12,6 +12,9 @@
     <%_ if (options.allowJs) { _%>
     "allowJs": true,
     <%_ } _%>
+    <%_ if (options.skipLibCheck) { _%>
+    "skipLibCheck": true,
+    <%_ } _%>
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,

--- a/packages/@vue/cli-plugin-typescript/prompts.js
+++ b/packages/@vue/cli-plugin-typescript/prompts.js
@@ -48,6 +48,12 @@ const prompts = module.exports = [
     type: `confirm`,
     message: `Allow .js files to be compiled?`,
     default: false
+  },
+  {
+    name: 'skipLibCheck',
+    type: `confirm`,
+    message: `Skip type checking of all declaration files (recommended for apps)?`,
+    default: true
   }
 ]
 


### PR DESCRIPTION
References:
- It's turned on by default with `tsc --init` https://github.com/microsoft/TypeScript/pull/37808 https://github.com/formium/tsdx/issues/529#issuecomment-598304924
- It's turned on by default in `create-react-app` https://github.com/facebook/create-react-app/pull/5903
- It's turned on by default in Angular CLI https://github.com/angular/angular-cli/pull/16682 https://github.com/angular/angular-cli/issues/16696

Pros:
- Greatly speeds up TypeScript compilation (not a big issue in Vue CLI because we use [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin))
- Both TypeScript and Vue minor version updates, though as widely tested as they can go, still have chances to break existing type definitions. Users' projects should not break because of code they can't control.
- As Vue 3 is still in the pre-release stage, the type definitions may still have breaking changes and ecosystem packages shall take some time to catch up. For average users, enabling `skipLibCheck` brings a better experience.

Cons:
- It skipped type checking of all `.d.ts` files, including the user-owned ones, which isn't ideal. We should turn on type checking for `.d.ts` files in the project once TypeScript provides such an option.
- For library authors, it may be a better idea to disable it. Because they need to ensure their library type definitions are up-to-date with their upstream dependencies/peerDependencies. (A reference issue in the React community: https://github.com/facebook/create-react-app/issues/8964)

/cc @cexbrayat 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
