### PR TITLE
Fix Grammar Mistake in Docs

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -267,7 +267,7 @@ In v3 this means the opposite of `css.requireModuleExtension`.
 - Type: `boolean | Object`
 - Default: `true` in production, `false` in development
 
-  Whether to extract CSS in your components into a standalone CSS files (instead of inlined in JavaScript and injected dynamically).
+  Whether to extract CSS in your components into a standalone CSS file (instead of inlined in JavaScript and injected dynamically).
 
   This is always disabled when building as web components (styles are inlined and injected into shadowRoot).
 


### PR DESCRIPTION
files -> file
Signed-off-by: Hollow Man hollowman@hollowman.ml

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

In `Whether to extract CSS in your components into a standalone CSS file`, `file` should use the singular form according to the context and the Chinese version `是否将组件中的 CSS 提取至一个独立的 CSS 文件中`. 