### PR TITLE
fix: mayProxy.isPublicFileRequest judgment

### DIFF
--- a/packages/@vue/cli-service/lib/util/prepareProxy.js
+++ b/packages/@vue/cli-service/lib/util/prepareProxy.js
@@ -49,7 +49,7 @@ module.exports = function prepareProxy (proxy, appPublicFolder) {
   // https://github.com/facebook/create-react-app/issues/6720
   function mayProxy (pathname) {
     const maybePublicPath = path.resolve(appPublicFolder, pathname.slice(1))
-    const isPublicFileRequest = fs.existsSync(maybePublicPath)
+    const isPublicFileRequest = fs.existsSync(maybePublicPath) && fs.statSync(maybePublicPath).isFile()
     const isWdsEndpointRequest = pathname.startsWith('/sockjs-node') // used by webpackHotDevClient
     return !(isPublicFileRequest || isWdsEndpointRequest)
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
if the proxy path is `/`,  `isPublicFileRequest` will be `/path/to/project/dist/` which is always exist by `fs.existSync(isPublicFileRequest)`. Therefore, it is also necessary to determine whether `isPublicFileRequest` is a file.
