### PR TITLE
feat: implement a migrator that removes `vue-cli-plugin-next` as it's no longer needed

### DIFF
--- a/packages/@vue/cli-service/migrator/index.js
+++ b/packages/@vue/cli-service/migrator/index.js
@@ -1,0 +1,14 @@
+module.exports = (api) => {
+  if (api.hasPlugin('vue-next')) {
+    api.extendPackage({
+      devDependencies: {
+        'vue-cli-plugin-vue-next': null
+      }
+    },
+    {
+      prune: true
+    })
+
+    api.exitLog('vue-cli-plugin-vue-next is removed because Vue 3 support has been built into the core plugins.')
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
