### PR TITLE
fix: more accurate warning message for missing global peer dependencies

### DIFF
--- a/packages/@vue/cli/lib/util/clearConsole.js
+++ b/packages/@vue/cli/lib/util/clearConsole.js
@@ -1,35 +1,12 @@
 const getVersions = require('./getVersions')
 const {
   chalk,
-  execa,
   semver,
 
-  clearConsole,
-
-  hasYarn,
-  hasPnpm3OrLater
+  clearConsole
 } = require('@vue/cli-shared-utils')
 
-async function getInstallationCommand () {
-  if (hasYarn()) {
-    const { stdout: yarnGlobalDir } = await execa('yarn', ['global', 'dir'])
-    if (__dirname.includes(yarnGlobalDir)) {
-      return 'yarn global add'
-    }
-  }
-
-  if (hasPnpm3OrLater()) {
-    const { stdout: pnpmGlobalPrefix } = await execa('pnpm', ['config', 'get', 'prefix'])
-    if (__dirname.includes(pnpmGlobalPrefix) && __dirname.includes('pnpm-global')) {
-      return `pnpm i -g`
-    }
-  }
-
-  const { stdout: npmGlobalPrefix } = await execa('npm', ['config', 'get', 'prefix'])
-  if (__dirname.includes(npmGlobalPrefix)) {
-    return `npm i -g`
-  }
-}
+const getGlobalInstallCommand = require('./getGlobalInstallCommand')
 
 exports.generateTitle = async function (checkUpdate) {
   const { current, latest, error } = await getVersions()
@@ -53,7 +30,7 @@ exports.generateTitle = async function (checkUpdate) {
       let upgradeMessage = `New version available ${chalk.magenta(current)} → ${chalk.green(latest)}`
 
       try {
-        const command = await getInstallationCommand()
+        const command = getGlobalInstallCommand()
         let name = require('../../package.json').name
         if (semver.prerelease(latest)) {
           name += '@next'

--- a/packages/@vue/cli/lib/util/getGlobalInstallCommand.js
+++ b/packages/@vue/cli/lib/util/getGlobalInstallCommand.js
@@ -1,6 +1,6 @@
 const { execa, hasYarn, hasPnpm3OrLater } = require('@vue/cli-shared-utils')
 
-module.exports.getGlobalInstallCommand = function getGlobalInstallCommand () {
+module.exports = function getGlobalInstallCommand () {
   if (hasYarn()) {
     const { stdout: yarnGlobalDir } = execa.sync('yarn', ['global', 'dir'])
     if (__dirname.includes(yarnGlobalDir)) {

--- a/packages/@vue/cli/lib/util/getGlobalInstallCommand.js
+++ b/packages/@vue/cli/lib/util/getGlobalInstallCommand.js
@@ -1,0 +1,22 @@
+const { execa, hasYarn, hasPnpm3OrLater } = require('@vue/cli-shared-utils')
+
+module.exports.getGlobalInstallCommand = function getGlobalInstallCommand () {
+  if (hasYarn()) {
+    const { stdout: yarnGlobalDir } = execa.sync('yarn', ['global', 'dir'])
+    if (__dirname.includes(yarnGlobalDir)) {
+      return 'yarn global add'
+    }
+  }
+
+  if (hasPnpm3OrLater()) {
+    const { stdout: pnpmGlobalPrefix } = execa.sync('pnpm', ['config', 'get', 'prefix'])
+    if (__dirname.includes(pnpmGlobalPrefix) && __dirname.includes('pnpm-global')) {
+      return `pnpm i -g`
+    }
+  }
+
+  const { stdout: npmGlobalPrefix } = execa.sync('npm', ['config', 'get', 'prefix'])
+  if (__dirname.includes(npmGlobalPrefix)) {
+    return `npm i -g`
+  }
+}

--- a/packages/@vue/cli/lib/util/loadCommand.js
+++ b/packages/@vue/cli/lib/util/loadCommand.js
@@ -1,3 +1,6 @@
+const { chalk } = require('@vue/cli-shared-utils')
+const getGlobalInstallCommand = require('./getGlobalInstallCommand')
+
 module.exports = function loadCommand (commandName, moduleName) {
   const isNotFoundError = err => {
     return err.message.match(/Cannot find module/)
@@ -10,13 +13,7 @@ module.exports = function loadCommand (commandName, moduleName) {
         return require('import-global')(moduleName)
       } catch (err2) {
         if (isNotFoundError(err2)) {
-          const { chalk, hasYarn, hasPnpm3OrLater } = require('@vue/cli-shared-utils')
-          let installCommand = `npm install -g`
-          if (hasYarn()) {
-            installCommand = `yarn global add`
-          } else if (hasPnpm3OrLater()) {
-            installCommand = `pnpm install -g`
-          }
+          const installCommand = getGlobalInstallCommand()
           console.log()
           console.log(
             `  Command ${chalk.cyan(`vue ${commandName}`)} requires a global addon to be installed.\n` +


### PR DESCRIPTION
such as `@vue/cli-service-global` & `@vue/cli-init`

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
