### PR TITLE
fix: do not throw when api.render is called from an anonymous function

### DIFF
--- a/packages/@vue/cli/__tests__/Generator.spec.js
+++ b/packages/@vue/cli/__tests__/Generator.spec.js
@@ -531,6 +531,26 @@ test('api: render fs directory', async () => {
   expect(fs.readFileSync('/.vscode/config.json', 'utf-8')).toMatch('{}')
 })
 
+// #4774
+test('api: call render inside an anonymous function', async () => {
+  const generator = new Generator('/', { plugins: [
+    {
+      id: 'test1',
+      apply: api => {
+        (() => {
+          api.render('./template', { m: 2 })
+        })()
+      },
+      options: {
+        n: 1
+      }
+    }
+  ] })
+
+  await generator.generate()
+  expect(fs.readFileSync('/foo.js', 'utf-8')).toMatch('foo(1)')
+})
+
 test('api: render object', async () => {
   const generator = new Generator('/', { plugins: [
     {

--- a/packages/@vue/cli/lib/GeneratorAPI.js
+++ b/packages/@vue/cli/lib/GeneratorAPI.js
@@ -457,7 +457,18 @@ function extractCallDir () {
   const obj = {}
   Error.captureStackTrace(obj)
   const callSite = obj.stack.split('\n')[3]
-  const fileName = callSite.match(/\s\((.*):\d+:\d+\)$/)[1]
+
+  // the regexp for the stack when called inside a named function
+  const namedStackRegExp = /\s\((.*):\d+:\d+\)$/
+  // the regexp for the stack when called inside an anonymous
+  const anonymousStackRegExp = /at (.*):\d+:\d+$/
+
+  let matchResult = callSite.match(namedStackRegExp)
+  if (!matchResult) {
+    matchResult = callSite.match(anonymousStackRegExp)
+  }
+
+  const fileName = matchResult[1]
   return path.dirname(fileName)
 }
 


### PR DESCRIPTION
Fixes #4774

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
