### PR TITLE
fix(webpack): slash on publicPath: 'auto'

### DIFF
--- a/packages/@vue/cli-service/lib/util/resolveUserConfig.js
+++ b/packages/@vue/cli-service/lib/util/resolveUserConfig.js
@@ -66,7 +66,9 @@ module.exports = function resolveUserConfig ({
   }
 
   // normalize some options
-  ensureSlash(resolved, 'publicPath')
+  if (resolved.publicPath !== 'auto') {
+    ensureSlash(resolved, 'publicPath')
+  }
   if (typeof resolved.publicPath === 'string') {
     resolved.publicPath = resolved.publicPath.replace(/^\.\//, '')
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Webpack 5 introduced an 'auto' publicPath feature in [webpack/pull/11258](https://github.com/webpack/webpack/pull/11258). The `ensureSlash` will currently add the slash regardless of the actual public path, so the feature would be obsolete.

I encountered the problem while creating a micro-frontend with the webpack 5's module federation. We want the public path to be the one micro frontend is deployed to, which webpack can automatically infer([module-federation/#infer-publicpath-from-script](https://webpack.js.org/concepts/module-federation/#infer-publicpath-from-script), there is a tip at the end of the paragraph).