### PR TITLE
fix: update vue-shims for Vue v3.0.1

### DIFF
--- a/packages/@vue/cli-plugin-typescript/generator/template-vue3/src/shims-vue.d.ts
+++ b/packages/@vue/cli-plugin-typescript/generator/template-vue3/src/shims-vue.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
-  const component: DefineComponent
+  const component: DefineComponent<{}, {}, any>
   export default component
 }


### PR DESCRIPTION


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
https://github.com/vuejs/vue-next/commit/6aa2256913bfd097500aba83b78482b87107c101 intriduced a change in `DefineComponent` type, that results in a broken bare CLI app that would use VTU, as `mount` will not compile.

This relaxes the type definitation by using generic `any`.

Fixes #5974