### PR TITLE
test: should not expect babel polyfill paths to be extension-less

### DIFF
--- a/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
+++ b/packages/@vue/babel-preset-app/__tests__/babel-preset.spec.js
@@ -29,7 +29,7 @@ test('polyfill detection', () => {
   // default includes
   expect(code).not.toMatch(getAbsolutePolyfill('es.promise'))
   // usage-based detection
-  expect(code).not.toMatch('"core-js/modules/es.map"')
+  expect(code).not.toMatch('core-js/modules/es.map')
 
   ;({ code } = babel.transformSync(`
     const a = new Map()
@@ -45,7 +45,7 @@ test('polyfill detection', () => {
   // promise polyfill alone doesn't work in IE, needs this as well. fix: #1642
   expect(code).toMatch(getAbsolutePolyfill('es.array.iterator'))
   // usage-based detection
-  expect(code).toMatch('"core-js/modules/es.map"')
+  expect(code).toMatch('core-js/modules/es.map')
 })
 
 test('modern mode always skips unnecessary polyfills', () => {
@@ -67,7 +67,7 @@ test('modern mode always skips unnecessary polyfills', () => {
   // (modern: safari >= 10.1, es.promise: safrai >= 11)
   // the custom configuration only expects to support safari >= 12
   // so it can be skipped
-  expect(code).not.toMatch('es.promise"')
+  expect(code).not.toMatch('es.promise[^.]')
   // es.promise.finally is supported in safari >= 13.0.3
   // so still needs to be included
   expect(code).toMatch('es.promise.finally')
@@ -89,10 +89,10 @@ test('modern mode always skips unnecessary polyfills', () => {
     filename: 'test-entry-file.js'
   }))
   // default includes
-  expect(code).not.toMatch('es.promise"')
+  expect(code).not.toMatch('es.promise[^.]')
   expect(code).not.toMatch('es.promise.finally')
   // usage-based detection
-  expect(code).not.toMatch('"core-js/modules/es.map"')
+  expect(code).not.toMatch('core-js/modules/es.map')
   expect(code).not.toMatch('es.global-this')
   delete process.env.VUE_CLI_MODERN_BUILD
 })
@@ -120,7 +120,7 @@ test('async/await', () => {
   `.trim(), defaultOptions)
   expect(code).toMatch(getAbsolutePolyfill('es.promise'))
   // should use regenerator runtime
-  expect(code).toMatch(`"regenerator-runtime/runtime"`)
+  expect(code).toMatch(`regenerator-runtime/runtime`)
 })
 
 test('jsx', () => {
@@ -166,7 +166,7 @@ test('disable absoluteRuntime', () => {
     filename: 'test-entry-file.js'
   })
 
-  expect(code).toMatch('"@babel/runtime/helpers/toConsumableArray"')
+  expect(code).toMatch('@babel/runtime/helpers/toConsumableArray')
   expect(code).not.toMatch(getAbsolutePolyfill('es.promise'))
 })
 
@@ -187,8 +187,8 @@ test('should inject polyfills / helpers using "require" statements for a umd mod
     }]],
     filename: 'test-entry-file.js'
   })
-  expect(code).toMatch('require("@babel/runtime/helpers/toConsumableArray")')
-  expect(code).toMatch('require("core-js/modules/es.promise")')
+  expect(code).toMatch('require("@babel/runtime/helpers/toConsumableArray')
+  expect(code).toMatch('require("core-js/modules/es.promise')
   expect(code).not.toMatch('import ')
 })
 
@@ -205,8 +205,8 @@ test('should inject polyfills / helpers using "import" statements for an es modu
     filename: 'test-entry-file.js'
   })
 
-  expect(code).toMatch('import _toConsumableArray from "@babel/runtime/helpers/esm/toConsumableArray"')
-  expect(code).toMatch('import "core-js/modules/es.promise"')
+  expect(code).toMatch('import _toConsumableArray from "@babel/runtime/helpers/esm/toConsumableArray')
+  expect(code).toMatch('import "core-js/modules/es.promise')
   expect(code).not.toMatch('require(')
 })
 


### PR DESCRIPTION
See https://github.com/babel/babel/pull/10862

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
