### PR TITLE
Show fallback message for typescript jest preset if ts-jest is not in…

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/presets/typescript/jest-preset.js
+++ b/packages/@vue/cli-plugin-unit-jest/presets/typescript/jest-preset.js
@@ -3,7 +3,7 @@ const defaultPreset = require('../default/jest-preset')
 
 let tsJest = null
 try {
-  tsJest = require('ts-jest')
+  tsJest = require.resolve('ts-jest')
 } catch (e) {
   throw new Error('Cannot resolve "ts-jest" module. Typescript preset requires "ts-jest" to be installed.')
 }

--- a/packages/@vue/cli-plugin-unit-jest/presets/typescript/jest-preset.js
+++ b/packages/@vue/cli-plugin-unit-jest/presets/typescript/jest-preset.js
@@ -1,12 +1,19 @@
 const deepmerge = require('deepmerge')
 const defaultPreset = require('../default/jest-preset')
 
+let tsJest = null
+try {
+  tsJest = require('ts-jest')
+} catch (e) {
+  throw new Error('Cannot resolve "ts-jest" module. Typescript preset requires "ts-jest" to be installed.')
+}
+
 module.exports = deepmerge(
   defaultPreset,
   {
     moduleFileExtensions: ['ts', 'tsx'],
     transform: {
-      '^.+\\.tsx?$': require.resolve('ts-jest')
+      '^.+\\.tsx?$': tsJest
     }
   }
 )


### PR DESCRIPTION
Show fallback message for typescript jest preset if ts-jest is not installed.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Because ts-jest is an optional peer dependency there are should be a fallback message If the module is not installed.
closes #6383