### PR TITLE
update ts-jest to above 26.2.0 to address security vulnerabilities of…

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -36,7 +36,7 @@
     "jest-serializer-vue": "^2.0.2",
     "jest-transform-stub": "^2.0.0",
     "jest-watch-typeahead": "^0.4.2",
-    "ts-jest": "^24.2.0",
+    "ts-jest": "^26.2.0",
     "vue-jest": "^3.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request updates `ts-jest` to above `26.2.0` to address security vulnerabilities of `yargs-parser` < `18.1.2`, a sub-dependency of `ts-jest`

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools (?dependency?)
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No
- [x] maybe: this project isn't containerized and I don't want to install yarn and things on my host

**Other information:**
I'm hoping your CI will figure out if this is a breaking change or not.

```
+-- @vue/cli-plugin-unit-jest@4.4.6
| `-- ts-jest@24.3.0
|   `-- yargs-parser@10.1.0 
```
```
Low             Prototype Pollution                                           
Package         yargs-parser                                                  
Patched in      >=13.1.2 <14.0.0 || >=15.0.1 <16.0.0 || >=18.1.2              
Dependency of   @vue/cli-plugin-unit-jest [dev]                               
Path            @vue/cli-plugin-unit-jest > ts-jest > yargs-parser            
More info       https://npmjs.com/advisories/1500
```