### PR TITLE
fix: update default vue 3 typescript shim

### DIFF
--- a/packages/@vue/cli-plugin-typescript/codemods/__testfixtures__/shims-vue.output.ts
+++ b/packages/@vue/cli-plugin-typescript/codemods/__testfixtures__/shims-vue.output.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
   import { DefineComponent } from 'vue';
-  const component: DefineComponent<{}, {}, any>;
+  const component: DefineComponent<{}, {}, unknown>;
   export default component;
 }

--- a/packages/@vue/cli-plugin-typescript/generator/template-vue3/src/shims-vue.d.ts
+++ b/packages/@vue/cli-plugin-typescript/generator/template-vue3/src/shims-vue.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
-  const component: DefineComponent<{}, {}, any>
+  const component: DefineComponent<{}, {}, unknown>
   export default component
 }


### PR DESCRIPTION
#6021  eslint warns about "unsafe any" in default shim when formatting.
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
