### PR TITLE
fix(cli-plugin-typescript): Remove legacy code

### DIFF
--- a/packages/@vue/cli-plugin-typescript/prompts.js
+++ b/packages/@vue/cli-plugin-typescript/prompts.js
@@ -32,11 +32,3 @@ const prompts = module.exports = [
     default: true
   }
 ]
-
-// in RC6+ the export can be function, but that would break invoke for RC5 and
-// below, so this is a temporary compatibility hack until we release stable.
-// TODO just export the function in 3.0.0
-module.exports.getPrompts = pkg => {
-  prompts[2].when = () => !('@vue/cli-plugin-eslint' in (pkg.devDependencies || {}))
-  return prompts
-}


### PR DESCRIPTION
The code originally disabled the prompt about choosing `tslint`, but that prompt was already removed from the code, so now it disables the wrong prompt. This bug has even been there since other prompts where inserted before the `tslint`-prompt and it was not at position `2` anymore.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**
