### PR TITLE
chore: use `stdout.columns` to determine the stats table width

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/formatStats.js
+++ b/packages/@vue/cli-service/lib/commands/build/formatStats.js
@@ -2,7 +2,7 @@ module.exports = function formatStats (stats, dir, api) {
   const fs = require('fs')
   const path = require('path')
   const zlib = require('zlib')
-  const ui = require('cliui')({ width: 80 })
+  const ui = require('cliui')({ width: process.stdout.columns || 80 })
   const { chalk } = require('@vue/cli-shared-utils')
 
   const json = stats.toJson({


### PR DESCRIPTION
closes #5749

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
