### PR TITLE
fix: make vue-loader-v16 an optional dependency, avoid crashing npm 5

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -72,13 +72,15 @@
     "thread-loader": "^2.1.3",
     "url-loader": "^2.2.0",
     "vue-loader": "^15.9.2",
-    "vue-loader-v16": "npm:vue-loader@^16.0.0-beta.3",
     "vue-style-loader": "^4.1.2",
     "webpack": "^4.0.0",
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-chain": "^6.4.0",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^4.2.2"
+  },
+  "optionalDependencies": {
+    "vue-loader-v16": "npm:vue-loader@^16.0.0-beta.3"
   },
   "peerDependencies": {
     "@vue/compiler-sfc": "^3.0.0-beta.14",


### PR DESCRIPTION
fixes #5715

*What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
