### PR TITLE
fix(typescript): add missing dependencies and `require.resolve` compiler

### DIFF
--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -85,7 +85,7 @@ module.exports = (api, projectOptions) => {
             extensions: {
               vue: {
                 enabled: true,
-                compiler: isVue3 ? '@vue/compiler-sfc' : 'vue-template-compiler'
+                compiler: isVue3 ? require.resolve('@vue/compiler-sfc') : require.resolve('vue-template-compiler')
               }
             },
             diagnosticOptions: {

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -38,10 +38,14 @@
   "peerDependencies": {
     "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
     "@vue/compiler-sfc": "^3.0.0-beta.14",
+    "vue-template-compiler": "^2.0.0",
     "typescript": ">=2"
   },
   "peerDependenciesMeta": {
     "@vue/compiler-sfc": {
+      "optional": true
+    },
+    "vue-template-compiler": {
       "optional": true
     }
   },

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@types/webpack-env": "^1.15.2",
     "@vue/cli-shared-utils": "^5.0.0-beta.0",
+    "@babel/core": "^7.12.16",
     "babel-loader": "^8.2.2",
     "cache-loader": "^4.1.0",
     "fork-ts-checker-webpack-plugin": "^6.1.0",


### PR DESCRIPTION
- The typescript plugin depends on `vue-template-compiler` when using Vue 2 but it isn't declared
- `@babel/core` isn't provided to `babel-loader`
- The compiler passed to `fork-ts-checker-webpack-plugin` isn't resolved making it rely on hoisting

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
