### PR TITLE
fix: prioritize node_modules of current project

### DIFF
--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -57,9 +57,9 @@ module.exports = (api, options) => {
         .merge(['.mjs', '.js', '.jsx', '.vue', '.json', '.wasm'])
         .end()
       .modules
-        .add('node_modules')
         .add(api.resolve('node_modules'))
         .add(resolveLocal('node_modules'))
+        .add('node_modules')
         .end()
       .alias
         .set('@', api.resolve('src'))


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

This PR changes the order of searching for node_modules, putting the relative path as the last one. It avoids, after all, duplication of dependencies.

Related Stackoverflow answer: https://stackoverflow.com/a/63992540/14397787
Webpack reference: https://v4.webpack.js.org/configuration/resolve/#resolvemodules

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
None
