### PR TITLE
feat(cli-service): support plugin to inject process-env before load config file

### DIFF
--- a/packages/@vue/cli-service/__tests__/Service.spec.js
+++ b/packages/@vue/cli-service/__tests__/Service.spec.js
@@ -247,6 +247,26 @@ test('api: defaultModes', () => {
   }
 
   createMockService([plugin2], false /* init */).run('test')
+
+  delete process.env.NODE_ENV
+  delete process.env.BABEL_ENV
+
+  const plugin3 = {
+    id: 'test-defaultModes',
+    apply: api => {
+      expect(process.env.NODE_ENV).toBe('test')
+      expect(process.env.BABEL_ENV).toBe('test')
+      expect(process.env.TEST_ENV).toBe('test-env')
+      api.registerCommand('bar', () => {})
+    }
+  }
+  plugin3.apply.defaultModes = {
+    bar: ['test', {
+      TEST_ENV: 'test-env'
+    }]
+  }
+
+  createMockService([plugin3], false /* init */).run('bar')
 })
 
 test('api: chainWebpack', () => {

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const debug = require('debug')
+const arrify = require('arrify')
 const { merge } = require('webpack-merge')
 const Config = require('webpack-chain')
 const PluginAPI = require('./PluginAPI')
@@ -39,7 +40,19 @@ module.exports = class Service {
     // this is provided by plugins as module.exports.defaultModes
     // so we can get the information without actually applying the plugin.
     this.modes = this.plugins.reduce((modes, { apply: { defaultModes }}) => {
-      return Object.assign(modes, defaultModes)
+      Object.keys(defaultModes || {}).forEach((cmd) => {
+        const [mode, extendEnv] = arrify(defaultModes[cmd])
+        Object.assign(modes, {
+          [cmd]: mode
+        })
+        // allow plugin to set addtional process.env
+        if (extendEnv) {
+          Object.keys(extendEnv).forEach((envKey) => {
+            process.env[envKey] = extendEnv[envKey]
+          })
+        }
+      })
+      return modes
     }, {})
   }
 

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -37,6 +37,7 @@
     "acorn": "^8.0.1",
     "acorn-walk": "^8.0.0",
     "address": "^1.1.2",
+    "arrify": "^2.0.1",
     "autoprefixer": "^10.1.0",
     "browserslist": "^4.16.0",
     "cache-loader": "^4.1.0",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

We now support customizing the path to the configuration file via `process.env.VUE_CLI_SERVICE_CONFIG_PATH`, but this variable will be executed before the plugin apply. It means we can not set configuration file path in plugin.

I have developed a plugin `cli-plugin-doc` that registers the `dev:doc` command for starting project's documentation development. This `cli-plugin-doc` plugin requires the `vue-cli` build process, but needs to read `./docs/vue.config.js`  to implement the independent `webpack` build parameters compared with `vue-cli-service serve`.

With the current mechanism, neither `defaultModes` nor `.env` can meet the need.

**Before:**

```
module.exports.defaultModes = {
  'test:e2e': 'production'
}
```
process.env.NODE_ENV will be `production` when running `vue-cli-service test:e2e`

**after:**

```
module.exports.defaultModes = {
  'test:e2e':  ['production', {
     'VUE_CLI_SERVICE_CONFIG_PATH': './docs/vue.config.js'
   }]
}
```
In addition to the setting `process.env.NODE_ENV` when running `vue-cli-service test:e2e` ,  environment variables will be set `process.env.VUE_CLI_SERVICE_CONFIG_PATH = './docs/vue.config.js'`

