### PR TITLE
types(vue.config.js): add descriptions for config

### DIFF
--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -25,21 +25,25 @@ interface ExtractOptions {
 interface CSSOptions {
   /**
    * Default: `true`
+   *
    * By default, only files that ends in `*.module.[ext]` are treated as CSS modules
    */
   requireModuleExtension?: boolean;
   /**
    * Default: `true`
+   *
    * Whether to extract CSS in your components into a standalone CSS files (instead of inlined in JavaScript and injected dynamically)
    */
   extract?: boolean | ExtractOptions;
   /**
    * Default: `false`
+   *
    * Whether to enable source maps for CSS. Setting this to `true` may affect build performance
    */
   sourceMap?: boolean;
   /**
    * Default: `{}`
+   *
    * Pass options to CSS-related loaders
    */
   loaderOptions?: LoaderOptions;
@@ -48,46 +52,55 @@ interface CSSOptions {
 interface ProjectOptions {
   /**
    * Default: `'/'`
+   *
    * The base URL your application bundle will be deployed at
    */
   publicPath?: string;
   /**
    * Default: `'dist'`
+   *
    * The directory where the production build files will be generated in when running `vue-cli-service build`
    */
   outputDir?: string;
   /**
    * Default: `''`
+   *
    * A directory (relative to `outputDir`) to nest generated static assets (js, css, img, fonts) under
    */
   assetsDir?: string;
   /**
    * Default: `'index.html'`
+   *
    * Specify the output path for the generated `index.html` (relative to `outputDir`). Can also be an absolute path
    */
   indexPath?: string;
   /**
    * Default: `true`
+   *
    * By default, generated static assets contains hashes in their filenames for better caching control
    */
   filenameHashing?: boolean;
   /**
    * Default: `false`
+   *
    * Whether to use the build of Vue core that includes the runtime compiler
    */
   runtimeCompiler?: boolean;
   /**
    * Default: `[]`
+   *
    * If you want to explicitly transpile a dependency with Babel, you can list it in this option
    */
   transpileDependencies?: Array<string | RegExp>;
   /**
    * Default: `true`
+   *
    * Setting this to `false` can speed up production builds if you don't need source maps for production
    */
   productionSourceMap?: boolean;
   /**
    * Default: `require('os').cpus().length > 1`
+   *
    * Whether to use `thread-loader` for Babel or TypeScript transpilation
    */
   parallel?: boolean | number;
@@ -97,6 +110,7 @@ interface ProjectOptions {
   devServer?: { proxy: string | object, [key: string]: any };
   /**
    * Default: `undefined`
+   *
    * Build the app in multi-page mode
    */
   pages?: {
@@ -104,11 +118,13 @@ interface ProjectOptions {
   };
   /**
    * Default: `undefined`
+   *
    * Configure the `crossorigin` attribute on `<link rel="stylesheet">` and `<script>` tags in generated HTML
    */
   crossorigin?: '' | 'anonymous' | 'use-credentials';
   /**
    * Default: `false`
+   *
    * Set to `true` to enable [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) on `<link rel="stylesheet">` and `<script>` tags in generated HTML
    */
   integrity?: boolean;
@@ -126,6 +142,7 @@ interface ProjectOptions {
 
   /**
    * Default: `'default'`
+   *
    * Whether to perform lint-on-save during development using [eslint-loader](https://github.com/webpack-contrib/eslint-loader)
    */
   lintOnSave?: boolean | 'default' | 'warning' | 'error';

--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -34,7 +34,7 @@ interface CSSOptions {
    */
   extract?: boolean | ExtractOptions;
   /**
-   * Default: `true`
+   * Default: `false`
    * Whether to enable source maps for CSS. Setting this to `true` may affect build performance
    */
   sourceMap?: boolean;

--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -125,7 +125,7 @@ interface ProjectOptions {
   configureWebpack?: WebpackOptions | ((config: WebpackOptions) => (WebpackOptions | void));
 
   /**
-   * Default: `default`
+   * Default: `'default'`
    * Whether to perform lint-on-save during development using [eslint-loader](https://github.com/webpack-contrib/eslint-loader)
    */
   lintOnSave?: boolean | 'default' | 'warning' | 'error';

--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -120,7 +120,7 @@ interface ProjectOptions {
    */
   chainWebpack?: (config: ChainableWebpackConfig) => void;
   /**
-   * Set webpack configuration.  If the value is `Object`, will be merged into config.  If value is `Function`, will receicve current config as argument
+   * Set webpack configuration.  If the value is `Object`, will be merged into config.  If value is `Function`, will receive current config as argument
    */
   configureWebpack?: WebpackOptions | ((config: WebpackOptions) => (WebpackOptions | void));
 

--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -23,37 +23,121 @@ interface ExtractOptions {
 }
 
 interface CSSOptions {
+  /**
+   * Default: `true`
+   * By default, only files that ends in `*.module.[ext]` are treated as CSS modules
+   */
   requireModuleExtension?: boolean;
+  /**
+   * Default: `true`
+   * Whether to extract CSS in your components into a standalone CSS files (instead of inlined in JavaScript and injected dynamically)
+   */
   extract?: boolean | ExtractOptions;
+  /**
+   * Default: `true`
+   * Whether to enable source maps for CSS. Setting this to `true` may affect build performance
+   */
   sourceMap?: boolean;
+  /**
+   * Default: `{}`
+   * Pass options to CSS-related loaders
+   */
   loaderOptions?: LoaderOptions;
 }
 
 interface ProjectOptions {
+  /**
+   * Default: `'/'`
+   * The base URL your application bundle will be deployed at
+   */
   publicPath?: string;
+  /**
+   * Default: `'dist'`
+   * The directory where the production build files will be generated in when running `vue-cli-service build`
+   */
   outputDir?: string;
+  /**
+   * Default: `''`
+   * A directory (relative to `outputDir`) to nest generated static assets (js, css, img, fonts) under
+   */
   assetsDir?: string;
+  /**
+   * Default: `'index.html'`
+   * Specify the output path for the generated `index.html` (relative to `outputDir`). Can also be an absolute path
+   */
   indexPath?: string;
+  /**
+   * Default: `true`
+   * By default, generated static assets contains hashes in their filenames for better caching control
+   */
   filenameHashing?: boolean;
+  /**
+   * Default: `false`
+   * Whether to use the build of Vue core that includes the runtime compiler
+   */
   runtimeCompiler?: boolean;
+  /**
+   * Default: `[]`
+   * If you want to explicitly transpile a dependency with Babel, you can list it in this option
+   */
   transpileDependencies?: Array<string | RegExp>;
+  /**
+   * Default: `true`
+   * Setting this to `false` can speed up production builds if you don't need source maps for production
+   */
   productionSourceMap?: boolean;
+  /**
+   * Default: `require('os').cpus().length > 1`
+   * Whether to use `thread-loader` for Babel or TypeScript transpilation
+   */
   parallel?: boolean | number;
-  devServer?: object;
+  /**
+   * [All options for `webpack-dev-server`](https://webpack.js.org/configuration/dev-server/) are supported
+   */
+  devServer?: { proxy: string | object, [key: string]: any };
+  /**
+   * Default: `undefined`
+   * Build the app in multi-page mode
+   */
   pages?: {
     [key: string]: PageEntry | PageConfig;
   };
+  /**
+   * Default: `undefined`
+   * Configure the `crossorigin` attribute on `<link rel="stylesheet">` and `<script>` tags in generated HTML
+   */
   crossorigin?: '' | 'anonymous' | 'use-credentials';
+  /**
+   * Default: `false`
+   * Set to `true` to enable [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) on `<link rel="stylesheet">` and `<script>` tags in generated HTML
+   */
   integrity?: boolean;
 
   css?: CSSOptions;
 
+  /**
+   * A function that will receive an instance of `ChainableConfig` powered by [webpack-chain](https://github.com/mozilla-neutrino/webpack-chain)
+   */
   chainWebpack?: (config: ChainableWebpackConfig) => void;
+  /**
+   * Default: `[]`
+   * If you want to explicitly transpile a dependency with Babel, you can list it in this option
+   */
   configureWebpack?: WebpackOptions | ((config: WebpackOptions) => (WebpackOptions | void));
 
+  /**
+   * Default: `default`
+   * Whether to perform lint-on-save during development using [eslint-loader](https://github.com/webpack-contrib/eslint-loader)
+   */
   lintOnSave?: boolean | 'default' | 'warning' | 'error';
+  /**
+   * Pass options to the [PWA Plugin](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-pwa)
+   */
   pwa?: object;
 
+  /**
+   * This is an object that doesn't go through any schema validation, so it can be used to pass arbitrary options to 3rd party plugins
+   */
   pluginOptions?: object;
 }
 

--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -120,8 +120,7 @@ interface ProjectOptions {
    */
   chainWebpack?: (config: ChainableWebpackConfig) => void;
   /**
-   * Default: `[]`
-   * If you want to explicitly transpile a dependency with Babel, you can list it in this option
+   * Set webpack configuration.  If the value is `Object`, will be merged into config.  If value is `Function`, will receicve current config as argument
    */
   configureWebpack?: WebpackOptions | ((config: WebpackOptions) => (WebpackOptions | void));
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools
- [x] Other, please describe: Config descriptions

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Personally, I have found it frustrating working with `vue.config.js`, due to lack of type information available.  Yesterday I discovered https://github.com/vuejs/vue-cli/issues/2138#issuecomment-484520356 , and was delighted to see I had a bit more info, but still not as much as I'd like.  

This commit adds JSDoc documentation (from `docs/config/README.md`) to add better editor support for `vue.config.js`