### PR TITLE
fix: should not include IE11 target in Vue 3 projects

### DIFF
--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -32,7 +32,8 @@ module.exports = (api, options) => {
     browserslist: [
       '> 1%',
       'last 2 versions',
-      'not dead'
+      'not dead',
+      ...(options.vueVersion === '3' ? ['not ie 11'] : [])
     ]
   })
 


### PR DESCRIPTION
As Vue 3 does not, and likely will not support IE11.

https://github.com/vuejs/rfcs/pull/294

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
