### PR TITLE
refactor(wip): replace node-ipc with a cleanroom IPC implementation

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -4,7 +4,7 @@ const {
   hasProjectYarn,
   hasProjectPnpm,
   openBrowser,
-  IpcMessenger
+  NewIpcMessenger
 } = require('@vue/cli-shared-utils')
 
 const defaults = {
@@ -301,7 +301,7 @@ module.exports = (api, options) => {
 
           // Send final app URL
           if (args.dashboard) {
-            const ipc = new IpcMessenger()
+            const ipc = new NewIpcMessenger()
             ipc.send({
               vueServe: {
                 url: localUrlForBrowser

--- a/packages/@vue/cli-service/lib/webpack/DashboardPlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/DashboardPlugin.js
@@ -7,14 +7,14 @@
 const path = require('path')
 const fs = require('fs-extra')
 const webpack = require('webpack')
-const { IpcMessenger } = require('@vue/cli-shared-utils')
+const { NewIpcMessenger } = require('@vue/cli-shared-utils')
 const { analyzeBundle } = require('./analyzeBundle')
 
 const ID = 'vue-cli-dashboard-plugin'
 const ONE_SECOND = 1000
 const FILENAME_QUERY_REGEXP = /\?.*$/
 
-const ipc = new IpcMessenger()
+const ipc = new NewIpcMessenger()
 
 function getTimeMessage (timer) {
   let time = Date.now() - timer

--- a/packages/@vue/cli-shared-utils/index.js
+++ b/packages/@vue/cli-shared-utils/index.js
@@ -2,6 +2,7 @@
   'env',
   'exit',
   'ipc',
+  'NewIpcMessenger',
   'logger',
   'module',
   'object',

--- a/packages/@vue/cli-shared-utils/lib/NewIpcMessenger.js
+++ b/packages/@vue/cli-shared-utils/lib/NewIpcMessenger.js
@@ -25,7 +25,7 @@ exports.NewIpcMessenger = class NewIpcMessenger {
     this.connected = false
     this.connecting = false
     this.disconnecting = false
-    this.queue = null
+    this.queue = []
     this.listeners = []
 
     this.disconnectTimeout = 15000
@@ -83,7 +83,7 @@ exports.NewIpcMessenger = class NewIpcMessenger {
       this.connected = true
       this.connecting = false
       this.queue && this.queue.forEach(data => this.send(data))
-      this.queue = null
+      this.queue = []
     })
   }
 


### PR DESCRIPTION
The packet format is compatible with the `node-ipc` default.

After this commit, no core plugins will rely on `node-ipc` to do anything.
But the UI still needs it to communicate with plugins.

TODOs:
- Fix UI build task
- Finish the IPC server implementation
- Refactor `@vue/cli-ui` to get rid of `node-ipc`, too
- Fully refactor the IpcMessenger module to address cross-platform
issues, etc.

Fixes #2621

It is a cleanroom implementation because I've never read a line of the `node-ipc` code. I've only read [the package's README](https://www.npmjs.com/package/node-ipc) before implementing this PR.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
