### PR TITLE
feat!: drop IE11 support in CLI UI

### DIFF
--- a/packages/@vue/cli-ui-addon-webpack/package.json
+++ b/packages/@vue/cli-ui-addon-webpack/package.json
@@ -39,7 +39,8 @@
   "browserslist": [
     "> 1%",
     "last 2 versions",
-    "not dead"
+    "not dead",
+    "not ie 11"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/@vue/cli-ui-addon-widgets/.browserslistrc
+++ b/packages/@vue/cli-ui-addon-widgets/.browserslistrc
@@ -1,3 +1,4 @@
 > 1%
 last 2 versions
 not dead
+not ie 11

--- a/packages/@vue/cli-ui/package.json
+++ b/packages/@vue/cli-ui/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "yarn run test:clear && start-server-and-test apollo:start:test http://localhost:4040/.well-known/apollo/server-health test:e2e:dev",
     "test:start": "yarn run test:clear && start-server-and-test apollo:start:test http://localhost:4040/.well-known/apollo/server-health test:e2e:start",
     "test:e2e:dev": "cross-env VUE_APP_CLI_UI_URL=ws://localhost:4040/graphql vue-cli-service test:e2e --mode development",
-    "test:e2e:start": "vue-cli-service test:e2e --mode production --headless --url=http://localhost:4040",
+    "test:e2e:start": "vue-cli-service test:e2e --mode production --browser chrome --headless --url=http://localhost:4040",
     "test:clear": "rimraf ../../test/cli-ui-test && rimraf ./live-test",
     "test": "yarn run build && cd ../cli-ui-addon-webpack && yarn run build && cd ../cli-ui-addon-widgets && yarn run build && cd ../cli-ui && yarn run test:start"
   },

--- a/packages/@vue/cli-ui/package.json
+++ b/packages/@vue/cli-ui/package.json
@@ -111,7 +111,8 @@
   "browserslist": [
     "> 1%",
     "last 2 versions",
-    "not dead"
+    "not dead",
+    "not ie 11"
   ],
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
1. Saves a lot of build time.
2. Somehow the modern mode bundle fails Cypress tests **only in electron headless mode**. I never reproduced the error in real browsers. Dropping the legacy bundle fixes the CI issue.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
