### PR TITLE
fix: correctly pad log strings

### DIFF
--- a/packages/@vue/cli-shared-utils/lib/logger.js
+++ b/packages/@vue/cli-shared-utils/lib/logger.js
@@ -21,7 +21,7 @@ const format = (label, msg) => {
   return msg.split('\n').map((line, i) => {
     return i === 0
       ? `${label} ${line}`
-      : line.padStart(stripAnsi(label).length)
+      : line.padStart(stripAnsi(label).length + line.length + 1)
   }).join('\n')
 }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

String padding does not calculate the length of the line and spaces, which makes the log look strange.（Sorry, I am not good at English, these words are translated by Google）

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
