### PR TITLE
fix: mini-css-extract-plugin publicPath option can be an absolute path

### DIFF
--- a/packages/@vue/cli-service/lib/config/css.js
+++ b/packages/@vue/cli-service/lib/config/css.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const isAbsoluteUrl = require('../util/isAbsoluteUrl')
 
 const findExisting = (context, files) => {
   for (const file of files) {
@@ -39,16 +40,19 @@ module.exports = (api, rootOptions) => {
       chunkFilename: filename
     }, extract && typeof extract === 'object' ? extract : {})
 
+    // when project publicPath is a relative path
     // use relative publicPath in extracted CSS based on extract location
-    const cssPublicPath = process.env.VUE_CLI_BUILD_TARGET === 'lib'
-      // in lib mode, CSS is extracted to dist root.
-      ? './'
-      : '../'.repeat(
-        extractOptions.filename
+    const cssPublicPath = (isAbsoluteUrl(rootOptions.publicPath) || rootOptions.publicPath.startsWith('/'))
+      ? rootOptions.publicPath
+      : process.env.VUE_CLI_BUILD_TARGET === 'lib'
+        // in lib mode, CSS is extracted to dist root.
+        ? './'
+        : '../'.repeat(
+          extractOptions.filename
             .replace(/^\.[/\\]/, '')
             .split(/[/\\]/g)
             .length - 1
-      )
+        )
 
     // check if the project has a valid postcss config
     // if it doesn't, don't use postcss-loader for direct style imports


### PR DESCRIPTION
    When the user set the project public path to the absolute path, the extract-css publicPath option should be changed synchronously

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
N/A