### PR TITLE
fix(cli-service): don't write entry-wc to node_modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,5 @@ template
 template-vue3
 packages/test
 temp
-entry-wc.js
 dist
 __testfixtures__

--- a/packages/@vue/cli-service/lib/commands/build/.gitignore
+++ b/packages/@vue/cli-service/lib/commands/build/.gitignore
@@ -1,1 +1,0 @@
-entry-wc.js

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -59,6 +59,12 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
     }
 
     config
+      .plugin('webpack-virtual-modules')
+        .use(require('webpack-virtual-modules'), [{
+          [dynamicEntry.filePath]: dynamicEntry.content
+        }])
+
+    config
       .plugin('web-component-options')
         .use(require('webpack').DefinePlugin, [{
           'process.env.CUSTOM_ELEMENT_NAME': JSON.stringify(libName)
@@ -108,7 +114,7 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
 
     const entryName = `${libName}${minify ? `.min` : ``}`
     rawConfig.entry = {
-      [entryName]: dynamicEntry
+      [entryName]: dynamicEntry.filePath
     }
 
     Object.assign(rawConfig.output, {

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const path = require('path')
 
 const camelizeRE = /-(\w)/g
@@ -56,6 +55,9 @@ import 'vue-style-loader/lib/addStylesShadow'
 import 'vue-loader/lib/runtime/componentNormalizer'
 
 ${elements}`.trim()
-  fs.writeFileSync(filePath, content)
-  return filePath
+
+  return {
+    filePath: filePath,
+    content: content
+  }
 }

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -78,7 +78,8 @@
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-chain": "^6.4.0",
     "webpack-dev-server": "^3.11.0",
-    "webpack-merge": "^4.2.2"
+    "webpack-merge": "^4.2.2",
+    "webpack-virtual-modules": "^0.4.1"
   },
   "peerDependencies": {
     "@vue/compiler-sfc": "^3.0.0-beta.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,6 +3385,87 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.2.1"
     camelcase "^5.0.0"
 
+"@vue/cli-plugin-babel@file:packages/@vue/cli-plugin-babel":
+  version "4.5.8"
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@vue/babel-preset-app" "^4.5.8"
+    "@vue/cli-shared-utils" "^4.5.8"
+    babel-loader "^8.1.0"
+    cache-loader "^4.1.0"
+    thread-loader "^3.0.0"
+    webpack "^4.0.0"
+
+"@vue/cli-plugin-unit-mocha@file:packages/@vue/cli-plugin-unit-mocha":
+  version "4.5.8"
+  dependencies:
+    "@vue/cli-shared-utils" "^4.5.8"
+    jsdom "^16.4.0"
+    jsdom-global "^3.0.2"
+    mocha "^7.2.0"
+    mochapack "^2.0.2"
+
+"@vue/cli-service@file:packages/@vue/cli-service":
+  version "4.5.8"
+  dependencies:
+    "@intervolga/optimize-cssnano-plugin" "^1.0.5"
+    "@soda/friendly-errors-webpack-plugin" "^1.7.1"
+    "@soda/get-current-script" "^1.0.0"
+    "@types/minimist" "^1.2.0"
+    "@types/webpack" "^4.0.0"
+    "@types/webpack-dev-server" "^3.11.0"
+    "@vue/cli-overlay" "^4.5.8"
+    "@vue/cli-plugin-router" "^4.5.8"
+    "@vue/cli-plugin-vuex" "^4.5.8"
+    "@vue/cli-shared-utils" "^4.5.8"
+    "@vue/component-compiler-utils" "^3.1.2"
+    "@vue/preload-webpack-plugin" "^1.1.0"
+    "@vue/web-component-wrapper" "^1.2.0"
+    acorn "^8.0.1"
+    acorn-walk "^8.0.0"
+    address "^1.1.2"
+    autoprefixer "^9.8.6"
+    browserslist "^4.14.1"
+    cache-loader "^4.1.0"
+    case-sensitive-paths-webpack-plugin "^2.3.0"
+    cli-highlight "^2.1.4"
+    clipboardy "^2.3.0"
+    cliui "^6.0.0"
+    copy-webpack-plugin "^6.2.1"
+    css-loader "^3.5.3"
+    cssnano "^4.1.10"
+    debug "^4.1.1"
+    default-gateway "^6.0.2"
+    dotenv "^8.2.0"
+    dotenv-expand "^5.1.0"
+    file-loader "^6.1.1"
+    fs-extra "^7.0.1"
+    globby "^9.2.0"
+    hash-sum "^2.0.0"
+    html-webpack-plugin "^3.2.0"
+    launch-editor-middleware "^2.2.1"
+    lodash.defaultsdeep "^4.6.1"
+    lodash.mapvalues "^4.6.0"
+    lodash.transform "^4.6.0"
+    mini-css-extract-plugin "^0.9.0"
+    minimist "^1.2.5"
+    pnp-webpack-plugin "^1.6.4"
+    portfinder "^1.0.26"
+    postcss-loader "^3.0.0"
+    ssri "^8.0.0"
+    terser-webpack-plugin "^4.2.3"
+    thread-loader "^3.0.0"
+    url-loader "^4.1.1"
+    vue-loader "^15.9.2"
+    vue-loader-v16 "npm:vue-loader@^16.1.0"
+    vue-style-loader "^4.1.2"
+    webpack "^4.0.0"
+    webpack-bundle-analyzer "^3.8.0"
+    webpack-chain "^6.4.0"
+    webpack-dev-server "^3.11.0"
+    webpack-merge "^4.2.2"
+    webpack-virtual-modules "^0.4.1"
+
 "@vue/compiler-core@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.2.tgz#7790b7a1fcbba5ace4d81a70ce59096fa5c95734"
@@ -20481,10 +20562,10 @@ vue-jest@^3.0.5:
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
 
-"vue-loader-v16@npm:vue-loader@^16.0.0-beta.7":
-  version "16.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.0.0-rc.2.tgz#b6a7e7f30d28f35659a83de41f4a1831a4232a04"
-  integrity sha512-cz8GK4dgIf1UTC+do80pGvh8BHcCRHLIQVHV9ONVQ8wtoqS9t/+H02rKcQP+TVNg7khgLyQV2+8eHUq7/AFq3g==
+"vue-loader-v16@npm:vue-loader@^16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.1.0.tgz#e4544abf65cbb3b81f3d5360d95a3e2ae83749a1"
+  integrity sha512-fTtCdI7VeyNK0HP4q4y9Z9ts8TUeaF+2/FjKx8CJ/7/Oem1rCX7zIJe+d+jLrVnVNQjENd3gqmANraLcdRWwnQ==
   dependencies:
     chalk "^4.1.0"
     hash-sum "^2.0.0"
@@ -20560,7 +20641,7 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.10, vue-template-compiler@^2.6.12:
+vue-template-compiler@^2.6.10, vue-template-compiler@^2.6.11, vue-template-compiler@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz#947ed7196744c8a5285ebe1233fe960437fcc57e"
   integrity sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==
@@ -20589,7 +20670,7 @@ vue-virtual-scroller@^1.0.10:
     vue-observe-visibility "^0.4.4"
     vue-resize "^0.4.5"
 
-vue@^2.6.10, vue@^2.6.12:
+vue@^2.6.10, vue@^2.6.11, vue@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
@@ -20919,6 +21000,11 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-virtual-modules@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.1.tgz#cae5a7085d34331d077225f77037bea233dbfdad"
+  integrity sha512-BH/RKOHk223WdBDLFqghztx3DF5AqR3CKg3ue1KN9S1SAaXP68Kj/4rF0lsdysxXaanzx7aWl1u0+lnfj7+OtQ==
 
 webpack@^4.0.0, webpack@^4.8.1:
   version "4.44.2"


### PR DESCRIPTION
Fixes https://github.com/yarnpkg/berry/issues/2189
Ref https://github.com/vuejs/vue-cli/issues/5135

When building web components (`--target wc`) `@vue/cli-service` tries to write an `entry-wc.js` file to itself which breaks when running multiple builds in parallel or when using Yarn PnP.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
