### PR TITLE
chore: update cmd-shim and move it to devDependencies

### DIFF
--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -32,7 +32,6 @@
     "@vue/cli-ui-addon-webpack": "^4.5.8",
     "@vue/cli-ui-addon-widgets": "^4.5.8",
     "boxen": "^4.1.0",
-    "cmd-shim": "^3.0.3",
     "commander": "^2.20.0",
     "debug": "^4.1.0",
     "deepmerge": "^4.2.2",
@@ -61,6 +60,9 @@
     "vue": "^2.6.12",
     "vue-codemod": "^0.0.4",
     "yaml-front-matter": "^4.1.0"
+  },
+  "devDependencies": {
+    "cmd-shim": "^4.0.2"
   },
   "engines": {
     "node": "^10.12.0 || ^12.0.0 || >= 14.0.0"


### PR DESCRIPTION
It's only used in the `linkBin` function, which is used for setting up
testing projects.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
