### PR TITLE
README: Suggest asset mocks

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/README.md
+++ b/packages/@vue/cli-plugin-unit-jest/README.md
@@ -33,6 +33,31 @@ node --inspect-brk ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:u
 
 Jest can be configured via `jest.config.js` in your project root, or the `jest` field in `package.json`.
 
+### Asset Mocks
+
+If you get a SyntaxError on an asset such as an image or stylesheet, you will need to configure mocks:
+
+**jest.config.js**:
+
+```
+  "moduleNameMapper": {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/file-mock.js",
+    "\\.(css|sass)$": "<rootDir>/__mocks__/style-mock.js"
+  }
+```
+
+**/src/__mock__/file-mock.js**:
+
+```js
+module.exports = 'test-file-stub'
+```
+
+**/src/__mock__/style-mock.js**:
+
+```js
+module.exports = {}
+```
+
 ## Installing in an Already Created Project
 
 ```sh


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Using Vue v3 and `vue add unit-jest` I got `SyntaxError: Invalid or unexpected token` on an imported gif. Adding asset mocks using `moduleNameMapper` ([StackOverflow](https://stackoverflow.com/a/47541818/480608)) fixed it. Let me know if a different approach to this problem is recommended.

```js
  moduleNameMapper: {
    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
      '<rootDir>/src/__mock__/file-mock.js',
    '\\.(css|less)$': '<rootDir>/src/__mock__/style-mock.js',
  },
```

I just noticed it's also possible with a transform via [jest-transform-stub](https://github.com/eddyerburgh/jest-transform-stub). Not sure which is preferable.

FYI My dependency versions:

```
    "@vue/cli-plugin-babel": "~4.5.9",
    "@vue/cli-plugin-eslint": "~4.5.9",
    "@vue/cli-plugin-unit-jest": "^4.5.9",
    "@vue/cli-service": "~4.5.9",
    "@vue/compiler-sfc": "^3.0.4",
    "@vue/test-utils": "^2.0.0-0",
    "babel-eslint": "^10.1.0",
    "vue-jest": "^5.0.0-0",
```