### PR TITLE
feat: transpile dependencies in node_modules

### DIFF
--- a/docs/guide/cli-service.md
+++ b/docs/guide/cli-service.md
@@ -52,6 +52,7 @@ Options:
   --https        use https (default: false)
   --public       specify the public network URL for the HMR client
   --skip-plugins comma-separated list of plugin names to skip for this run
+  --no-transpile-all: don't transpile all dependencies with Babel; only those specified by 'transpileDependencies' will be processed
 ```
 
 ::: tip --copy
@@ -85,6 +86,7 @@ Options:
   --report       generate report.html to help analyze bundle content
   --report-json  generate report.json to help analyze bundle content
   --skip-plugins comma-separated list of plugin names to skip for this run
+  --no-transpile-all don't transpile all dependencies with Babel; only those specified by 'transpileDependencies' will be processed
   --watch        watch for changes
 ```
 

--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -2,7 +2,8 @@ const defaults = {
   clean: true,
   target: 'app',
   formats: 'commonjs,umd,umd-min',
-  'unsafe-inline': true
+  'unsafe-inline': true,
+  'transpile-all': true
 }
 
 const buildModes = {
@@ -37,6 +38,7 @@ module.exports = (api, options) => {
       '--report': `generate report.html to help analyze bundle content`,
       '--report-json': 'generate report.json to help analyze bundle content',
       '--skip-plugins': `comma-separated list of plugin names to skip for this run`,
+      '--no-transpile-all': `don't transpile all dependencies with Babel; only those specified by 'transpileDependencies' will be processed`,
       '--watch': `watch for changes`,
       '--stdin': `close when stdin ends`
     }

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -10,7 +10,8 @@ const {
 const defaults = {
   host: '0.0.0.0',
   port: 8080,
-  https: false
+  https: false,
+  'transpile-all': true
 }
 
 module.exports = (api, options) => {
@@ -26,7 +27,8 @@ module.exports = (api, options) => {
       '--port': `specify port (default: ${defaults.port})`,
       '--https': `use https (default: ${defaults.https})`,
       '--public': `specify the public network URL for the HMR client`,
-      '--skip-plugins': `comma-separated list of plugin names to skip for this run`
+      '--skip-plugins': `comma-separated list of plugin names to skip for this run`,
+      '--no-transpile-all': `don't transpile all dependencies with Babel; only those specified by 'transpileDependencies' will be processed`
     }
   }, async function serve (args) {
     info('Starting development server...')
@@ -46,6 +48,11 @@ module.exports = (api, options) => {
     const launchEditorMiddleware = require('launch-editor-middleware')
     const validateWebpackConfig = require('../util/validateWebpackConfig')
     const isAbsoluteUrl = require('../util/isAbsoluteUrl')
+
+    const transpileAll = args['transpile-all'] || defaults['transpile-all']
+    if (transpileAll) {
+      process.env.VUE_CLI_BABEL_TRANSPILE_ALL_DEPS = true
+    }
 
     // configs that only matters for dev server
     api.chainWebpack(webpackConfig => {


### PR DESCRIPTION
TODOs:
- [x] ~~A simplified `dependencies` babel preset for `node_modules`, to reduce the performance overhead~~ I don't think there will be much overhead because the default preset only adds very few custom features. It would also be against the users' intention if they choose a different preset for their project
- [x] ~~Decide whether to opt-in or opt-out of this feature~~ Should be opt-out. And we should continue improving the cache configuration to speed up incremental builds.
- [ ] Test cases
- [ ] Revise the `transpileDependencies` documentation
- [ ] Mention this feature in the migration documentation

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
