### PR TITLE
fix: eslint formatter path error

### DIFF
--- a/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
@@ -1,4 +1,4 @@
-jest.setTimeout(35000)
+jest.setTimeout(300000)
 
 const path = require('path')
 const { linkBin } = require('@vue/cli/lib/util/linkBin')

--- a/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
@@ -225,3 +225,46 @@ test('should persist cache', async () => {
 
   expect(has('node_modules/.cache/eslint/cache.json')).toBe(true)
 })
+
+test(`should use formatter 'codeframe'`, async () => {
+  const project = await create('eslint-formatter-codeframe', {
+    plugins: {
+      '@vue/cli-plugin-babel': {},
+      '@vue/cli-plugin-eslint': {
+        config: 'airbnb',
+        lintOn: 'save'
+      }
+    }
+  })
+  const { read, write, run } = project
+  const main = await read('src/main.js')
+  expect(main).toMatch(';')
+
+  let done
+  const donePromise = new Promise(resolve => {
+    done = resolve
+  })
+  // remove semicolons
+  const updatedMain = main.replace(/;/g, '')
+  await write('src/main.js', updatedMain)
+
+  const server = run('vue-cli-service serve')
+
+  let isFirstMsg = true
+  server.stdout.on('data', data => {
+    data = data.toString()
+    if (isFirstMsg) {
+      expect(data).toMatch(/Failed to compile with \d error/)
+      isFirstMsg = false
+    } else if (data.match(/semi/)) {
+      // check the format of output
+      // https://eslint.org/docs/user-guide/formatters/#codeframe
+      expect(data).toMatch(`error: Missing semicolon (semi) at src${path.sep}main.js`)
+
+      server.stdin.write('close')
+      done()
+    }
+  })
+
+  await donePromise
+})

--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -52,7 +52,7 @@ module.exports = (api, options) => {
           resolveModule('eslint/package.json', cwd) ||
             resolveModule('eslint/package.json', __dirname)
         ),
-        formatter: loadModule('eslint/lib/formatters/codeframe', cwd, true)
+        formatter: loadModule('eslint/lib/cli-engine/formatters/codeframe', cwd, true)
       }
       webpackConfig.plugin('eslint').use(eslintWebpackPlugin, [eslintWebpackPluginOptions])
     })

--- a/packages/@vue/cli-plugin-eslint/index.js
+++ b/packages/@vue/cli-plugin-eslint/index.js
@@ -52,7 +52,7 @@ module.exports = (api, options) => {
           resolveModule('eslint/package.json', cwd) ||
             resolveModule('eslint/package.json', __dirname)
         ),
-        formatter: loadModule('eslint/lib/cli-engine/formatters/codeframe', cwd, true)
+        formatter: 'codeframe'
       }
       webpackConfig.plugin('eslint').use(eslintWebpackPlugin, [eslintWebpackPluginOptions])
     })


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

ESlint 7 has move code formatter to `eslint/lib/cli-engine/formatters/codeframe` but we have not change the path