### PR TITLE
refactor: output webdriverio logs to `tests/e2e/logs`

### DIFF
--- a/packages/@vue/cli-plugin-e2e-webdriverio/generator/template/wdio.shared.conf.js
+++ b/packages/@vue/cli-plugin-e2e-webdriverio/generator/template/wdio.shared.conf.js
@@ -31,7 +31,7 @@ exports.config = {
   logLevel: 'trace',
   //
   // Set directory to store all logs into
-  outputDir: path.join(__dirname, '/logs'),
+  outputDir: path.join(__dirname, 'test/e2e/logs'),
   //
   // If you only want to run your tests until a specific amount of tests have failed use
   // bail (default is 0 - don't bail, run all tests).

--- a/packages/@vue/cli-service/generator/template/_gitignore
+++ b/packages/@vue/cli-service/generator/template/_gitignore
@@ -14,6 +14,11 @@ geckodriver.log
 /tests/e2e/screenshots/
 <%_ } _%>
 
+<%_ if (rootOptions.plugins && rootOptions.plugins['@vue/cli-plugin-e2e-webdriverio']) { _%>
+
+/tests/e2e/logs/
+<%_ } _%>
+
 # local env files
 .env.local
 .env.*.local


### PR DESCRIPTION
This allows us to have a more accurate path to specify in .gitignore

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
