### PR TITLE
Correct nginx.conf root path

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -468,7 +468,7 @@ Deploy your application using nginx inside of a docker container.
         listen       80;
         server_name  localhost;
         location / {
-          root   /app;
+          root   /usr/share/nginx/html;
           index  index.html;
           try_files $uri $uri/ /index.html;
         }


### PR DESCRIPTION
The documentation at ### Docker (Nginx) 4. Create a `nginx.conf` file in the root of your project it is suggested to use /app. 
It should be /usr/share/nginx/html;

This can be very frustrating for first time devs trying to run vue in docker as this would result in a 500 error page.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
