### PR TITLE
docs: don't add `.loader()` when modifying vue-loader options

### DIFF
--- a/docs/guide/webpack.md
+++ b/docs/guide/webpack.md
@@ -55,7 +55,6 @@ module.exports = {
     config.module
       .rule('vue')
       .use('vue-loader')
-        .loader('vue-loader')
         .tap(options => {
           // modify the options...
           return options

--- a/docs/ru/guide/webpack.md
+++ b/docs/ru/guide/webpack.md
@@ -55,7 +55,6 @@ module.exports = {
     config.module
       .rule('vue')
       .use('vue-loader')
-        .loader('vue-loader')
         .tap(options => {
           // изменение настроек...
           return options

--- a/docs/zh/guide/webpack.md
+++ b/docs/zh/guide/webpack.md
@@ -55,7 +55,6 @@ module.exports = {
     config.module
       .rule('vue')
       .use('vue-loader')
-        .loader('vue-loader')
         .tap(options => {
           // 修改它的选项...
           return options


### PR DESCRIPTION
See the reasoning at https://github.com/Akryum/vue-cli-plugin-apollo/pull/463

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
