### PR TITLE
fix(cli-plugin-typescript): remove getPrompts function in prompts.js

### DIFF
--- a/packages/@vue/cli-plugin-typescript/prompts.js
+++ b/packages/@vue/cli-plugin-typescript/prompts.js
@@ -1,7 +1,7 @@
 // these prompts are used if the plugin is late-installed into an existing
 // project and invoked by `vue invoke`.
 
-const prompts = module.exports = [
+module.exports = [
   {
     name: `classComponent`,
     type: `confirm`,
@@ -32,11 +32,3 @@ const prompts = module.exports = [
     default: true
   }
 ]
-
-// in RC6+ the export can be function, but that would break invoke for RC5 and
-// below, so this is a temporary compatibility hack until we release stable.
-// TODO just export the function in 3.0.0
-module.exports.getPrompts = pkg => {
-  prompts[2].when = () => !('@vue/cli-plugin-eslint' in (pkg.devDependencies || {}))
-  return prompts
-}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

TSLint options have been removed. [#5065](https://github.com/vuejs/vue-cli/pull/5065/files#diff-e24fb13625fcff6df42f64355ccad136579fbf2932b01d32a4a9a01e0756124b) `getPrompts` would break `convertJsToTs` prompt. https://github.com/vuejs/vue-cli/issues/2676
