### PR TITLE
Troubleshooting for Windows, when vue command doesn't work

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -16,7 +16,7 @@ npm_config_unsafe_perm=true vue create my-project
 
 ## Symbolic Links in `node_modules`
 
-If there're dependencies installed by `npm link` or `yarn link`, ESLint (and sometimes Babel as well) may not work properly for those symlinked dependencies. It is because [webpack resolves symlinks to their real locations by default](https://webpack.js.org/configuration/resolve/#resolvesymlinks), thus breaks ESLint / Babel config lookup.
+If there are dependencies installed by `npm link` or `yarn link`, ESLint (and sometimes Babel as well) may not work properly for those symlinked dependencies. It is because [webpack resolves symlinks to their real locations by default](https://webpack.js.org/configuration/resolve/#resolvesymlinks), thus breaks ESLint / Babel config lookup.
 
 A workaround for this issue is to manually disable symlinks resolution in webpack:
 
@@ -31,3 +31,7 @@ module.exports = {
 
 ::: warning
 Disabling `resolve.symlinks` may break hot module reloading if your dependencies are installed by third-party npm clients that utilized symbolic links, such as`cnpm` or `pnpm`.
+
+::: 'vue' is not recognized as an internal or external command
+This error happens in Windows if you don't have npm in your system path. To check: from a command prompt type `path`.
+Confirm the actual path to your npm repo. It should be like `c:\Users\[YourLoginName]\AppData\Roaming\npm` (using your actual login name). Add that to your System Properties, Environment Variables.


### PR DESCRIPTION
After installing vue\cli, if the >vue command doesn't work, it could be because the npm path is not in the Windows system path.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Other information:**
