### PR TITLE
refactor!: move vue-jest and ts-jest to peer dependencies

### DIFF
--- a/docs/migrations/migrate-from-v4.md
+++ b/docs/migrations/migrate-from-v4.md
@@ -124,6 +124,8 @@ Please consider switching to ESLint. You can check out [`tslint-to-eslint-config
 
 ### Unit-Jest Plugin
 
+* For Vue 2 projects, `vue-jest` is now required as a peer dependency, please install `vue-jest@^4.0.1` as a dev dependency to the project.
+* For TypeScript projects, `ts-jest` is now required as a peer dependency. Users need to install `ts-jest@26` manually to the project root.
 * The underlying `jest`-related packages are upgraded from v24 to v26. For most users the transition would be seamless. See their corresponding changelogs for more detail:
   * [jest, babel-jest](https://github.com/facebook/jest/blob/v26.6.3/CHANGELOG.md)
   * [ts-jest](https://github.com/kulshekhar/ts-jest/blob/v26.4.4/CHANGELOG.md)

--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -12,6 +12,7 @@ module.exports = (api, options, rootOptions, invoking) => {
       'test:unit': 'vue-cli-service test:unit'
     },
     devDependencies: {
+      'vue-jest': isVue3 ? '^5.0.0-0' : '^4.0.1',
       '@vue/test-utils': isVue3 ? '^2.0.0-0' : '^1.1.3'
     },
     jest: {
@@ -20,21 +21,6 @@ module.exports = (api, options, rootOptions, invoking) => {
         : '@vue/cli-plugin-unit-jest/presets/no-babel'
     }
   })
-
-  if (isVue3) {
-    api.extendPackage({
-      devDependencies: {
-        'vue-jest': '^5.0.0-0',
-        // vue-jest 5.0.0-alpha.1 requires typescript to be present
-        'typescript': '~4.1.2'
-      },
-      jest: {
-        transform: {
-          '^.+\\.vue$': 'vue-jest'
-        }
-      }
-    })
-  }
 
   if (api.hasPlugin('eslint')) {
     applyESLint(api)
@@ -71,7 +57,8 @@ const applyTS = (module.exports.applyTS = (api, invoking) => {
         : '@vue/cli-plugin-unit-jest/presets/typescript'
     },
     devDependencies: {
-      '@types/jest': '^26.0.20'
+      '@types/jest': '^26.0.20',
+      'ts-jest': '^26.5.3'
     }
   })
 

--- a/packages/@vue/cli-plugin-unit-jest/migrator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/migrator/index.js
@@ -1,0 +1,24 @@
+/** @param {import('@vue/cli/lib/MigratorAPI')} api MigratorAPI */
+module.exports = (api) => {
+  api.extendPackage(pkg => {
+    const toMerge = {}
+
+    const allDeps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+      ...pkg.optionalDependencies
+    }
+
+    if (!allDeps['vue-jest']) {
+      // Likely a Vue 2 project, and uses the builtin preset.
+      // Because we used to add `vue-jest` v5 to dev deps for Vue 3 projects.
+      toMerge['vue-jest'] = '^4.0.1'
+    }
+
+    if (allDeps['@vue/cli-plugin-typescript'] && !allDeps['ts-jest']) {
+      toMerge['ts-jest'] = '^26.5.3'
+    }
+
+    return toMerge
+  })
+}

--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -32,14 +32,21 @@
     "jest": "^26.6.3",
     "jest-serializer-vue": "^2.0.2",
     "jest-transform-stub": "^2.0.0",
-    "jest-watch-typeahead": "^0.6.1",
-    "ts-jest": "^26.5.1",
-    "vue-jest": "^4.0.1"
+    "jest-watch-typeahead": "^0.6.1"
   },
   "devDependencies": {
-    "@vue/test-utils": "^1.1.3"
+    "@vue/test-utils": "^1.1.3",
+    "ts-jest": "^26.5.3",
+    "vue-jest": "^4.0.1"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
+    "vue-jest": "^4.0.1 || ^5.0.0-0",
+    "ts-jest": "^26.5.3"
+  },
+  "peerDependenciesMeta": {
+    "ts-jest": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
vue-jest now requires several different peer deps for vue 2 and vue 3;
ts-jest now requires typescript as peer dep, which should be optional
for unit-jest plugin users because they might choose not to use
typescript.

Both are causing annoying peer dep warnings.

So it only makes sense to move them to the project level, to keep things
clean.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
