### PR TITLE
fix resolve lib public path

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -123,10 +123,7 @@ module.exports = (api, { entry, name, formats, filename, 'inline-vue': inlineVue
     }, rawConfig.output, {
       filename: `${entryName}.js`,
       chunkFilename: `${entryName}.[name].js`,
-      // use dynamic publicPath so this can be deployed anywhere
-      // the actual path will be determined at runtime by checking
-      // document.currentScript.src.
-      publicPath: ''
+
     })
 
     return rawConfig


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

when i'm building a library and i've correctly configured vue.config.js publicPath, the resolver must use configured path instead of '' for two reasons: 
1) it's not good to change a user configuration (it's responsability of the user to correctly se publicPath according to his needs)
2) i'm developing a big application using microfrontend development approach and i need to address specific module separation also in folder structure because my application is composed at runtime of different umd modules. so is not correct to put all modules in / root folder or in a global javascript folder of main app. if you reset publicPath to '' i'm forced to put all modules in root folder and i cannot address module separation or module versioning by folder structure that is important during microfrontend development and ci/cd process. 

in the picture you can see an example of a deployment configuration i cannot address with publicPath resetted to '' for libs. 

![image](https://user-images.githubusercontent.com/1579329/106669831-8aa85500-65ac-11eb-9f4a-92a9109657d2.png)

