### PR TITLE
chore: use webpack-chain v6.5.1

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -76,7 +76,7 @@
     "vue-style-loader": "^4.1.2",
     "webpack": "^5.4.0",
     "webpack-bundle-analyzer": "^4.1.0",
-    "webpack-chain": "^6.4.0",
+    "webpack-chain": "^6.5.1",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^5.5.0",
     "webpack-virtual-modules": "^0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21888,7 +21888,7 @@ webpack-chain@^4.9.0:
     deepmerge "^1.5.2"
     javascript-stringify "^1.6.0"
 
-webpack-chain@^6.0.0, webpack-chain@^6.4.0:
+webpack-chain@^6.0.0, webpack-chain@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-6.5.1.tgz#4f27284cbbb637e3c8fbdef43eef588d4d861206"
   integrity sha512-7doO/SRtLu8q5WM0s7vPKPWX580qhi0/yBHkOxNkv50f6qB76Zy9o2wRTrrPULqYTvQlVHuvbA8v+G5ayuUDsA==


### PR DESCRIPTION
Vue CLI v5.0.0-alpha.0 uses `rule.resolve` in the CLI service (see https://github.com/vuejs/vue-cli/blob/v5.0.0-alpha.0/packages/@vue/cli-service/lib/config/base.js#L17-L20) which was introduced in webpack-chain v6.5.0.

See https://github.com/neutrinojs/webpack-chain/blob/master/CHANGELOG.md#v650

As the CLI service defines a dependency to webpack-chain v6.4.0, this causes issues in existing projects when trying to upgrade to the CLI v5.

Upgrading an existing project leads to `yarn build` throwing:

```
TypeError: Cannot read property 'set' of undefined
    at /Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/config/base.js:20:19
    at /Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/Service.js:240:40
    at Array.forEach (<anonymous>)
    at Service.resolveChainableWebpackConfig (/Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/Service.js:240:26)
    at PluginAPI.resolveChainableWebpackConfig (/Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/PluginAPI.js:145:25)
    at module.exports (/Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/commands/build/resolveAppConfig.js:9:22)
    at build (/Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/commands/build/index.js:147:50)
    at /Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/commands/build/index.js:89:13
    at Service.run (/Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/lib/Service.js:234:12)
    at Object.<anonymous> (/Users/ced-pro/Code/ninjasquad/vue-ebook/book-tests/node_modules/@vue/cli-service/bin/vue-cli-service.js:36:9)
```

This fixes the issue by specifying the necesseray minimal version for webpack-chain.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
