### PR TITLE
fix: strip non-ansi characters from registry config

### DIFF
--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -5,6 +5,8 @@ const ini = require('ini')
 const minimist = require('minimist')
 const LRU = require('lru-cache')
 
+const stripAnsi = require('strip-ansi')
+
 const {
   chalk,
   execa,
@@ -152,6 +154,7 @@ class PackageManager {
       }
     }
 
+    this._registry = stripAnsi(this._registry).trim()
     return this._registry
   }
 

--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -55,6 +55,7 @@
     "resolve": "^1.17.0",
     "shortid": "^2.2.15",
     "slash": "^3.0.0",
+    "strip-ansi": "^6.0.0",
     "validate-npm-package-name": "^3.0.0",
     "vue": "^2.6.11",
     "vue-codemod": "^0.0.4",


### PR DESCRIPTION
To deal with malformed stdout result retrieved from child processes.

Fixes #5802

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
