### PR TITLE
docs: update Node version requirement to address package manager issues

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -6,7 +6,10 @@ If you have the previous `vue-cli` (1.x or 2.x) package installed globally, you 
 :::
 
 ::: tip Node Version Requirement
-Vue CLI requires [Node.js](https://nodejs.org/) version 8.9 or above (8.11.0+ recommended). You can manage multiple versions of Node on the same machine with [nvm](https://github.com/creationix/nvm) or [nvm-windows](https://github.com/coreybutler/nvm-windows).
+Vue CLI 4.x requires [Node.js](https://nodejs.org/) version 8.9 or above (v10+ recommended). You can manage multiple versions of Node on the same machine with [n](https://github.com/tj/n), [nvm](https://github.com/creationix/nvm) or [nvm-windows](https://github.com/coreybutler/nvm-windows).
+
+As Node.js v8 has reached end-of-life, it's now recommended to use Node.js v10+ for best compatibility.
+If you have to stay with Node.js v8, please make sure npm v6 is used as the default package manager. (`npm -v` to check the version, and `vue config --set packageManager npm` to set the default package manager.)
 :::
 
 To install the new package, use one of the following commands. You need administrator privileges to execute these unless npm was installed on your system through a Node.js version manager (e.g. n or nvm).
@@ -38,7 +41,7 @@ yarn global upgrade --latest @vue/cli
 
 #### Project Dependencies
 
-Upgrade commands shown above apply to the global Vue CLI installation. To upgrade one or more `@vue/cli` related packages (including packages starting with `@vue/cli-plugin-`) inside your project, run `vue upgrade` inside the project directory:
+Upgrade commands shown above apply to the global Vue CLI installation. To upgrade one or more `@vue/cli` related packages (including packages starting with `@vue/cli-plugin-` or `vue-cli-plugin-`) inside your project, run `vue upgrade` inside the project directory:
 
 ```
 Usage: upgrade [options] [plugin-name]
@@ -46,7 +49,7 @@ Usage: upgrade [options] [plugin-name]
 (experimental) upgrade vue cli service / plugins
 
 Options:
-  -t, --to <version>    Upgrade <package-name> to a version that is not latest
+  -t, --to <version>    Upgrade <plugin-name> to a version that is not latest
   -f, --from <version>  Skip probing installed plugin, assuming it is upgraded from the designated version
   -r, --registry <url>  Use specified npm registry when installing dependencies
   --all                 Upgrade all plugins

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -6,7 +6,10 @@ Vue CLI 的包名称由 `vue-cli` 改成了 `@vue/cli`。
 :::
 
 ::: tip Node 版本要求
-Vue CLI 需要 [Node.js](https://nodejs.org/) 8.9 或更高版本 (推荐 8.11.0+)。你可以使用 [nvm](https://github.com/creationix/nvm) 或 [nvm-windows](https://github.com/coreybutler/nvm-windows) 在同一台电脑中管理多个 Node 版本。
+Vue CLI 4.x 需要 [Node.js](https://nodejs.org/) v8.9 或更高版本 (推荐 v10 以上)。你可以使用 [n](https://github.com/tj/n)，[nvm](https://github.com/creationix/nvm) 或 [nvm-windows](https://github.com/coreybutler/nvm-windows) 在同一台电脑中管理多个 Node 版本。
+
+由于 Node.js v8 已不再维护，我们建议使用 Node.js v10 以上的版本，以保证最佳的兼容性。
+如果暂时无法升级 Node.js 版本，请使用 npm v6 作为默认的包管理工具。（可以用 `npm -v` 检查 npm 版本，然后运行 `vue config --set packageManager npm` 以设置默认包管理工具。）
 :::
 
 可以使用下列任一命令安装这个新的包：
@@ -24,3 +27,33 @@ yarn global add @vue/cli
 ```bash
 vue --version
 ```
+
+### 升级
+
+如需升级全局的 Vue CLI 包，请运行：
+
+``` bash
+npm update -g @vue/cli
+
+# 或者
+yarn global upgrade --latest @vue/cli
+```
+
+#### 项目依赖
+
+上面列出来的命令是用于升级全局的 Vue CLI。如需升级项目中的 Vue CLI 相关模块（以 `@vue/cli-plugin-` 或 `vue-cli-plugin-` 开头），请在项目目录下运行 `vue upgrade`：
+
+```
+用法： upgrade [options] [plugin-name]
+
+（试用）升级 Vue CLI 服务及插件
+
+选项：
+  -t, --to <version>    升级 <plugin-name> 到指定的版本
+  -f, --from <version>  跳过本地版本检测，默认插件是从此处指定的版本升级上来
+  -r, --registry <url>  使用指定的 registry 地址安装依赖
+  --all                 升级所有的插件
+  --next                检查插件新版本时，包括 alpha/beta/rc 版本在内
+  -h, --help            输出帮助内容
+```
+


### PR DESCRIPTION
It's recommended to use NPM v6 with Node.js v8, because:

1. Some of the upstream packages may accidentally introduce dependencies
that require Node.js 10+ in the `engines` field. This only leads to a
warning in NPM but will break Yarn.

2. NPM v5 does not support dependency versions starting with `npm:`,
so it can't support Vue 3 related features in Vue CLI.

Also added recommendation for `n` as the Node version manager because `nvm` sometimes causes problems for Vue CLI UI.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
