### PR TITLE
fix: discard `NODE_ENV` when installing project dependencies

### DIFF
--- a/packages/@vue/cli/lib/util/ProjectPackageManager.js
+++ b/packages/@vue/cli/lib/util/ProjectPackageManager.js
@@ -347,8 +347,14 @@ class PackageManager {
   }
 
   async runCommand (command, args) {
+    const prevNodeEnv = process.env.NODE_ENV
+    // In the use case of Vue CLI, when installing dependencies,
+    // the `NODE_ENV` environment variable does no good;
+    // it only confuses users by skipping dev deps (when set to `production`).
+    delete process.env.NODE_ENV
+
     await this.setRegistryEnvs()
-    return await executeCommand(
+    await executeCommand(
       this.bin,
       [
         ...PACKAGE_MANAGER_CONFIG[this.bin][command],
@@ -356,6 +362,10 @@ class PackageManager {
       ],
       this.context
     )
+
+    if (prevNodeEnv) {
+      process.env.NODE_ENV = prevNodeEnv
+    }
   }
 
   async install () {


### PR DESCRIPTION
Avoid empty `node_modules` when the user has set `NODE_ENV` to
`production` in the shell environment.

In the long run, we should have a more comprehensive preflight check
for execution environment though.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
