### PR TITLE
chore: remove the word "Preview" from vue 3 preset

### DIFF
--- a/packages/@vue/cli-ui/apollo-server/connectors/projects.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/projects.js
@@ -137,7 +137,7 @@ async function initCreator (context) {
         if (key === 'default') {
           name = 'org.vue.views.project-create.tabs.presets.default-preset'
         } else if (key === '__default_vue_3__') {
-          name = 'org.vue.views.project-create.tabs.presets.default-preset-vue-3-preview'
+          name = 'org.vue.views.project-create.tabs.presets.default-preset-vue-3'
         }
         const info = {
           id: key,

--- a/packages/@vue/cli-ui/locales/en.json
+++ b/packages/@vue/cli-ui/locales/en.json
@@ -345,7 +345,7 @@
                 "done": "Done"
               },
               "default-preset": "Default preset",
-              "default-preset-vue-3-preview": "Default preset (Vue 3 preview)"
+              "default-preset-vue-3": "Default preset (Vue 3)"
             },
             "features": {
               "title": "Features",

--- a/packages/@vue/cli/__tests__/Creator.spec.js
+++ b/packages/@vue/cli/__tests__/Creator.spec.js
@@ -10,7 +10,7 @@ test('default', async () => {
       message: 'pick a preset',
       choices: [
         'Default',
-        'Default (Vue 3 Preview)',
+        'Default (Vue 3)',
         'Manually select'
       ],
       choose: 0
@@ -107,7 +107,7 @@ test('manual + PromptModuleAPI', async () => {
       choices: [
         'test',
         'Default',
-        'Default (Vue 3 Preview)',
+        'Default (Vue 3)',
         'Manually'
       ],
       choose: 0

--- a/packages/@vue/cli/lib/Creator.js
+++ b/packages/@vue/cli/lib/Creator.js
@@ -412,7 +412,7 @@ module.exports = class Creator extends EventEmitter {
       if (name === 'default') {
         displayName = 'Default'
       } else if (name === '__default_vue_3__') {
-        displayName = 'Default (Vue 3 Preview)'
+        displayName = 'Default (Vue 3)'
       }
 
       return {


### PR DESCRIPTION
Now that most Vue 3 core packages has reached stable, I think it makes
sense to remove the word "Preview".

Remaining dependencies to reach stable:
- @vue/test-utils 2.x (in RC)
- vue-class-component 8.x (in RC)
- vue-jest v5 (in alpha)


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
