### PR TITLE
fix(cli-service): restrict request headers of historyApiFallback in WebpackDevServer

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -175,6 +175,10 @@ module.exports = (api, options) => {
       clientLogLevel: 'silent',
       historyApiFallback: {
         disableDotRule: true,
+        htmlAcceptHeaders: [
+          'text/html',
+          'application/xhtml+xml'
+        ],
         rewrites: genHistoryApiFallbackRewrites(options.publicPath, options.pages)
       },
       contentBase: api.resolve('public'),


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

To support history route mode, we current make `webpackDevServer` to redirects all requests to the entry html.

All 404 requests will be redirected, including requests for non-existent js/css files. In the case of JS files, this will usually result in a JS syntax error while try to execute html content as javascript.

And if the user code needs to use 404 errors, for example, `docisfy` will try to load `_sidebar.md` from multiple url one by one, all the way to the success one, this will lead to `docisfy`  never try to load next url  because the first request will be either success or redirect to entry html,  and will never return 404.

this PR will restrict request headers of historyApiFallback only work with `[ 'text/html', 'application/xhtml+xml']`

document is here https://github.com/bripkens/connect-history-api-fallback#htmlacceptheaders
