### PR TITLE
chore: disable cacheCompression for babel-loader by default

### DIFF
--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -78,15 +78,18 @@ module.exports = (api, options) => {
     jsRule
       .use('babel-loader')
         .loader(require.resolve('babel-loader'))
-        .options(api.genCacheConfig('babel-loader', {
-          '@babel/core': require('@babel/core/package.json').version,
-          '@vue/babel-preset-app': require('@vue/babel-preset-app/package.json').version,
-          'babel-loader': require('babel-loader/package.json').version,
-          modern: !!process.env.VUE_CLI_MODERN_BUILD,
-          browserslist: api.service.pkg.browserslist
-        }, [
-          'babel.config.js',
-          '.browserslistrc'
-        ]))
+        .options({
+          cacheCompression: false,
+          ...api.genCacheConfig('babel-loader', {
+            '@babel/core': require('@babel/core/package.json').version,
+            '@vue/babel-preset-app': require('@vue/babel-preset-app/package.json').version,
+            'babel-loader': require('babel-loader/package.json').version,
+            modern: !!process.env.VUE_CLI_MODERN_BUILD,
+            browserslist: api.service.pkg.browserslist
+          }, [
+            'babel.config.js',
+            '.browserslistrc'
+          ])
+        })
   })
 }


### PR DESCRIPTION
See the reasoning at https://github.com/facebook/create-react-app/pull/7633

This change should improve the build speed for large projects

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
