### PR TITLE
fix: use basic auth for npm registry access

### DIFF
--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -197,7 +197,7 @@ class PackageManager {
     return this._registries[cacheKey]
   }
 
-  async getAuthToken (scope) {
+  async getAuthConfig (scope) {
     // get npmrc (https://docs.npmjs.com/configuring-npm/npmrc.html#files)
     const possibleRcPaths = [
       path.resolve(this.context, '.npmrc'),
@@ -225,8 +225,18 @@ class PackageManager {
       .replace(/https?:/, '') // remove leading protocol
       .replace(/([^/])$/, '$1/') // ensure ending with slash
     const authTokenKey = `${registryWithoutProtocol}:_authToken`
+    const authUsernameKey = `${registryWithoutProtocol}:username`
+    const authPasswordKey = `${registryWithoutProtocol}:_password`
 
-    return npmConfig[authTokenKey]
+    const auth = {}
+    if (authTokenKey in npmConfig) {
+      auth.token = npmConfig[authTokenKey]
+    }
+    if (authPasswordKey in npmConfig) {
+      auth.username = npmConfig[authUsernameKey]
+      auth.password = Buffer.from(npmConfig[authPasswordKey], 'base64').toString()
+    }
+    return auth
   }
 
   async setRegistryEnvs () {
@@ -296,9 +306,13 @@ class PackageManager {
       headers.Accept = 'application/vnd.npm.install-v1+json;q=1.0, application/json;q=0.9, */*;q=0.8'
     }
 
-    const authToken = await this.getAuthToken(scope)
-    if (authToken) {
-      headers.Authorization = `Bearer ${authToken}`
+    const authConfig = await this.getAuthConfig(scope)
+    if ('password' in authConfig) {
+      const credentials = Buffer.from(`${authConfig.username}:${authConfig.password}`).toString('base64')
+      headers.Authorization = `Basic ${credentials}`
+    }
+    if ('token' in authConfig) {
+      headers.Authorization = `Bearer ${authConfig.token}`
     }
 
     const url = `${registry.replace(/\/$/g, '')}/${packageName}`


### PR DESCRIPTION
When username and password are configured in the .npmrc for the
respective scope, use basic auth when getting package metadate from the
npm registry.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Cf. https://github.com/vuejs/vue-cli/issues/6206