### PR TITLE
feat: add a @vue/cli-plugin-webpack-4 package for future use

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/generator/index.js
@@ -7,30 +7,19 @@ module.exports = (api, options, rootOptions, invoking) => {
     hasRouter: api.hasPlugin('router')
   })
 
+  // mochapack currently does not support webpack 5 yet
+  require('@vue/cli-plugin-webpack-4/generator')(api, {}, rootOptions, invoking)
+
   api.extendPackage({
     devDependencies: {
+      '@vue/cli-plugin-webpack-4': require('../package.json').dependencies['@vue/cli-plugin-webpack-4'],
       '@vue/test-utils': isVue3 ? '^2.0.0-0' : '^1.1.0',
-      'chai': '^4.2.0',
-      'webpack': '^4.0.0'
+      'chai': '^4.2.0'
     },
     scripts: {
       'test:unit': 'vue-cli-service test:unit'
-    },
-    // Force resolutions is more reliable than module-alias
-    // Yarn and PNPM 5.10+ support this feature
-    // So we'll try to use that whenever possible
-    resolutions: {
-      '@vue/cli-*/webpack': '^4.0.0'
     }
   })
-
-  if (isVue3) {
-    api.extendPackage({
-      devDependencies: {
-        '@vue/server-renderer': '^3.0.0'
-      }
-    })
-  }
 
   if (api.hasPlugin('eslint')) {
     applyESLint(api)

--- a/packages/@vue/cli-plugin-unit-mocha/package.json
+++ b/packages/@vue/cli-plugin-unit-mocha/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-plugin-unit-mocha#readme",
   "dependencies": {
+    "@vue/cli-plugin-webpack-4": "^4.5.8",
     "@vue/cli-shared-utils": "^4.5.8",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",

--- a/packages/@vue/cli-plugin-webpack-4/README.md
+++ b/packages/@vue/cli-plugin-webpack-4/README.md
@@ -1,0 +1,3 @@
+# @vue/cli-plugin-webpack-4
+
+This plugin provides compatibily for webpack 4 in Vue CLI 5.

--- a/packages/@vue/cli-plugin-webpack-4/generator.js
+++ b/packages/@vue/cli-plugin-webpack-4/generator.js
@@ -1,0 +1,14 @@
+/** @type {import('@vue/cli').GeneratorPlugin} */
+module.exports = (api) => {
+  api.extendPackage({
+    devDependencies: {
+      'webpack': '^4.0.0'
+    },
+    // Force resolutions is more reliable than module-alias
+    // Yarn and PNPM 5.10+ support this feature
+    // So we'll try to use that whenever possible
+    resolutions: {
+      '@vue/cli-*/webpack': '^4.0.0'
+    }
+  })
+}

--- a/packages/@vue/cli-plugin-webpack-4/index.js
+++ b/packages/@vue/cli-plugin-webpack-4/index.js
@@ -1,0 +1,8 @@
+/** @type {import('@vue/cli-service').ServicePlugin} */
+module.exports = () => {
+  // TODO:
+  // terser-webpack-plugin v4
+  // copy-webpack-plugin v6
+  // html-webpack-plugin v4
+  // css-minimizer-webpack-plugin v1
+}

--- a/packages/@vue/cli-plugin-webpack-4/package.json
+++ b/packages/@vue/cli-plugin-webpack-4/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@vue/cli-plugin-webpack-4",
+  "version": "4.5.8",
+  "description": "webpack-4 plugin for @vue/cli v5",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuejs/vue-cli.git",
+    "directory": "packages/@vue/cli-plugin-webpack-4"
+  },
+  "keywords": [
+    "vue",
+    "cli",
+    "webpack 4"
+  ],
+  "author": "Haoqun Jiang",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vuejs/vue-cli/issues"
+  },
+  "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/@vue/cli-plugin-webpack-4#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "webpack": "^4.44.2"
+  },
+  "peerDependencies": {
+    "@vue/cli-service": "^5.0.0-0"
+  }
+}

--- a/packages/@vue/cli-shared-utils/lib/pluginResolution.js
+++ b/packages/@vue/cli-shared-utils/lib/pluginResolution.js
@@ -13,7 +13,8 @@ const officialPlugins = [
   'typescript',
   'unit-jest',
   'unit-mocha',
-  'vuex'
+  'vuex',
+  'webpack-4'
 ]
 
 exports.isPlugin = id => pluginRE.test(id)


### PR DESCRIPTION
More and more webpack plugins no longer support webpack 4 in their most
recent versions. For better webpack 5 compatibilities and easier upgrades
in the future, we should update these dependencies.

So it makes sense to extract webpack-4-specific dependencies and logic
to a standalone package.

While the task is not that urgent at the moment, and I haven't got the
time to complete this refactor, I think we should at least have a
placeholder package here, so that users don't have to add this
dependency manually in later prerelease versions.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
