### PR TITLE
fix: add missing mocha type if wdio is not installed along with any unit testing frameworks

### DIFF
--- a/packages/@vue/cli-plugin-e2e-webdriverio/package.json
+++ b/packages/@vue/cli-plugin-e2e-webdriverio/package.json
@@ -25,6 +25,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@types/mocha": "^8.0.1",
     "@vue/cli-shared-utils": "^4.5.2",
     "@wdio/cli": "^6.1.11",
     "@wdio/local-runner": "^6.1.11",

--- a/packages/@vue/cli-plugin-typescript/generator/index.js
+++ b/packages/@vue/cli-plugin-typescript/generator/index.js
@@ -88,6 +88,11 @@ module.exports = (api, {
       // eslint-disable-next-line node/no-extraneous-require
       require('@vue/cli-plugin-eslint/generator').applyTS(api)
     }
+
+    if (api.hasPlugin('e2e-webdriverio')) {
+      // eslint-disable-next-line node/no-extraneous-require
+      require('@vue/cli-plugin-e2e-webdriverio/generator').applyTS(api)
+    }
   }
 
   api.render('./template', {

--- a/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
+++ b/packages/@vue/cli-plugin-typescript/generator/template/tsconfig.json
@@ -22,6 +22,7 @@
     "types": [
       "webpack-env"<% if (hasMocha || hasJest || hasWebDriverIO) { %>,<% } %>
       <%_ if (hasWebDriverIO) { _%>
+      <% if (!hasMocha && !hasJest) { %>"mocha",<% } %>
       "@wdio/mocha-framework",
       "@wdio/sync"<% if (hasMocha || hasJest) { %>,<% } %>
       <%_ } _%>


### PR DESCRIPTION
A better fix is to use different `tsconfig` for E2E or unit testing files, but I haven't got the time to figure it out. So adding this as a temporary workaround.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
