### PR TITLE
fix: writeFileSync path was missing api.resolve

### DIFF
--- a/docs/dev-guide/plugin-dev.md
+++ b/docs/dev-guide/plugin-dev.md
@@ -289,7 +289,7 @@ module.exports.hooks = (api) => {
     const renderIndex = lines.findIndex(line => line.match(/render/))
     lines[renderIndex] += `${EOL}  router,`
 
-    fs.writeFileSync(api.entryFile, lines.join(EOL), { encoding: 'utf-8' })
+    fs.writeFileSync(api.resolve(api.entryFile), lines.join(EOL), { encoding: 'utf-8' })
   })
 }
 ```


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
I've tested the example code on the docs, however it didn't work. After wrapping the file path with api.resolve it worked.