### PR TITLE
fix: fix skipLibCheck default value for `vue create`

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -4,6 +4,7 @@ module.exports = (api, {
   classComponent,
   tsLint,
   lintOn = [],
+  skipLibCheck = true,
   convertJsToTs,
   allowJs
 }, rootOptions, invoking) => {
@@ -90,6 +91,7 @@ module.exports = (api, {
   }
 
   api.render('./template', {
+    skipLibCheck,
     hasMocha: api.hasPlugin('unit-mocha'),
     hasJest: api.hasPlugin('unit-jest')
   })

--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -12,7 +12,7 @@
     <%_ if (options.allowJs) { _%>
     "allowJs": true,
     <%_ } _%>
-    <%_ if (options.skipLibCheck) { _%>
+    <%_ if (skipLibCheck) { _%>
     "skipLibCheck": true,
     <%_ } _%>
     "esModuleInterop": true,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
