### PR TITLE
fix(cli-plugin-pwa): webpack5 warning for emitting manifest.json

### DIFF
--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -183,27 +183,31 @@ module.exports = class HtmlPwaPlugin {
     })
 
     if (!isHrefAbsoluteUrl(this.options.manifestPath)) {
-      compiler.hooks.emit.tapAsync(ID, (data, cb) => {
-        const {
-          name,
-          themeColor,
-          manifestPath,
-          manifestOptions
-        } = this.options
-        const publicOptions = {
-          name,
-          short_name: name,
-          theme_color: themeColor
-        }
-        const outputManifest = JSON.stringify(
-          Object.assign(publicOptions, defaultManifest, manifestOptions)
-        )
-        data.assets[manifestPath] = {
-          source: () => outputManifest,
-          size: () => outputManifest.length
-        }
-        cb(null, data)
-      })
+      compiler.hooks.compilation.tap(ID, compilation => {
+        compilation.hooks.processAssets.tap(
+          {name: ID, stage: 'PROCESS_ASSETS_STAGE_ADDITIONS'},
+          assets => {
+            const {
+              name,
+              themeColor,
+              manifestPath,
+              manifestOptions
+            } = this.options
+            const publicOptions = {
+              name,
+              short_name: name,
+              theme_color: themeColor
+            }
+            const outputManifest = JSON.stringify(
+              Object.assign(publicOptions, defaultManifest, manifestOptions)
+            )
+            assets[manifestPath] = {
+              source: () => outputManifest,
+              size: () => outputManifest.length,
+            };
+          },
+        );
+      });
     }
   }
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

While #6247 was closed and called a dupe of #6236. This warning will still occur if the plugin needs to generate a manifest.json file.

This PR will address the deprecation warning and fix the issue.