### PR TITLE
feat(wip): add filesystem cache config for webpack 5

### DIFF
--- a/packages/@vue/cli-service/lib/PluginAPI.js
+++ b/packages/@vue/cli-service/lib/PluginAPI.js
@@ -212,6 +212,28 @@ class PluginAPI {
     const cacheIdentifier = hash(variables)
     return { cacheDirectory, cacheIdentifier }
   }
+
+  /**
+   * Vue CLI enables the filesystem cache in webpack 5 by default.
+   * If your plugin depends on an additional config file (e.g. `stylelint.config.js`),
+   * the default cache config does not take that file into account,
+   * thus causing unexpected cache persistence.
+   * To avoid such problems, you should add that file to the `buildDependencies`
+   * of webpack by calling this function.
+   * (e.g. `api.addBuildDependencies('stylelint.config.js')`)
+   * @param {string[]|Object} deps if an array of strings is passed, it will be
+   * appended to the cache.buildDependencies.config field; if an object is passed,
+   * it will be merged into the cache.buildDependencies filed
+   */
+  addBuildDependencies (deps, { shouldEvaluate }) {
+    if (Array.isArray(deps)) {
+      this.configureWebpack(() => ({ cache: { buildDependencies: { config: deps } } }))
+    } else {
+      this.configureWebpack(() => ({ cache: { buildDependencies: deps } }))
+    }
+
+    // FIXME: how to deal with random environment variables in `.js` buildDependencies?
+  }
 }
 
 module.exports = PluginAPI

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -349,11 +349,9 @@ module.exports = class Service {
         }
 
         if (!fileConfig || typeof fileConfig !== 'object') {
-          // TODO: show throw an Error here, to be fixed in v5
-          error(
+          throw new Error(
             `Error loading ${chalk.bold(fileConfigPath)}: should export an object or a function that returns object.`
           )
-          fileConfig = null
         }
       } catch (e) {
         error(`Error loading ${chalk.bold(fileConfigPath)}:`)
@@ -384,12 +382,20 @@ module.exports = class Service {
       }
       resolved = fileConfig
       resolvedFrom = 'vue.config.js'
+
+      // add the path to buildDependencies
+      this.plugins.push({
+        id: 'set-build-dependencies',
+        apply: (api) => api.addBuildDependencies([fileConfigPath])
+      })
     } else if (pkgConfig) {
       resolved = pkgConfig
       resolvedFrom = '"vue" field in package.json'
     } else {
       resolved = this.inlineOptions || {}
       resolvedFrom = 'inline options'
+
+      // FIXME: may need to add inline options hash to cache name
     }
 
     if (resolved.css && typeof resolved.css.modules !== 'undefined') {

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -12,12 +12,28 @@ module.exports = (api, options) => {
     const isLegacyBundle = process.env.VUE_CLI_MODERN_MODE && !process.env.VUE_CLI_MODERN_BUILD
     const resolveLocal = require('../util/resolveLocal')
 
-    // https://github.com/webpack/webpack/issues/11467#issuecomment-691873586
     if (webpackMajor !== 4) {
+      // https://github.com/webpack/webpack/issues/11467#issuecomment-691873586
       webpackConfig.module
         .rule('esm')
           .test(/\.m?jsx?$/)
           .resolve.set('fullySpecified', false)
+
+      // Filesystem cache only available for webpack 5
+      webpackConfig.cache({
+        type: 'filesystem',
+        // Set different cache name for different modes and targets (and commands).
+        // Since we use environment variables for all kinds of purposes,
+        // the most straightforward way is to just find and combine those
+        // Vue CLI-specific environment variables.
+        name: Object.entries(process.env)
+          .filter(([key]) => key.startsWith('VUE_CLI'))
+          .map(([key, value]) => `${key}-${value}`)
+          .join(';'),
+        buildDependencies: {
+          config: [require.resolve('../../webpack.config')]
+        }
+      })
     }
 
     webpackConfig

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -55,6 +55,12 @@ const schema = createSchema(joi => joi.object({
     })
   }),
 
+  // for cache invalidation
+  buildDependencies: joi.alternatives().try(
+    joi.array().items(joi.string().required()),
+    joi.object()
+  ),
+
   // webpack
   chainWebpack: joi.func(),
   configureWebpack: joi.alternatives().try(

--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -132,6 +132,12 @@ interface ProjectOptions {
   css?: CSSOptions;
 
   /**
+   * Tell webpack to invalidate the build cache when changes are detected in these additional buildDependencies.
+   * Can be an array of config file paths or an object that is accepted by the webpack `cache.buildDependencies` option.
+   */
+  buildDependencies?: Array<string> | Object,
+
+  /**
    * A function that will receive an instance of `ChainableConfig` powered by [webpack-chain](https://github.com/mozilla-neutrino/webpack-chain)
    */
   chainWebpack?: (config: ChainableWebpackConfig) => void;


### PR DESCRIPTION
New:
- Turn on `filesystem` cache by default in webpack 5
- An `addBuildDependencies` plugin API for plugins to add additional
dependencies to the cache config

To Fix:
- Need to implement a `--no-cache` option for both `serve` and `build`
command
- Need to decide how to deal with `.js` config files when a random
environment variable change may affect its exports
- `lintOnSave` option needs an overhaul to work better with webpack 5
and the new cache mechanism
- Not sure how to test the cache implementation

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

Due to the may-be-buggy cache configuration, it should be considered as a breaking change.

- [x] Yes
- [ ] No

**Other information:**
