### PR TITLE
fix publicPath reset if build in PRODUCTION mode

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -122,8 +122,7 @@ module.exports = (api, { entry, name, formats, filename, 'inline-vue': inlineVue
       globalObject: `(typeof self !== 'undefined' ? self : this)`
     }, rawConfig.output, {
       filename: `${entryName}.js`,
-      chunkFilename: `${entryName}.[name].js`,
-
+      chunkFilename: `${entryName}.[name].js`
     })
 
     if (format === 'commonjs2') {

--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -123,10 +123,7 @@ module.exports = (api, { entry, name, formats, filename, 'inline-vue': inlineVue
     }, rawConfig.output, {
       filename: `${entryName}.js`,
       chunkFilename: `${entryName}.[name].js`,
-      // use dynamic publicPath so this can be deployed anywhere
-      // the actual path will be determined at runtime by checking
-      // document.currentScript.src.
-      publicPath: ''
+
     })
 
     if (format === 'commonjs2') {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

I have a group of microfronend applications, each one build as lib in a separate build process. 
My CI/CD scripts place every build in a different server path, so i've change the publicPath in vue.config of each lib to match my publish path.
The main app load libs and use it correctly loading every lib at runtime via a json config from the correct subpath, but if a lib build has produced an additional chunk it fails if PRODUCTION env, because of publicPath has been resetted to '' and load of libs chunks happens from main app path and not from lib path;  if i build in DEVELOPMENT mode it works, because in DEVELOPMENT env the cli does not reset the publicPath of lib . 

