### PR TITLE
fix docs type error;  `+ =` => `+=`

### DIFF
--- a/docs/zh/dev-guide/plugin-dev.md
+++ b/docs/zh/dev-guide/plugin-dev.md
@@ -268,7 +268,7 @@ module.exports.hooks = (api) => {
     const lines = contentMain.split(/\r?\n/g)
 
     const renderIndex = lines.findIndex(line => line.match(/render/))
-    lines[renderIndex] + = `\n router,`
+    lines[renderIndex] += `\n router,`
   })
 }
 ```


### PR DESCRIPTION
lines[renderIndex] + = `\n router,` => lines[renderIndex] += `\n router,`

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
