### PR TITLE
add DS_Store to npmignore

### DIFF
--- a/packages/@vue/babel-preset-app/.npmignore
+++ b/packages/@vue/babel-preset-app/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-init/.npmignore
+++ b/packages/@vue/cli-init/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-overlay/.npmignore
+++ b/packages/@vue/cli-overlay/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-babel/.npmignore
+++ b/packages/@vue/cli-plugin-babel/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-e2e-cypress/.npmignore
+++ b/packages/@vue/cli-plugin-e2e-cypress/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-e2e-nightwatch/.npmignore
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-eslint/.npmignore
+++ b/packages/@vue/cli-plugin-eslint/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-router/.npmignore
+++ b/packages/@vue/cli-plugin-router/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-typescript/.npmignore
+++ b/packages/@vue/cli-plugin-typescript/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-unit-jest/.npmignore
+++ b/packages/@vue/cli-plugin-unit-jest/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-unit-mocha/.npmignore
+++ b/packages/@vue/cli-plugin-unit-mocha/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-plugin-vuex/.npmignore
+++ b/packages/@vue/cli-plugin-vuex/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-service-global/.npmignore
+++ b/packages/@vue/cli-service-global/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-shared-utils/.npmignore
+++ b/packages/@vue/cli-shared-utils/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli-test-utils/.npmignore
+++ b/packages/@vue/cli-test-utils/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 __mocks__
+.DS_Store

--- a/packages/@vue/cli/.npmignore
+++ b/packages/@vue/cli/.npmignore
@@ -1,3 +1,4 @@
 __tests__
 __mocks__
 .version
+.DS_Store

--- a/packages/@vue/cli/lib/util/.npmignore
+++ b/packages/@vue/cli/lib/util/.npmignore
@@ -1,2 +1,3 @@
 __tests__
 .version
+.DS_Store


### PR DESCRIPTION
- [x ] Bugfix
**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x ] No

**Other information:**

https://unpkg.com/browse/vue@2.6.12/src/

fixes publish from mac including .DS_Store causing cleanup issues in /usr/local global npm install
