### PR TITLE
fix: using `lang` attribute with empty string in html template

### DIFF
--- a/packages/@vue/cli-service-global/template/index.html
+++ b/packages/@vue/cli-service-global/template/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="">
   <head>
     <meta charset="utf-8">
     <title>Vue CLI App</title>

--- a/packages/@vue/cli-service/generator/template/public/index.html
+++ b/packages/@vue/cli-service/generator/template/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/packages/@vue/cli-service/lib/config/index-default.html
+++ b/packages/@vue/cli-service/lib/config/index-default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Fixes #5945

`lang="en"` may be wrong to users, use empty string instead. See : https://github.com/h5bp/html5-boilerplate/issues/1542

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

