### PR TITLE
fix: narrow the eslint peer dep version range, avoiding npm 7 error

### DIFF
--- a/packages/@vue/cli-plugin-eslint/package.json
+++ b/packages/@vue/cli-plugin-eslint/package.json
@@ -32,6 +32,6 @@
   },
   "peerDependencies": {
     "@vue/cli-service": "^3.0.0 || ^4.0.0-0",
-    "eslint": ">= 1.6.0"
+    "eslint": ">= 1.6.0 < 7.0.0"
   }
 }


### PR DESCRIPTION
v4 does not support eslint 7

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
