### PR TITLE
genTranspileDepRegex放在chainWebpack内再执行

### DIFF
--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -22,7 +22,6 @@ function genTranspileDepRegex (transpileDependencies) {
 module.exports = (api, options) => {
   const useThreads = process.env.NODE_ENV === 'production' && !!options.parallel
   const cliServicePath = path.dirname(require.resolve('@vue/cli-service'))
-  const transpileDepRegex = genTranspileDepRegex(options.transpileDependencies)
 
   // try to load the project babel config;
   // if the default preset is used,
@@ -33,6 +32,7 @@ module.exports = (api, options) => {
 
   api.chainWebpack(webpackConfig => {
     webpackConfig.resolveLoader.modules.prepend(path.join(__dirname, 'node_modules'))
+    const transpileDepRegex = genTranspileDepRegex(options.transpileDependencies)
 
     const jsRule = webpackConfig.module
       .rule('js')


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe: genTranspileDepRegex执行时机下移

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
自己的vue-cli插件在package.json中默认是在 @vue/cli-plugin-babel 后面，我需要在我的插件内更改统一transpileDependencies
配置，将genTranspileDepRegex执行时机下移，使自己的插件中的配置变更生效，虽然可以在package.json中调整插件顺序，但是有时候会自动按名称排序，不方便
