### PR TITLE
fix(cli-service): pass --public host to devserver

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -112,6 +112,7 @@ module.exports = (api, options) => {
         ? rawPublicUrl
         : `${protocol}://${rawPublicUrl}`
       : null
+    const publicHost = publicUrl ? /^[a-zA-Z]+:\/\/([^/?#]+)/.exec(publicUrl)[1] : undefined
 
     const urls = prepareURLs(
       protocol,
@@ -181,6 +182,7 @@ module.exports = (api, options) => {
       hot: !isProduction,
       injectClient: false,
       compress: isProduction,
+      public: publicHost,
       publicPath: options.publicPath,
       overlay: isProduction // TODO disable this
         ? false

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -182,7 +182,6 @@ module.exports = (api, options) => {
       hot: !isProduction,
       injectClient: false,
       compress: isProduction,
-      public: publicHost,
       publicPath: options.publicPath,
       overlay: isProduction // TODO disable this
         ? false
@@ -190,6 +189,7 @@ module.exports = (api, options) => {
     }, projectDevServerOptions, {
       https: useHttps,
       proxy: proxySettings,
+      public: publicHost,
       // eslint-disable-next-line no-shadow
       before (app, server) {
         // launch editor support.


### PR DESCRIPTION
close #3220

Prevent "Invalid Host" error by passing public host through to webpack-dev-server when `--public` is used

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

When you use the `public` option in webpack-dev-server [it'll automatically allow requests from the specified host](https://github.com/webpack/webpack-dev-server/blob/master/lib/Server.js#L926-L935), without needing the additional `allowedHosts[]` or `disableHostCheck` options. However when the `--public` option in Vue CLI was used, the value was not passed through to webpack-dev-server (as HMR client injection is handled separately) so you still got the `Invalid host` error in that case.

This PR extracts the host from the `--public` arg and passes it through to the dev server to prevent this error.
