### PR TITLE
fix(SafariNomoduleFixPlugin): use RawSource instead of a plain object

### DIFF
--- a/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
@@ -23,7 +23,9 @@ class SafariNomoduleFixPlugin {
     if (!needsSafariFix) {
       return
     }
-    const { RawSource } = compiler.webpack.sources
+    const { RawSource } = compiler.webpack
+      ? compiler.webpack.sources
+      : require('webpack-sources')
 
     const ID = 'SafariNomoduleFixPlugin'
     compiler.hooks.compilation.tap(ID, compilation => {

--- a/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
@@ -23,6 +23,7 @@ class SafariNomoduleFixPlugin {
     if (!needsSafariFix) {
       return
     }
+    const { RawSource } = compiler.webpack.sources
 
     const ID = 'SafariNomoduleFixPlugin'
     compiler.hooks.compilation.tap(ID, compilation => {
@@ -40,14 +41,7 @@ class SafariNomoduleFixPlugin {
           // inject the fix as an external script
           const safariFixPath = path.join(this.jsDirectory, 'safari-nomodule-fix.js')
           const fullSafariFixPath = path.join(compilation.options.output.publicPath, safariFixPath)
-          compilation.assets[safariFixPath] = {
-            source: function () {
-              return Buffer.from(safariFix)
-            },
-            size: function () {
-              return Buffer.byteLength(safariFix)
-            }
-          }
+          compilation.assets[safariFixPath] = new RawSource(safariFix)
           scriptTag = {
             tagName: 'script',
             closeTag: true,

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -83,7 +83,8 @@
   },
   "peerDependencies": {
     "@vue/compiler-sfc": "^3.0.0-beta.14",
-    "vue-template-compiler": "^2.0.0"
+    "vue-template-compiler": "^2.0.0",
+    "webpack-sources": "*"
   },
   "peerDependenciesMeta": {
     "@vue/compiler-sfc": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Writing plain objects to `compilation.assets` can cause the following error:
```
UnhandledPromiseRejectionWarning: TypeError: asset.map is not a function
    at getTaskForFile (/home/kael/Documents/vuetifyjs/vuetify-next/packages/docs/node_modules/webpack/lib/SourceMapDevToolPlugin.js:88:47)
    at /home/kael/Documents/vuetifyjs/vuetify-next/packages/docs/node_modules/webpack/lib/SourceMapDevToolPlugin.js:272:22
    at /home/kael/Documents/vuetifyjs/vuetify-next/packages/docs/node_modules/webpack/lib/Cache.js:93:5
```