### PR TITLE
fix(cli-service): remove highlight config output

### DIFF
--- a/packages/@vue/cli-service/lib/commands/inspect.js
+++ b/packages/@vue/cli-service/lib/commands/inspect.js
@@ -17,7 +17,6 @@ module.exports = (api, options) => {
     args => {
       const { chalk, get } = require('@vue/cli-shared-utils')
       const { toString } = require('webpack-chain')
-      const { highlight } = require('cli-highlight')
       const config = api.resolveWebpackConfig()
       const { _: paths, verbose } = args
 
@@ -49,7 +48,7 @@ module.exports = (api, options) => {
       }
 
       const output = toString(res, { verbose })
-      console.log(highlight(output, { language: 'js' }))
+      console.log(output)
 
       // Log explanation for Nameless Rules
       if (hasUnnamedRule) {

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -43,7 +43,6 @@
     "browserslist": "^4.14.1",
     "cache-loader": "^4.1.0",
     "case-sensitive-paths-webpack-plugin": "^2.3.0",
-    "cli-highlight": "^2.1.4",
     "clipboardy": "^2.3.0",
     "cliui": "^6.0.0",
     "copy-webpack-plugin": "^6.2.1",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

```bash
    vue inspect > output.js
```

```js
{
  [36mmode[39m: [31m'production'[39m,
  [36mcontext[39m: [31m'D:\\Project\\vue\\vue-config-demo'[39m,
  [36mdevtool[39m: [31m'source-map'[39m,
  [36mnode[39m: {
    [36msetImmediate[39m: [34mfalse[39m,

   // ......
```

The output of utf-16 by default will produce unintelligible code.
