### PR TITLE
[RFC] fix: Generate TypeScript templete when using Router

### DIFF
--- a/packages/@vue/cli/lib/Generator.js
+++ b/packages/@vue/cli/lib/Generator.js
@@ -3,6 +3,7 @@ const debug = require('debug')
 const GeneratorAPI = require('./GeneratorAPI')
 const PackageManager = require('./util/ProjectPackageManager')
 const sortObject = require('./util/sortObject')
+const sortArrayPartially = require('./util/sortArrayPartially')
 const writeFileTree = require('./util/writeFileTree')
 const inferRootOptions = require('./util/inferRootOptions')
 const normalizeFilePaths = require('./util/normalizeFilePaths')
@@ -142,6 +143,9 @@ module.exports = class Generator {
     this.afterInvokeCbs = this.passedAfterInvokeCbs
     this.afterAnyInvokeCbs = []
     this.postProcessFilesCbs = []
+
+    // `@vue/cli-plugin-router` must be executed before `@vue/cli-plugin-typescript`
+    this.plugins = sortArrayPartially(this.plugins, ['@vue/cli-plugin-router', '@vue/cli-plugin-typescript'])
 
     // apply generators from plugins
     for (const plugin of this.plugins) {

--- a/packages/@vue/cli/lib/util/sortArrayPartially.js
+++ b/packages/@vue/cli/lib/util/sortArrayPartially.js
@@ -1,0 +1,21 @@
+module.exports = function sortArrayPartially (array, idOrder) {
+  if (!array) return []
+  const res = array
+  const swappableIndexes = []
+  const subArrayItems = []
+
+  if (idOrder) {
+    idOrder.forEach(key => {
+      const index = array.findIndex((i) => i.id === key)
+      if (index !== -1) {
+        swappableIndexes.push(index)
+        subArrayItems.push(array[index])
+      }
+    })
+  }
+  swappableIndexes.sort().forEach((index, subIndex) => {
+    res[index] = subArrayItems[subIndex]
+  })
+
+  return res
+}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**

References #5695

I found that `@vue/cli-plugin-typescript` won't generate typescript vue templete while using `@vue/cli-plugin-router`.
Its seems overridden by router's template. 
(Please take a look at the issue for detail.)

I made small patch to modify plugin order before their execution.

This is just a PoC.
I don't think this is the best way to solve the problem.

I'd like to ask you to give me some advice.
Maybe it's better to add some methods to GeneratorAPI to manage execution order.

---

FYI: 

I tried to solve this by adding options to `sortObject` in `Creator.resolvePlugins` like this.
```javascript
  // { id: options } => [{ id, apply, options }]
  async resolvePlugins (rawPlugins, pkg) {
    // ensure cli-service is invoked first
    rawPlugins = sortObject(rawPlugins, ['@vue/cli-service', '@vue/cli-plugin-router', '@vue/cli-plugin-typescript'], true)
```

But somehow it didn't work as I intended. It generated same JS template.

I suspect that there is another dependencies on execution order in `generator` functions.