### PR TITLE
fix: ignore `.svn/**` when reading and writing files

### DIFF
--- a/packages/@vue/cli/lib/util/readFiles.js
+++ b/packages/@vue/cli/lib/util/readFiles.js
@@ -10,7 +10,7 @@ module.exports = async function readFiles (context) {
     cwd: context,
     onlyFiles: true,
     gitignore: true,
-    ignore: ['**/node_modules/**', '**/.git/**'],
+    ignore: ['**/node_modules/**', '**/.git/**', '**/.svn/**'],
     dot: true
   })
   const res = {}


### PR DESCRIPTION
Fixes #5689

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
