### PR TITLE
chore!: bump ejs to v3

### DIFF
--- a/packages/@vue/cli/package.json
+++ b/packages/@vue/cli/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/ejs": "^2.7.0",
+    "@types/ejs": "^3.0.5",
     "@types/inquirer": "^7.3.1",
     "@vue/cli-shared-utils": "^4.5.8",
     "@vue/cli-ui": "^4.5.8",
@@ -36,7 +36,7 @@
     "debug": "^4.1.0",
     "deepmerge": "^4.2.2",
     "download-git-repo": "^3.0.2",
-    "ejs": "^2.7.1",
+    "ejs": "^3.1.5",
     "envinfo": "^7.7.3",
     "fs-extra": "^7.0.1",
     "globby": "^9.2.0",


### PR DESCRIPTION
The only notable change may be dropping support of the include
preprocessor directive, which I don't know any Vue CLI plugin is using.

<https://github.com/mde/ejs/pull/478/files>

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
