### PR TITLE
chore: show error message that the `wc` target with Vue 3 isn't supported yet

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -5,11 +5,16 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
   // Disable CSS extraction and turn on CSS shadow mode for vue-style-loader
   process.env.VUE_CLI_CSS_SHADOW_MODE = true
 
-  const { log, error } = require('@vue/cli-shared-utils')
+  const { log, error, loadModule, semver } = require('@vue/cli-shared-utils')
   const abort = msg => {
     log()
     error(msg)
     process.exit(1)
+  }
+
+  const vue = loadModule('vue', api.resolve('.'))
+  if (vue && semver.satisfies(vue.version, '^3.0.0-0')) {
+    abort(`Vue 3 support of the web component target is still under development.`)
   }
 
   const isAsync = /async/.test(target)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
