### PR TITLE
chore: remove deprecated node-sass

### DIFF
--- a/packages/@vue/cli-service/__tests__/generator.spec.js
+++ b/packages/@vue/cli-service/__tests__/generator.spec.js
@@ -19,15 +19,6 @@ test('sass (default)', async () => {
   expect(pkg).toHaveProperty(['devDependencies', 'sass'])
 })
 
-test('node sass', async () => {
-  const { pkg, files } = await generateWithOptions({
-    cssPreprocessor: 'node-sass'
-  })
-
-  expect(files['src/App.vue']).toMatch('<style lang="scss">')
-  expect(pkg).toHaveProperty(['devDependencies', 'node-sass'])
-})
-
 test('dart sass', async () => {
   const { pkg, files } = await generateWithOptions({
     cssPreprocessor: 'dart-sass'

--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -41,10 +41,6 @@ module.exports = (api, options) => {
         sass: '^1.26.5',
         'sass-loader': '^8.0.2'
       },
-      'node-sass': {
-        'node-sass': '^4.12.0',
-        'sass-loader': '^8.0.2'
-      },
       'dart-sass': {
         sass: '^1.26.5',
         'sass-loader': '^8.0.2'

--- a/packages/@vue/cli/lib/options.js
+++ b/packages/@vue/cli/lib/options.js
@@ -43,7 +43,7 @@ const presetSchema = createSchema((joi) =>
         }),
       cssPreprocessor: joi
         .string()
-        .valid('sass', 'dart-sass', 'node-sass', 'less', 'stylus'),
+        .valid('sass', 'dart-sass', 'less', 'stylus'),
       plugins: joi.object().required(),
       configs: joi.object()
     })

--- a/packages/@vue/cli/lib/promptModules/__tests__/cssPreprocessors.spec.js
+++ b/packages/@vue/cli/lib/promptModules/__tests__/cssPreprocessors.spec.js
@@ -14,7 +14,7 @@ test('CSS pre-processor ', async () => {
     },
     {
       message: 'Pick a CSS pre-processor',
-      choices: ['Sass/SCSS (with dart-sass)', 'Sass/SCSS (with node-sass)', 'Less', 'Stylus'],
+      choices: ['Sass/SCSS (with dart-sass)', 'Less', 'Stylus'],
       choose: 0
     }
   ]

--- a/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
+++ b/packages/@vue/cli/lib/promptModules/cssPreprocessors.js
@@ -15,17 +15,9 @@ module.exports = cli => {
     message: `Pick a CSS pre-processor${process.env.VUE_CLI_API_MODE ? '' : ` (${notice})`}:`,
     description: `${notice}.`,
     choices: [
-      // In Vue CLI <= 3.3, the value of Sass option in 'sass' an means 'node-sass'.
-      // Considering the 'sass' package on NPM is actually for Dart Sass, we renamed it to 'node-sass'.
-      // In @vue/cli-service there're still codes that accepts 'sass' as an option value, for compatibility reasons,
-      // and they're meant to be removed in v4.
       {
         name: 'Sass/SCSS (with dart-sass)',
         value: 'dart-sass'
-      },
-      {
-        name: 'Sass/SCSS (with node-sass)',
-        value: 'node-sass'
       },
       {
         name: 'Less',

--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -247,7 +247,7 @@ class PackageManager {
     }
 
     try {
-      // node-sass, chromedriver, etc.
+      // chromedriver, etc.
       const binaryMirrorConfigMetadata = await this.getMetadata('binary-mirror-config', { full: true })
       const latest = binaryMirrorConfigMetadata['dist-tags'] && binaryMirrorConfigMetadata['dist-tags'].latest
       const mirrors = binaryMirrorConfigMetadata.versions[latest].mirrors.china

--- a/packages/@vue/cli/lib/util/inferRootOptions.js
+++ b/packages/@vue/cli/lib/util/inferRootOptions.js
@@ -34,8 +34,6 @@ module.exports = function inferRootOptions (pkg) {
   // cssPreprocessors
   if ('sass' in deps) {
     rootOptions.cssPreprocessor = 'sass'
-  } else if ('node-sass' in deps) {
-    rootOptions.cssPreprocessor = 'node-sass'
   } else if ('less-loader' in deps) {
     rootOptions.cssPreprocessor = 'less'
   } else if ('stylus-loader' in deps) {

--- a/packages/@vue/cli/types/cli-test.ts
+++ b/packages/@vue/cli/types/cli-test.ts
@@ -45,10 +45,6 @@ const testPromptAPI = (cli: PromptModuleAPI) => {
         value: 'dart-sass'
       },
       {
-        name: 'Sass/SCSS (with node-sass)',
-        value: 'node-sass'
-      },
-      {
         name: 'Less',
         value: 'less'
       },

--- a/packages/@vue/cli/types/index.d.ts
+++ b/packages/@vue/cli/types/index.d.ts
@@ -48,7 +48,7 @@ type Preset = Partial<{
   useConfigFiles: boolean
   plugins: Record<string, any>
   configs: Record<string, any>
-  cssPreprocessor: 'sass' | 'dart-sass' | 'node-sass' | 'less' | 'stylus'
+  cssPreprocessor: 'sass' | 'dart-sass' | 'less' | 'stylus'
 }>
 
 declare class PromptModuleAPI {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Other information:**
The `node-sass` package is deprecated so it shouldn't be used anymore https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate