### PR TITLE
Fix documentation on default linted files

### DIFF
--- a/docs/core-plugins/eslint.md
+++ b/docs/core-plugins/eslint.md
@@ -17,7 +17,7 @@
     --max-warnings       specify number of warnings to make build failed (default: Infinity)
   ```
 
-  Lints and fixes files. If no specific files are given, it lints all files in `src` and `tests`.
+  Lints and fixes files. If no specific files are given, it lints all files in `src` and `tests`, as well as all Javascript files in the root directory (these are most often config files such as `babel.config.js` or `.eslintrc.js`).
 
   Other [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options) are also supported.
 

--- a/docs/core-plugins/eslint.md
+++ b/docs/core-plugins/eslint.md
@@ -17,9 +17,14 @@
     --max-warnings       specify number of warnings to make build failed (default: Infinity)
   ```
 
-  Lints and fixes files. If no specific files are given, it lints all files in `src` and `tests`, as well as all Javascript files in the root directory (these are most often config files such as `babel.config.js` or `.eslintrc.js`).
+Lints and fixes files. If no specific files are given, it lints all files in `src` and `tests`.
 
-  Other [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options) are also supported.
+Other [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options) are also supported.
+  
+::: tip
+`vue-cli-service lint` will lint dotfiles `.*.js` by default. If you want to follow ESLint's default behavior instead, consider adding a `.eslintignore` file in your project.
+:::
+
 
 ## Configuration
 

--- a/docs/core-plugins/eslint.md
+++ b/docs/core-plugins/eslint.md
@@ -17,7 +17,7 @@
     --max-warnings       specify number of warnings to make build failed (default: Infinity)
   ```
 
-Lints and fixes files. If no specific files are given, it lints all files in `src` and `tests`.
+Lints and fixes files. If no specific files are given, it lints all files in `src` and `tests`, as well as all JavaScript files in the root directory (these are most often config files such as `babel.config.js` or `.eslintrc.js`).
 
 Other [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options) are also supported.
   


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

The documentation mentions all files in the `src` and `tests` directories are linted by default. Upon inspection of the [sourcecode](https://github.com/vuejs/vue-cli/blob/3eaef4d388c52ea1d698991e7e96497164f90a04/packages/%40vue/cli-plugin-eslint/lint.js#L55) however, it seems that also Javascript files in the root directory are being linted by default.

I stumbled upon this when trying to figure out why my `.eslintrc.js` file itself was being linted by running `vue-cli-service lint` without passing any args.