### PR TITLE
feat: support `vue.config.mjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/vue-cli-version-marker"
   ],
   "scripts": {
-    "test": "node scripts/test.js",
+    "test": "node --experimental-vm-modules scripts/test.js",
     "pretest": "yarn clean",
     "lint": "eslint --fix packages/**/*.js packages/**/bin/*",
     "lint-without-fix": "eslint packages/**/*.js packages/**/bin/*",

--- a/packages/@vue/cli-plugin-typescript/__tests__/tsPluginBabel.spec.js
+++ b/packages/@vue/cli-plugin-typescript/__tests__/tsPluginBabel.spec.js
@@ -4,7 +4,7 @@ const Service = require('@vue/cli-service/lib/Service')
 const create = require('@vue/cli-test-utils/createTestProject')
 const { assertServe, assertBuild } = require('./tsPlugin.helper')
 
-test('using correct loader', () => {
+test('using correct loader', async () => {
   const service = new Service('/', {
     pkg: {},
     plugins: [
@@ -13,7 +13,7 @@ test('using correct loader', () => {
     ]
   })
 
-  service.init()
+  await service.init()
   const config = service.resolveWebpackConfig()
   // eslint-disable-next-line no-shadow
   const rule = config.module.rules.find(rule => rule.test.test('foo.ts'))

--- a/packages/@vue/cli-service/__tests__/ServiceESM.spec.js
+++ b/packages/@vue/cli-service/__tests__/ServiceESM.spec.js
@@ -1,3 +1,4 @@
+jest.setTimeout(200000)
 const path = require('path')
 const fs = require('fs-extra')
 

--- a/packages/@vue/cli-service/__tests__/ServiceESM.spec.js
+++ b/packages/@vue/cli-service/__tests__/ServiceESM.spec.js
@@ -1,52 +1,63 @@
-const Service = require('../lib/Service')
-
 const path = require('path')
-const configPath = path.resolve('/', 'vue.config.cjs')
+const fs = require('fs-extra')
 
-jest.mock('fs')
-const fs = require('fs')
+const { defaultPreset } = require('@vue/cli/lib/options')
+const create = require('@vue/cli-test-utils/createTestProject')
+const { loadModule } = require('@vue/cli-shared-utils')
 
-beforeEach(() => {
-  fs.writeFileSync(path.resolve('/', 'package.json'), JSON.stringify({
-    type: 'module',
-    vue: {
-      lintOnSave: 'default'
-    }
-  }, null, 2))
+let project
+beforeAll(async () => {
+  project = await create('service-esm-test', defaultPreset)
+  const pkg = JSON.parse(await project.read('package.json'))
+  pkg.type = 'module'
+  pkg.vue = { lintOnSave: 'default' }
+  await project.write('package.json', JSON.stringify(pkg, null, 2))
+  fs.renameSync(path.resolve(project.dir, 'babel.config.js'), path.resolve(project.dir, 'babel.config.cjs'))
 })
 
-afterEach(() => {
-  if (fs.existsSync(configPath)) {
-    fs.unlinkSync(configPath)
-  }
-})
-
-const createService = () => {
-  const service = new Service('/', {
+const createService = async () => {
+  const Service = loadModule('@vue/cli-service/lib/Service', project.dir)
+  const service = new Service(project.dir, {
     plugins: [],
     useBuiltIn: false
   })
-  service.init()
+  await service.init()
   return service
 }
 
-// vue.config.cjs has higher priority
-
 test('load project options from package.json', async () => {
-  const service = createService()
+  const service = await createService()
   expect(service.projectOptions.lintOnSave).toBe('default')
 })
 
 test('load project options from vue.config.cjs', async () => {
-  fs.writeFileSync(configPath, '')
-  jest.mock(configPath, () => ({ lintOnSave: true }), { virtual: true })
-  const service = createService()
+  const configPath = path.resolve(project.dir, './vue.config.cjs')
+  fs.writeFileSync(configPath, 'module.exports = { lintOnSave: true }')
+  const service = await createService()
   expect(service.projectOptions.lintOnSave).toBe(true)
+  await fs.unlinkSync(configPath)
 })
 
 test('load project options from vue.config.cjs as a function', async () => {
-  fs.writeFileSync(configPath, '')
-  jest.mock(configPath, () => function () { return { lintOnSave: true } }, { virtual: true })
-  const service = createService()
+  const configPath = path.resolve(project.dir, './vue.config.cjs')
+  fs.writeFileSync(configPath, 'module.exports = function () { return { lintOnSave: true } }')
+  const service = await createService()
   expect(service.projectOptions.lintOnSave).toBe(true)
+  await fs.unlinkSync(configPath)
+})
+
+test('load project options from vue.config.js', async () => {
+  const configPath = path.resolve(project.dir, './vue.config.js')
+  fs.writeFileSync(configPath, 'export default { lintOnSave: true }')
+  const service = await createService()
+  expect(service.projectOptions.lintOnSave).toBe(true)
+  await fs.unlinkSync(configPath)
+})
+
+test('load project options from vue.config.mjs', async () => {
+  const configPath = path.resolve(project.dir, './vue.config.mjs')
+  fs.writeFileSync(configPath, 'export default { lintOnSave: true }')
+  const service = await createService()
+  expect(service.projectOptions.lintOnSave).toBe(true)
+  await fs.unlinkSync(configPath)
 })

--- a/packages/@vue/cli-service/__tests__/css.spec.js
+++ b/packages/@vue/cli-service/__tests__/css.spec.js
@@ -19,11 +19,11 @@ const LOADERS = {
   stylus: 'stylus'
 }
 
-const genConfig = (pkg = {}, env) => {
+const genConfig = async (pkg = {}, env) => {
   const prevEnv = process.env.NODE_ENV
   if (env) process.env.NODE_ENV = env
   const service = new Service('/', { pkg })
-  service.init()
+  await service.init()
   const config = service.resolveWebpackConfig()
   process.env.NODE_ENV = prevEnv
   return config
@@ -58,8 +58,8 @@ const findOptions = (config, lang, _loader, index) => {
   return use.options || {}
 }
 
-test('default loaders', () => {
-  const config = genConfig()
+test('default loaders', async () => {
+  const config = await genConfig()
 
   LANGS.forEach(lang => {
     const loader = lang === 'css' ? [] : LOADERS[lang]
@@ -80,8 +80,8 @@ test('default loaders', () => {
   })
 })
 
-test('production defaults', () => {
-  const config = genConfig({}, 'production')
+test('production defaults', async () => {
+  const config = await genConfig({}, 'production')
   LANGS.forEach(lang => {
     const loader = lang === 'css' ? [] : LOADERS[lang]
     expect(findLoaders(config, lang)).toEqual([extractLoaderPath, 'css', 'postcss'].concat(loader))
@@ -93,8 +93,8 @@ test('production defaults', () => {
   })
 })
 
-test('override postcss config', () => {
-  const config = genConfig({ postcss: {} })
+test('override postcss config', async () => {
+  const config = await genConfig({ postcss: {} })
   LANGS.forEach(lang => {
     const loader = lang === 'css' ? [] : LOADERS[lang]
     expect(findLoaders(config, lang)).toEqual(['vue-style', 'css', 'postcss'].concat(loader))
@@ -107,7 +107,7 @@ test('override postcss config', () => {
   })
 })
 
-test('Customized CSS Modules rules', () => {
+test('Customized CSS Modules rules', async () => {
   const userOptions = {
     vue: {
       css: {
@@ -122,7 +122,7 @@ test('Customized CSS Modules rules', () => {
     }
   }
 
-  const config = genConfig(userOptions)
+  const config = await genConfig(userOptions)
 
   LANGS.forEach(lang => {
     const expected = {
@@ -142,8 +142,8 @@ test('Customized CSS Modules rules', () => {
   })
 })
 
-test('css.extract', () => {
-  const config = genConfig({
+test('css.extract', async () => {
+  const config = await genConfig({
     vue: {
       css: {
         extract: false
@@ -159,7 +159,7 @@ test('css.extract', () => {
     expect(findOptions(config, lang, 'postcss').postcssOptions.plugins).toBeTruthy()
   })
 
-  const config2 = genConfig({
+  const config2 = await genConfig({
     postcss: {},
     vue: {
       css: {
@@ -178,8 +178,8 @@ test('css.extract', () => {
   })
 })
 
-test('css.sourceMap', () => {
-  const config = genConfig({
+test('css.sourceMap', async () => {
+  const config = await genConfig({
     postcss: {},
     vue: {
       css: {
@@ -194,9 +194,9 @@ test('css.sourceMap', () => {
   })
 })
 
-test('css-loader options', () => {
+test('css-loader options', async () => {
   const localIdentName = '[name]__[local]--[hash:base64:5]'
-  const config = genConfig({
+  const config = await genConfig({
     vue: {
       css: {
         loaderOptions: {
@@ -219,9 +219,9 @@ test('css-loader options', () => {
   })
 })
 
-test('css.loaderOptions', () => {
+test('css.loaderOptions', async () => {
   const prependData = '$env: production;'
-  const config = genConfig({
+  const config = await genConfig({
     vue: {
       css: {
         loaderOptions: {
@@ -254,11 +254,11 @@ test('css.loaderOptions', () => {
   })
 })
 
-test('scss loaderOptions', () => {
+test('scss loaderOptions', async () => {
   const sassData = '$env: production'
   const scssData = '$env: production;'
 
-  const config = genConfig({
+  const config = await genConfig({
     vue: {
       css: {
         loaderOptions: {

--- a/packages/@vue/cli-service/lib/Service.js
+++ b/packages/@vue/cli-service/lib/Service.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const path = require('path')
 const debug = require('debug')
 const { merge } = require('webpack-merge')
@@ -7,10 +6,12 @@ const PluginAPI = require('./PluginAPI')
 const dotenv = require('dotenv')
 const dotenvExpand = require('dotenv-expand')
 const defaultsDeep = require('lodash.defaultsdeep')
-const { chalk, warn, error, isPlugin, resolvePluginId, loadModule, resolvePkg, resolveModule } = require('@vue/cli-shared-utils')
+const { warn, error, isPlugin, resolvePluginId, loadModule, resolvePkg, resolveModule } = require('@vue/cli-shared-utils')
 
-const { defaults, validate } = require('./options')
-const checkWebpack = require('@vue/cli-service/lib/util/checkWebpack')
+const { defaults } = require('./options')
+const checkWebpack = require('./util/checkWebpack')
+const loadFileConfig = require('./util/loadFileConfig')
+const resolveUserConfig = require('./util/resolveUserConfig')
 
 module.exports = class Service {
   constructor (context, { plugins, pkg, inlineOptions, useBuiltIn } = {}) {
@@ -55,7 +56,7 @@ module.exports = class Service {
     return pkg
   }
 
-  init (mode = process.env.VUE_CLI_MODE) {
+  async init (mode = process.env.VUE_CLI_MODE) {
     if (this.initialized) {
       return
     }
@@ -70,7 +71,7 @@ module.exports = class Service {
     this.loadEnv()
 
     // load user config
-    const userOptions = this.loadUserOptions()
+    const userOptions = await this.loadUserOptions()
     this.projectOptions = defaultsDeep(userOptions, defaults())
 
     debug('vue:project-config')(this.projectOptions)
@@ -227,7 +228,7 @@ module.exports = class Service {
     this.setPluginsToSkip(args)
 
     // load env variables, load user config, apply plugins
-    this.init(mode)
+    await this.init(mode)
 
     args._ = args._ || []
     let command = this.commands[name]
@@ -316,110 +317,32 @@ module.exports = class Service {
     return config
   }
 
+  // Note: we intentionally make this function synchronous by default
+  // because eslint-import-resolver-webpack does not support async webpack configs.
   loadUserOptions () {
-    // vue.config.c?js
-    let fileConfig, pkgConfig, resolved, resolvedFrom
-    const esm = this.pkg.type && this.pkg.type === 'module'
+    const { fileConfig, fileConfigPath } = loadFileConfig(this.context)
 
-    const possibleConfigPaths = [
-      process.env.VUE_CLI_SERVICE_CONFIG_PATH,
-      './vue.config.js',
-      './vue.config.cjs'
-    ]
-
-    let fileConfigPath
-    for (const p of possibleConfigPaths) {
-      const resolvedPath = p && path.resolve(this.context, p)
-      if (resolvedPath && fs.existsSync(resolvedPath)) {
-        fileConfigPath = resolvedPath
-        break
-      }
+    // Seems we can't use `instanceof Promise` here (would fail the tests)
+    if (fileConfig && typeof fileConfig.then === 'function') {
+      return fileConfig
+        .then(mod => {
+          // fs.writeFileSync(`${this.context}/aaaa`, `mod ${JSON.stringify(mod, null, 2)}`)
+          return mod.default
+        })
+        .then(loadedConfig => resolveUserConfig({
+          inlineOptions: this.inlineOptions,
+          pkgConfig: this.pkg.vue,
+          fileConfig: loadedConfig,
+          fileConfigPath
+        }))
     }
 
-    if (fileConfigPath) {
-      if (esm && fileConfigPath === './vue.config.js') {
-        throw new Error(`Please rename ${chalk.bold('vue.config.js')} to ${chalk.bold('vue.config.cjs')} when ECMAScript modules is enabled`)
-      }
-
-      try {
-        fileConfig = loadModule(fileConfigPath, this.context)
-
-        if (typeof fileConfig === 'function') {
-          fileConfig = fileConfig()
-        }
-
-        if (!fileConfig || typeof fileConfig !== 'object') {
-          // TODO: show throw an Error here, to be fixed in v5
-          error(
-            `Error loading ${chalk.bold(fileConfigPath)}: should export an object or a function that returns object.`
-          )
-          fileConfig = null
-        }
-      } catch (e) {
-        error(`Error loading ${chalk.bold(fileConfigPath)}:`)
-        throw e
-      }
-    }
-
-    // package.vue
-    pkgConfig = this.pkg.vue
-    if (pkgConfig && typeof pkgConfig !== 'object') {
-      error(
-        `Error loading vue-cli config in ${chalk.bold(`package.json`)}: ` +
-        `the "vue" field should be an object.`
-      )
-      pkgConfig = null
-    }
-
-    if (fileConfig) {
-      if (pkgConfig) {
-        warn(
-          `"vue" field in package.json ignored ` +
-          `due to presence of ${chalk.bold('vue.config.js')}.`
-        )
-        warn(
-          `You should migrate it into ${chalk.bold('vue.config.js')} ` +
-          `and remove it from package.json.`
-        )
-      }
-      resolved = fileConfig
-      resolvedFrom = 'vue.config.js'
-    } else if (pkgConfig) {
-      resolved = pkgConfig
-      resolvedFrom = '"vue" field in package.json'
-    } else {
-      resolved = this.inlineOptions || {}
-      resolvedFrom = 'inline options'
-    }
-
-    // normalize some options
-    ensureSlash(resolved, 'publicPath')
-    if (typeof resolved.publicPath === 'string') {
-      resolved.publicPath = resolved.publicPath.replace(/^\.\//, '')
-    }
-    removeSlash(resolved, 'outputDir')
-
-    // validate options
-    validate(resolved, msg => {
-      error(
-        `Invalid options in ${chalk.bold(resolvedFrom)}: ${msg}`
-      )
+    return resolveUserConfig({
+      inlineOptions: this.inlineOptions,
+      pkgConfig: this.pkg.vue,
+      fileConfig,
+      fileConfigPath
     })
-
-    return resolved
-  }
-}
-
-function ensureSlash (config, key) {
-  const val = config[key]
-  if (typeof val === 'string') {
-    config[key] = val.replace(/([^/])$/, '$1/')
-  }
-}
-
-function removeSlash (config, key) {
-  if (typeof config[key] === 'string') {
-    config[key] = config[key].replace(/\/$/g, '')
   }
 }
 

--- a/packages/@vue/cli-service/lib/util/checkWebpack.js
+++ b/packages/@vue/cli-service/lib/util/checkWebpack.js
@@ -24,6 +24,7 @@ module.exports = function checkWebpack (cwd) {
   // Check the package.json,
   // and only load from the project if webpack is explictly depended on,
   // in case of accidental hoisting.
+
   let pkg = {}
   try {
     pkg = loadModule('./package.json', cwd)

--- a/packages/@vue/cli-service/lib/util/loadFileConfig.js
+++ b/packages/@vue/cli-service/lib/util/loadFileConfig.js
@@ -1,0 +1,38 @@
+const fs = require('fs')
+const path = require('path')
+
+const isFileEsm = require('is-file-esm')
+const { loadModule } = require('@vue/cli-shared-utils')
+
+module.exports = function loadFileConfig (context) {
+  let fileConfig, fileConfigPath
+
+  const possibleConfigPaths = [
+    process.env.VUE_CLI_SERVICE_CONFIG_PATH,
+    './vue.config.js',
+    './vue.config.cjs',
+    './vue.config.mjs'
+  ]
+  for (const p of possibleConfigPaths) {
+    const resolvedPath = p && path.resolve(context, p)
+    if (resolvedPath && fs.existsSync(resolvedPath)) {
+      fileConfigPath = resolvedPath
+      break
+    }
+  }
+
+  if (fileConfigPath) {
+    const { esm } = isFileEsm.sync(fileConfigPath)
+
+    if (esm) {
+      fileConfig = import(fileConfigPath)
+    } else {
+      fileConfig = loadModule(fileConfigPath, context)
+    }
+  }
+
+  return {
+    fileConfig,
+    fileConfigPath
+  }
+}

--- a/packages/@vue/cli-service/lib/util/resolveUserConfig.js
+++ b/packages/@vue/cli-service/lib/util/resolveUserConfig.js
@@ -1,0 +1,81 @@
+const path = require('path')
+const { chalk, warn, error } = require('@vue/cli-shared-utils')
+const { validate } = require('../options')
+
+function ensureSlash (config, key) {
+  const val = config[key]
+  if (typeof val === 'string') {
+    config[key] = val.replace(/([^/])$/, '$1/')
+  }
+}
+
+function removeSlash (config, key) {
+  if (typeof config[key] === 'string') {
+    config[key] = config[key].replace(/\/$/g, '')
+  }
+}
+
+module.exports = function resolveUserConfig ({
+  inlineOptions,
+  pkgConfig,
+  fileConfig,
+  fileConfigPath
+}) {
+  if (fileConfig) {
+    if (typeof fileConfig === 'function') {
+      fileConfig = fileConfig()
+    }
+
+    if (!fileConfig || typeof fileConfig !== 'object') {
+      throw new Error(
+        `Error loading ${chalk.bold(fileConfigPath)}: ` +
+        `should export an object or a function that returns object.`
+      )
+    }
+  }
+
+  // package.vue
+  if (pkgConfig && typeof pkgConfig !== 'object') {
+    throw new Error(
+      `Error loading Vue CLI config in ${chalk.bold(`package.json`)}: ` +
+      `the "vue" field should be an object.`
+    )
+  }
+
+  let resolved, resolvedFrom
+  if (fileConfig) {
+    const configFileName = path.basename(fileConfigPath)
+    if (pkgConfig) {
+      warn(
+        `"vue" field in package.json ignored ` +
+        `due to presence of ${chalk.bold(configFileName)}.`
+      )
+      warn(
+        `You should migrate it into ${chalk.bold(configFileName)} ` +
+        `and remove it from package.json.`
+      )
+    }
+    resolved = fileConfig
+    resolvedFrom = configFileName
+  } else if (pkgConfig) {
+    resolved = pkgConfig
+    resolvedFrom = '"vue" field in package.json'
+  } else {
+    resolved = inlineOptions || {}
+    resolvedFrom = 'inline options'
+  }
+
+  // normalize some options
+  ensureSlash(resolved, 'publicPath')
+  if (typeof resolved.publicPath === 'string') {
+    resolved.publicPath = resolved.publicPath.replace(/^\.\//, '')
+  }
+  removeSlash(resolved, 'outputDir')
+
+  // validate options
+  validate(resolved, msg => {
+    error(`Invalid options in ${chalk.bold(resolvedFrom)}: ${msg}`)
+  })
+
+  return resolved
+}

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -56,6 +56,7 @@
     "globby": "^11.0.2",
     "hash-sum": "^2.0.0",
     "html-webpack-plugin": "^5.1.0",
+    "is-file-esm": "^1.0.0",
     "launch-editor-middleware": "^2.2.1",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.mapvalues": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12658,6 +12658,13 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
+is-file-esm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-file-esm/-/is-file-esm-1.0.0.tgz#987086b0f5a5318179e9d30f4f2f8d37321e1b5f"
+  integrity sha512-rZlaNKb4Mr8WlRu2A9XdeoKgnO5aA53XdPHgCKVyCrQ/rWi89RET1+bq37Ru46obaQXeiX4vmFIm1vks41hoSA==
+  dependencies:
+    read-pkg-up "^7.0.1"
+
 is-finite@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.1.0.tgz#904135c77fb42c0641d6aa1bcdbc4daa8da082f3"


### PR DESCRIPTION
In Node.js 12.17+ only.
Otherwise, the `--experimental-modules` flag need to be turned on for
Node.

Not compatible with `eslint-import-resolver-webpack`.

Closes #4477

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
