### PR TITLE
fix: prevent snoretoast shortcut, set notif title (#2720)

### DIFF
--- a/packages/@vue/cli-ui/apollo-server/util/notification.js
+++ b/packages/@vue/cli-ui/apollo-server/util/notification.js
@@ -6,8 +6,16 @@ const builtinIcons = {
   error: path.resolve(__dirname, '../../src/assets/error.png')
 }
 
+// https://github.com/mikaelbr/node-notifier/issues/154
+// Specify appID to prevent SnoreToast shortcut installation.
+// SnoreToast actually uses it as the string in the notification's
+// title bar (different from title heading inside notification).
+// This only has an effect in Windows.
+const snoreToastOptions = notifier.Notification === notifier.WindowsToaster && { appID: 'Vue UI' }
+
 exports.notify = ({ title, message, icon }) => {
   notifier.notify({
+    ...snoreToastOptions,
     title,
     message,
     icon: builtinIcons[icon] || icon


### PR DESCRIPTION
This prevents SnoreToast from installing a Start Menu shortcut by specifying an `appID`. The `appID` is also used to set the
notification's title bar text in Windows 10. That text is now set to "Vue UI", which replaces the default value of "SnoreToast".

fixes #2720

*Screenshot of desktop notification on Windows 10:*
![desktop-notif](https://user-images.githubusercontent.com/26580/97066642-8d8eb500-157c-11eb-8d7b-6ef434c4d4c9.jpg)

*Screenshot of notification bar on Windows 10:*
![notif-bar](https://user-images.githubusercontent.com/26580/97066644-9089a580-157c-11eb-9d89-1abcc875bbe0.jpg)

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
