### PR TITLE
 fix: ensure Dev Tool is enabled in Vue 3 runtime

### DIFF
--- a/packages/@vue/cli-service/__tests__/serve.spec.js
+++ b/packages/@vue/cli-service/__tests__/serve.spec.js
@@ -15,6 +15,7 @@ test('serve', async () => {
     async ({ page, nextUpdate, helpers }) => {
       const msg = `Welcome to Your Vue.js App`
       expect(await helpers.getText('h1')).toMatch(msg)
+      expect(await page.evaluate('window.__VUE__')).toBeDefined()
 
       // test hot reload
       const file = await project.read(`src/App.vue`)

--- a/packages/@vue/cli-service/__tests__/serve.spec.js
+++ b/packages/@vue/cli-service/__tests__/serve.spec.js
@@ -15,7 +15,6 @@ test('serve', async () => {
     async ({ page, nextUpdate, helpers }) => {
       const msg = `Welcome to Your Vue.js App`
       expect(await helpers.getText('h1')).toMatch(msg)
-      expect(await page.evaluate(() => window.__VUE__)).toBeDefined()
 
       // test hot reload
       const file = await project.read(`src/App.vue`)

--- a/packages/@vue/cli-service/__tests__/serve.spec.js
+++ b/packages/@vue/cli-service/__tests__/serve.spec.js
@@ -15,7 +15,7 @@ test('serve', async () => {
     async ({ page, nextUpdate, helpers }) => {
       const msg = `Welcome to Your Vue.js App`
       expect(await helpers.getText('h1')).toMatch(msg)
-      expect(await page.evaluate('window.__VUE__')).toBeDefined()
+      expect(await page.evaluate(() => window.__VUE__)).toBeDefined()
 
       // test hot reload
       const file = await project.read(`src/App.vue`)

--- a/packages/@vue/cli-service/__tests__/serveVue3.spec.js
+++ b/packages/@vue/cli-service/__tests__/serveVue3.spec.js
@@ -13,7 +13,7 @@ test('serve with Vue 3', async () => {
     async ({ page, nextUpdate, helpers }) => {
       const msg = `Welcome to Your Vue.js App`
       expect(await helpers.getText('h1')).toMatch(msg)
-      expect(await page.evaluate('window.__VUE__')).toBeDefined()
+      expect(await page.evaluate(() => window.__VUE__)).toBeDefined()
 
       // test hot reload
       const file = await project.read(`src/App.vue`)

--- a/packages/@vue/cli-service/__tests__/serveVue3.spec.js
+++ b/packages/@vue/cli-service/__tests__/serveVue3.spec.js
@@ -13,6 +13,7 @@ test('serve with Vue 3', async () => {
     async ({ page, nextUpdate, helpers }) => {
       const msg = `Welcome to Your Vue.js App`
       expect(await helpers.getText('h1')).toMatch(msg)
+      expect(await page.evaluate('window.__VUE__')).toBeDefined()
 
       // test hot reload
       const file = await project.read(`src/App.vue`)

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -121,7 +121,7 @@ module.exports = (api, options) => {
             'vue$',
             options.runtimeCompiler
               ? 'vue/dist/vue.esm-bundler.js'
-              : '@vue/runtime-dom'
+              : 'vue/dist/vue.runtime.esm-bundler.js'
           )
 
       webpackConfig.module


### PR DESCRIPTION
The old alias `@vue/runtime-dom` was introduced because webpack HMR has
trouble with pure re-exports. Now that the `vue.runtime.esm-bundler.js`
file also includes a call to `initDev`, it's no longer an issue. This
also enables Dev Tool in Vue 3 runtime.

Fixes #5785

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
