### PR TITLE
Add note about loader incompatible with webpack 4

### DIFF
--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -21,6 +21,15 @@ npm install -D less-loader less
 npm install -D stylus-loader stylus
 ```
 
+::: tip Note on webpack 4
+When using `webpack` version 4, the default in Vue CLI 4, you need to make sure your loaders are compatible with it. Otherwise you will get errors about confliciting peer dependencies. In this case you can use an older version of the loader that is still compatible with `webpack` 4.
+
+``` bash
+# Sass
+npm install -D sass-loader@^10 sass
+```
+:::
+ 
 Then you can import the corresponding file types, or use them in `*.vue` files with:
 
 ``` vue


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
sass-loader is incompatible with webpack 4 since https://github.com/webpack-contrib/sass-loader/releases/tag/v11.0.0. It might be good to include a note for users stumbling upon this problem.