### PR TITLE
fix(unit-mocha): shouldn't require webpack-4 plugin with cli-service v4

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/generator/index.js
@@ -1,3 +1,4 @@
+/** @type {import('@vue/cli').GeneratorPlugin} */
 module.exports = (api, options, rootOptions, invoking) => {
   const isVue3 = rootOptions && rootOptions.vueVersion === '3'
 
@@ -7,8 +8,12 @@ module.exports = (api, options, rootOptions, invoking) => {
     hasRouter: api.hasPlugin('router')
   })
 
-  // mochapack currently does not support webpack 5 yet
-  require('@vue/cli-plugin-webpack-4/generator')(api, {}, rootOptions, invoking)
+  const { semver } = require('@vue/cli-shared-utils')
+  const cliServiceVersion = require('@vue/cli-service/package.json').version
+  if (semver.gte(cliServiceVersion, '5.0.0-0')) {
+    // mochapack currently does not support webpack 5 yet
+    require('@vue/cli-plugin-webpack-4/generator')(api, {}, rootOptions, invoking)
+  }
 
   api.extendPackage({
     devDependencies: {


### PR DESCRIPTION
Note this plugin is compatible with cli-service v4, therefore users can
upgrade to it separately for mocha major version upgrades


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
