### PR TITLE
Update vue-compiler-sfc-shim.js

### DIFF
--- a/packages/@vue/cli-plugin-typescript/vue-compiler-sfc-shim.js
+++ b/packages/@vue/cli-plugin-typescript/vue-compiler-sfc-shim.js
@@ -1,7 +1,7 @@
 const compilerSFC = require('@vue/compiler-sfc')
 
 module.exports = {
-  parseComponent (content, options) {
+  parse (content, options) {
     const result = compilerSFC.parse(content, options)
     const { script } = result.descriptor
 


### PR DESCRIPTION
https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/master/src/typescript-reporter/extension/vue/TypeScriptVueExtension.ts#L36

fork-ts-checker-webpack-plugin-v5中判断是vue 3版本依据的是`typeof (compiler as VueTemplateCompilerV3).parse === 'function'`，而这个文件中的方法是parseComponent，导致fork-ts-checker-webpack-plugin-v5中判断是vue 2版本，无法正确处理vue文件中的ts编译。

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
