### PR TITLE
fix(cli): fix module resolve of preset generator

### DIFF
--- a/packages/@vue/cli/__tests__/mock-preset-with-template-extend/generator/index.js
+++ b/packages/@vue/cli/__tests__/mock-preset-with-template-extend/generator/index.js
@@ -1,0 +1,3 @@
+module.exports = (api, options) => {
+  api.render('./template', options)
+}

--- a/packages/@vue/cli/__tests__/mock-preset-with-template-extend/generator/template/App.vue
+++ b/packages/@vue/cli/__tests__/mock-preset-with-template-extend/generator/template/App.vue
@@ -1,0 +1,10 @@
+---
+extend: '@vue/cli-service/generator/template/src/App.vue'
+replace: !!js/regexp /<script>[^]*?<\/script>/
+---
+
+<script>
+export default {
+  // Replace default script
+}
+</script>

--- a/packages/@vue/cli/__tests__/mock-preset-with-template-extend/preset.json
+++ b/packages/@vue/cli/__tests__/mock-preset-with-template-extend/preset.json
@@ -1,0 +1,5 @@
+{
+  "plugins": {
+    "@vue/cli-plugin-babel": {}
+  }
+}

--- a/packages/@vue/cli/__tests__/preset.spec.js
+++ b/packages/@vue/cli/__tests__/preset.spec.js
@@ -2,6 +2,7 @@ jest.mock('inquirer')
 const { expectPrompts } = require('inquirer')
 
 const path = require('path')
+const os = require('os')
 const fs = require('fs-extra')
 const create = require('@vue/cli/lib/create')
 
@@ -52,6 +53,51 @@ test('should recognize generator/index.js in a local preset directory', async ()
 
   const testFile = await fs.readFile(path.resolve(cwd, name, 'test.js'), 'utf-8')
   expect(testFile).toBe('true\n')
+
+  const pkg = require(path.resolve(cwd, name, 'package.json'))
+  expect(pkg.devDependencies).toHaveProperty('@vue/cli-plugin-babel')
+})
+
+test('should resolve module required by local preset generator', async () => {
+  const cwd = path.resolve(__dirname, '../../../test')
+  const name = 'test-preset-template-extend'
+
+  await create(
+    name,
+    {
+      force: true,
+      git: false,
+      cwd,
+      preset: path.resolve(__dirname, './mock-preset-with-template-extend')
+    }
+  )
+
+  const testFile = await fs.readFile(path.resolve(cwd, name, 'App.vue'), 'utf-8')
+  expect(testFile).toMatch('Replace default script')
+
+  const pkg = require(path.resolve(cwd, name, 'package.json'))
+  expect(pkg.devDependencies).toHaveProperty('@vue/cli-plugin-babel')
+})
+
+test('should resolve module required by local preset generator in the tmp folder ', async () => {
+  const cwd = path.resolve(__dirname, '../../../test')
+  const name = 'test-preset-template-extend-tmp'
+
+  const tmpdir = path.resolve(os.tmpdir(), './mock-preset-with-template-extend')
+  await fs.copy(path.resolve(__dirname, './mock-preset-with-template-extend'), tmpdir)
+
+  await create(
+    name,
+    {
+      force: true,
+      git: false,
+      cwd,
+      preset: tmpdir
+    }
+  )
+
+  const testFile = await fs.readFile(path.resolve(cwd, name, 'App.vue'), 'utf-8')
+  expect(testFile).toMatch('Replace default script')
 
   const pkg = require(path.resolve(cwd, name, 'package.json'))
   expect(pkg.devDependencies).toHaveProperty('@vue/cli-plugin-babel')


### PR DESCRIPTION
Fixes #5965

Resolve module maybe failed based on `$TMPDIR/path_to_preset/generator/template/public/` (example in issue #5965)

If it fails, try to find the module in the project we created.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
None
