### PR TITLE
fix(cli-service): respect the existing 'devtool'

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -13,6 +13,7 @@ const defaults = {
   https: false
 }
 
+/** @type {import('@vue/cli-service').ServicePlugin} */
 module.exports = (api, options) => {
   api.registerCommand('serve', {
     description: 'start development server',
@@ -50,8 +51,10 @@ module.exports = (api, options) => {
     // configs that only matters for dev server
     api.chainWebpack(webpackConfig => {
       if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
-        webpackConfig
-          .devtool('eval-cheap-module-source-map')
+        if (!webpackConfig.get('devtool')) {
+          webpackConfig
+            .devtool('eval-cheap-module-source-map')
+        }
 
         webpackConfig
           .plugin('hmr')


### PR DESCRIPTION
Respect the existing 'devtool' when running dev server

Fixes #6398

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
