### PR TITLE
fix(pwa): Replace closeTag parameter with voidTag for HtmlWebpackPlugin

### DIFF
--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -225,10 +225,10 @@ module.exports = class HtmlPwaPlugin {
   }
 }
 
-function makeTag (tagName, attributes, closeTag = false) {
+function makeTag (tagName, attributes, voidTag = true) {
   return {
     tagName,
-    closeTag,
+    voidTag,
     attributes
   }
 }


### PR DESCRIPTION
HtmlWebpackPlugin has a `voidTag` parameter that needs to be set to true
so that both `<link>` and `<meta>` are treated as void elements (with no
contents). The `closeTag` parameter doesn't exist anymore since HtmlWebpackPlugin 4.

https://github.com/jantimon/html-webpack-plugin/blob/570f735c237d4a03a65622cfe64652431aca4132/typings.d.ts#L280
https://html.spec.whatwg.org/multipage/syntax.html#void-elements

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
