### PR TITLE
update serialize-javascript to 3.1.0+ to address security vulnerabili…

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -46,7 +46,7 @@
     "cli-highlight": "^2.1.4",
     "clipboardy": "^2.3.0",
     "cliui": "^6.0.0",
-    "copy-webpack-plugin": "^5.1.1",
+    "copy-webpack-plugin": "^6.0.3",
     "css-loader": "^3.5.3",
     "cssnano": "^4.1.10",
     "debug": "^4.1.1",


### PR DESCRIPTION
This PR updates `serialize-javascript` to `3.1.0`+ to address security vulnerabilities of `serialize-javascript` < `3.1.0`, a sub-dependency of `copy-webpack-plugin`.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools (?dependency?)
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No
- [x] not sure, this project isn't containerized and I don't want to install yarn and other artifacts on my host

**Other information:**
I'm hoping your CI will figure out if this is a breaking change or not.

```
High            Remote Code Execution
Package         serialize-javascript
Patched in      >=3.1.0
Dependency of   @vue/cli-service [dev]
Path            @vue/cli-service > copy-webpack-plugin >
                serialize-javascript
More info       https://npmjs.com/advisories/1548
```
```
`-- @vue/cli-service@4.4.6
  +-- copy-webpack-plugin@5.1.1
  | `-- serialize-javascript@2.1.2 
  `-- terser-webpack-plugin@2.3.7
    `-- serialize-javascript@3.1.0 
```