### PR TITLE
fix: skip checking git gpgSign config

### DIFF
--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -259,7 +259,6 @@ module.exports = class Creator extends EventEmitter {
 
     // commit initial state
     let gitCommitFailed = false
-    let gpgSign = false
     if (shouldInitGit) {
       await run('git add -A')
       if (isTestOrDebug) {
@@ -267,14 +266,6 @@ module.exports = class Creator extends EventEmitter {
         await run('git', ['config', 'user.email', 'test@test.com'])
         await run('git', ['config', 'commit.gpgSign', 'false'])
       }
-      gpgSign = await (async () => {
-        const { stdout: gpgSignConfig } = await run('git', [
-          'config',
-          '--get',
-          'commit.gpgSign'
-        ])
-        return gpgSignConfig === 'true'
-      })()
       const msg = typeof cliOptions.git === 'string' ? cliOptions.git : 'init'
       try {
         await run('git', ['commit', '-m', msg, '--no-verify'])
@@ -298,7 +289,7 @@ module.exports = class Creator extends EventEmitter {
 
     if (gitCommitFailed) {
       warn(
-        `Skipped git commit due to missing username and email in git config${gpgSign ? ' or failed to sign commit' : ''}.\n` +
+        `Skipped git commit due to missing username and email in git config, or failed to sign commit.\n` +
         `You will need to perform the initial commit yourself.\n`
       )
     }


### PR DESCRIPTION
Fix the issue described at https://github.com/vuejs/vue-cli/pull/5823#issuecomment-690269893

This simplifies the logic, thus less error-prone.
The error message is still correct anyway.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
