### PR TITLE
feat: support webpack 5 in unit-mocha plugin

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-mocha/generator/index.js
@@ -8,16 +8,8 @@ module.exports = (api, options, rootOptions, invoking) => {
     hasRouter: api.hasPlugin('router')
   })
 
-  const { semver } = require('@vue/cli-shared-utils')
-  const cliServiceVersion = require('@vue/cli-service/package.json').version
-  if (semver.gte(cliServiceVersion, '5.0.0-0')) {
-    // mochapack currently does not support webpack 5 yet
-    require('@vue/cli-plugin-webpack-4/generator')(api, {}, rootOptions, invoking)
-  }
-
   api.extendPackage({
     devDependencies: {
-      '@vue/cli-plugin-webpack-4': require('../package.json').dependencies['@vue/cli-plugin-webpack-4'],
       '@vue/test-utils': isVue3 ? '^2.0.0-0' : '^1.1.3',
       'chai': '^4.2.0'
     },

--- a/packages/@vue/cli-plugin-unit-mocha/package.json
+++ b/packages/@vue/cli-plugin-unit-mocha/package.json
@@ -22,12 +22,11 @@
   },
   "homepage": "https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-plugin-unit-mocha#readme",
   "dependencies": {
-    "@vue/cli-plugin-webpack-4": "^5.0.0-beta.0",
     "@vue/cli-shared-utils": "^5.0.0-beta.0",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^8.3.0",
-    "mochapack": "^2.0.2"
+    "mochapack": "^2.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15706,10 +15706,10 @@ mocha@^8.0.1, mocha@^8.3.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-mochapack@^2.0.2:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/mochapack/-/mochapack-2.0.6.tgz#79bee97a3d300c890816ce6cf374c5fb5053dec0"
-  integrity sha512-6ijz1pJlSnzuy0PXEZKhO2QRrZ1RSI8ZEQ2Rk9jvGAm7dyXXrYcyd8hMmrBXSJSLnZqRuKV0e1SAYQJxYSlfEg==
+mochapack@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mochapack/-/mochapack-2.1.0.tgz#45b9ddda909443cf8fbd9020be5d606e2c5be193"
+  integrity sha512-m/h4qVcsNfLZcCph0OfYaeHcXaRjf3DtswAk09uOj7h7JMlVaDMDCzMxZ6M6uNfeh4LJT9f3wUwgChTyrdLtxA==
   dependencies:
     "@babel/runtime-corejs2" "^7.0.0"
     chalk "^2.4.2"


### PR DESCRIPTION
mochapack 2.1.0 has added webpack 5 support

Closes #6412

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
