### PR TITLE
fix: "commonjs2" target should not be used with "output.library"

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -129,6 +129,11 @@ module.exports = (api, { entry, name, formats, filename, 'inline-vue': inlineVue
       publicPath: ''
     })
 
+    if (format === 'commonjs2') {
+      // #6188
+      delete rawConfig.output.library
+    }
+
     return rawConfig
   }
 


### PR DESCRIPTION
Closes #6188


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
