### PR TITLE
docs: add yarn link error solution

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,6 +26,7 @@ yarn
 # if you have the old vue-cli installed globally, you may
 # need to uninstall it first.
 cd packages/@vue/cli
+# before yarn link, you can delete the link in ~/.config/yarn/link @vue (refer iissue: [yarn link error message is not helpful](https://github.com/yarnpkg/yarn/issues/7054))
 yarn link
 
 # create test projects in /packages/test

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ yarn
 # if you have the old vue-cli installed globally, you may
 # need to uninstall it first.
 cd packages/@vue/cli
-# before yarn link, you can delete the link in ~/.config/yarn/link @vue (refer iissue: [yarn link error message is not helpful](https://github.com/yarnpkg/yarn/issues/7054))
+# before yarn link, you can delete the link in `~/.config/yarn/link/@vue` (see issue: [yarn link error message is not helpful](https://github.com/yarnpkg/yarn/issues/7054))
 yarn link
 
 # create test projects in /packages/test


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

```bash
$ yarn link
---> warning There's already a package called "@vue" registered. This command has had no effect. If this command was run in another folder with the same name, the other folder is still linked. Please run yarn unlink in the other folder if you want to register this folder.
```