### PR TITLE
Update npx package target

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -26,7 +26,7 @@ yarn serve
 If you have [npx](https://github.com/npm/npx) available (should be bundled with an up-to-date version of npm), you can also invoke the binary directly with:
 
 ``` bash
-npx vue-cli-service serve
+npx @vue/cli-service serve
 ```
 
 ::: tip
@@ -115,13 +115,13 @@ You can use `vue-cli-service inspect` to inspect the webpack config inside a Vue
 Some CLI plugins  will inject additional commands to `vue-cli-service`. For example, `@vue/cli-plugin-eslint` injects the `vue-cli-service lint` command. You can see all injected commands by running:
 
 ``` bash
-npx vue-cli-service help
+npx @vue/cli-service help
 ```
 
 You can also learn about the available options of each command with:
 
 ``` bash
-npx vue-cli-service help [command]
+npx @vue/cli-service help [command]
 ```
 
 ## Skipping Plugins
@@ -129,7 +129,7 @@ npx vue-cli-service help [command]
 Sometimes, you may want to not use a certain CLI Plugin when running a command. For example you might want to build a version of your app that doesn't include the PWA plugin. You can do that by passing the name of the plugin to the `--skip-plugins` option.
 
 ```bash
-npx vue-cli-service build --skip-plugins pwa
+npx @vue/cli-service build --skip-plugins pwa
 ```
 
 ::: tip
@@ -139,18 +139,18 @@ This option is available for _every_ `vue-cli-service` command, including custom
 You can skip multiple plugins by passing their names as a comma-separated list:
 
 ```bash
-npx vue-cli-service build --skip-plugins pwa,apollo
+npx @vue/cli-service build --skip-plugins pwa,apollo
 ```
 
 Plugin names are resolved the same way they are during install, as described [here](./plugins-and-presets.md#installing-plugins-in-an-existing-project)
 
 ``` bash
 # these are all equivalent
-npx vue-cli-service build --skip-plugins pwa
+npx @vue/cli-service build --skip-plugins pwa
 
-npx vue-cli-service build --skip-plugins @vue/pwa
+npx @vue/cli-service build --skip-plugins @vue/pwa
 
-npx vue-cli-service build --skip-plugins @vue/cli-plugin-pwa
+npx @vue/cli-service build --skip-plugins @vue/cli-plugin-pwa
 ```
 
 ## Caching and Parallelization


### PR DESCRIPTION
Using `npx vue-cli-service` would throw the following error:

```
➜  ~ npx vue-cli-service help
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/vue-cli-service - Not found
npm ERR! 404
npm ERR! 404  'vue-cli-service@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/nook/.npm/_logs/2020-12-18T16_27_37_234Z-debug.log
Install for [ 'vue-cli-service@latest' ] failed with code 1
```

Replacing `npx vue-cli-service` with `npx @vue/cli-service` worked.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
