### PR TITLE
chore(cli): rely on default arg parser behaviour

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -234,10 +234,6 @@ enhanceErrorMessages('optionMissingArgument', (option, flag) => {
 
 program.parse(process.argv)
 
-if (!process.argv.slice(2).length) {
-  program.outputHelp()
-}
-
 function suggestCommands (unknownCommand) {
   const availableCommands = program.commands.map(cmd => cmd._name)
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

From [v5.0.0](https://github.com/tj/commander.js/releases/tag/v5.0.0), `Commander.js` displays help information for missing subcommand by default.