### PR TITLE
Handle GPG sign git config for initial commit

### DIFF
--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -254,6 +254,7 @@ module.exports = class Creator extends EventEmitter {
       if (isTestOrDebug) {
         await run('git', ['config', 'user.name', 'test'])
         await run('git', ['config', 'user.email', 'test@test.com'])
+        await run('git', ['config', 'commit.gpgSign', 'false'])
       }
       gpgSign = await (async () => {
         const { stdout: gpgSignConfig } = await run('git', [

--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -248,12 +248,21 @@ module.exports = class Creator extends EventEmitter {
 
     // commit initial state
     let gitCommitFailed = false
+    let gpgSign = false
     if (shouldInitGit) {
       await run('git add -A')
       if (isTestOrDebug) {
         await run('git', ['config', 'user.name', 'test'])
         await run('git', ['config', 'user.email', 'test@test.com'])
       }
+      gpgSign = await (async () => {
+        const { stdout: gpgSignConfig } = await run('git', [
+          'config',
+          '--get',
+          'commit.gpgSign'
+        ])
+        return gpgSignConfig === 'true'
+      })()
       const msg = typeof cliOptions.git === 'string' ? cliOptions.git : 'init'
       try {
         await run('git', ['commit', '-m', msg, '--no-verify'])
@@ -277,7 +286,7 @@ module.exports = class Creator extends EventEmitter {
 
     if (gitCommitFailed) {
       warn(
-        `Skipped git commit due to missing username and email in git config.\n` +
+        `Skipped git commit due to missing username and email in git config${gpgSign ? ' or failed to sign commit' : ''}.\n` +
         `You will need to perform the initial commit yourself.\n`
       )
     }


### PR DESCRIPTION
Fixes #5818 

~~If the git config option `commit.gpgSign` is set
to `true`, passes the flag `--no-gpg-sign` when
creating the initial commit, then warns user that
initial commit is not signed and instructs how
to sign the initial commit~~

If git config `commit.gpgSign = true`, then warning on failed initial commit is expanded to also state that failure to commit could
be due to failure to sign commit. Also sets the `commit.gpgSign` config to `false` if testing or debugging.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
~~This PR will change `vue create` to *never* sign the initial commit. My personal opinion is that this is the preferred behavior, since I wouldn't want to default to signing a commit that I did not create. But another way to fix #5818 would be to continue to attempt GPG sign if `commit.gpgSign = true` in git config, and make warning say that commit failed due to missing username, email, *or* failure to sign commit. If you think it is better to continue signing and change the `gitCommitFailed` warning instead, I could create a PR for that instead~~ :slightly_smiling_face: 