### PR TITLE
fix: add missing jest-transform-stub media types (#6169)

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/presets/default/jest-preset.js
+++ b/packages/@vue/cli-plugin-unit-jest/presets/default/jest-preset.js
@@ -9,7 +9,7 @@ module.exports = {
   transform: {
     // process *.vue files with vue-jest
     '^.+\\.vue$': require.resolve('vue-jest'),
-    '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$':
+    '.+\\.(css|styl|less|sass|scss|jpg|jpeg|png|svg|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
     require.resolve('jest-transform-stub'),
     '^.+\\.jsx?$': require.resolve('babel-jest')
   },


### PR DESCRIPTION
<!-- Please don't delete this template -->

Add missing assets to default present `jest-transform-stub` regex. A better solution to #6169.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
N/A