### PR TITLE
manifest link can use relative path

### DIFF
--- a/docs/core-plugins/pwa.md
+++ b/docs/core-plugins/pwa.md
@@ -65,6 +65,15 @@ file, or the `"vue"` field in `package.json`.
 
     This option is used if you need to add a version to your icons and manifest, against browser’s cache. This will append `?v=<pwa.assetsVersion>` to the URLs of the icons and manifest.
 
+- **pwa.manifestUseRelative**
+
+  - Default: `false`
+
+    Enable use a relative path on `<link rel="manifest" />` . This value will be replaced by **publicPath** when it false.
+
+    By this way, you can set a relative path for `start_url` in `manifest.json`
+
+
 - **pwa.manifestPath**
 
   - Default: `'manifest.json'`

--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -7,6 +7,7 @@ const defaults = {
   appleMobileWebAppCapable: 'no',
   appleMobileWebAppStatusBarStyle: 'default',
   assetsVersion: '',
+  manifestUseRelative: false,
   manifestPath: 'manifest.json',
   manifestOptions: {},
   manifestCrossorigin: undefined
@@ -73,6 +74,7 @@ module.exports = class HtmlPwaPlugin {
           appleMobileWebAppCapable,
           appleMobileWebAppStatusBarStyle,
           assetsVersion,
+          manifestUseRelative,
           manifestPath,
           iconPaths,
           manifestCrossorigin
@@ -104,12 +106,12 @@ module.exports = class HtmlPwaPlugin {
           makeTag('link', manifestCrossorigin
             ? {
               rel: 'manifest',
-              href: getTagHref(publicPath, manifestPath, assetsVersionStr),
+              href: getTagHref(publicPath, manifestPath, assetsVersionStr, manifestUseRelative),
               crossorigin: manifestCrossorigin
             }
             : {
               rel: 'manifest',
-              href: getTagHref(publicPath, manifestPath, assetsVersionStr)
+              href: getTagHref(publicPath, manifestPath, assetsVersionStr, manifestUseRelative)
             }
           )
         )
@@ -206,8 +208,11 @@ function makeTag (tagName, attributes, closeTag = false) {
   }
 }
 
-function getTagHref (publicPath, href, assetsVersionStr) {
+function getTagHref (publicPath, href, assetsVersionStr, useRelativePath) {
   let tagHref = `${href}${assetsVersionStr}`
+  if (useRelativePath) {
+    return tagHref
+  }
   if (!isHrefAbsoluteUrl(href)) {
     tagHref = `${publicPath}${tagHref}`
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

In production , we usually set static resource on CDN. So, we set a property publicPath.

But, start_url in 'manifest.json` has been required to be of the same origin.

So, when we use relative path in 'manifestPath' and use publicPath in webpack.


[issue](https://github.com/vuejs/vue-cli/issues/5953)

