### PR TITLE
feat: a `defineConfig` API from `@vue/cli-service` for better typing support in `vue.config.js`

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -27,6 +27,17 @@ module.exports = {
 }
 ```
 
+Or, you can use the `defineConfig` helper from `@vue/cli-service`, which could provide better intellisense support:
+
+```js
+// vue.config.js
+const { defineConfig } = require('@vue/cli-service')
+
+module.exports = defineConfig({
+  // options...
+})
+```
+
 ### baseUrl
 
 Deprecated since Vue CLI 3.3, please use [`publicPath`](#publicPath) instead.

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -26,6 +26,18 @@ module.exports = {
   // 选项...
 }
 ```
+
+或者，你也可以使用 `@vue/cli-service` 提供的 `defineConfig` 帮手函数，以获得更好的类型提示：
+
+```js
+// vue.config.js
+const { defineConfig } = require('@vue/cli-service')
+
+module.exports = defineConfig({
+  // 选项
+})
+```
+
 ### baseUrl
 
 从 Vue CLI 3.3 起已弃用，请使用[`publicPath`](#publicpath)。

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -436,3 +436,14 @@ function cloneRuleNames (to, from) {
     }
   })
 }
+
+/**
+ * @typedef {import('../types/index').ConfigFunction} ConfigFunction
+ * @typedef {import('../types/index').ProjectOptions} ProjectOptions
+ * @typedef {ProjectOptions|ConfigFunction} UserConfig
+ * @param {UserConfig} config
+ * @returns UserConfig
+ */
+module.exports.defineConfig = function defineConfig (config) {
+  return config
+}

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -437,13 +437,5 @@ function cloneRuleNames (to, from) {
   })
 }
 
-/**
- * @typedef {import('../types/index').ConfigFunction} ConfigFunction
- * @typedef {import('../types/index').ProjectOptions} ProjectOptions
- * @typedef {ProjectOptions|ConfigFunction} UserConfig
- * @param {UserConfig} config
- * @returns UserConfig
- */
-module.exports.defineConfig = function defineConfig (config) {
-  return config
-}
+/** @type {import('../types/index').defineConfig} */
+module.exports.defineConfig = (config) => config

--- a/packages/@vue/cli-service/types/index.d.ts
+++ b/packages/@vue/cli-service/types/index.d.ts
@@ -3,7 +3,7 @@ import ChainableConfig = require('webpack-chain')
 import webpack = require('webpack')
 import WebpackDevServer = require('webpack-dev-server')
 import express = require('express') // @types/webpack-dev-server depends on @types/express
-import { ProjectOptions } from './ProjectOptions'
+import { ProjectOptions, ConfigFunction } from './ProjectOptions'
 
 type RegisterCommandFn = (args: minimist.ParsedArgs, rawArgv: string[]) => any
 
@@ -134,4 +134,5 @@ type ServicePlugin = (
 ) => any
 
 export { ProjectOptions, ServicePlugin, PluginAPI }
-export { ConfigFunction } from './ProjectOptions'
+type UserConfig = ProjectOptions | ConfigFunction
+export function defineConfig(config: UserConfig): UserConfig


### PR DESCRIPTION
Just like the API with the same name in Vite.
<https://vitejs.dev/config/>


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
