### PR TITLE
chore: remove the word "Preview" from vue 3 preset

### DIFF
--- a/packages/@vue/cli/lib/promptModules/vueVersion.js
+++ b/packages/@vue/cli/lib/promptModules/vueVersion.js
@@ -17,7 +17,7 @@ module.exports = cli => {
         value: '2'
       },
       {
-        name: '3.x (Preview)',
+        name: '3.x',
         value: '3'
       }
     ],


### PR DESCRIPTION
This removes `Preview` from the Vue 3.x version prompt.

related to #6300

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe: version list prompt

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
