### PR TITLE
perf(packages/@vue/cli/bin/vue.js): deleting the EOL_NODE_MAJORS chec…

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -19,7 +19,6 @@ function checkNodeVersion (wanted, id) {
 
 checkNodeVersion(requiredVersion, '@vue/cli')
 
-
 const fs = require('fs')
 const path = require('path')
 const slash = require('slash')

--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -19,16 +19,6 @@ function checkNodeVersion (wanted, id) {
 
 checkNodeVersion(requiredVersion, '@vue/cli')
 
-const EOL_NODE_MAJORS = ['8.x', '9.x', '11.x', '13.x']
-for (const major of EOL_NODE_MAJORS) {
-  if (semver.satisfies(process.version, major)) {
-    console.log(chalk.red(
-      `You are using Node ${process.version}.\n` +
-      `Node.js ${major} has already reached end-of-life and will not be supported in future major releases.\n` +
-      `It's strongly recommended to use an active LTS version instead.`
-    ))
-  }
-}
 
 const fs = require('fs')
 const path = require('path')


### PR DESCRIPTION
I think that the 'checkNodeVersion' function has covered the situation of checking EOL_NODE_MAJORS. So, maybe deleting the repetitive feature code of checking EOL_NODE_MAJORS will be more concise or little faster.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
love vue❤