### PR TITLE
chore: use scoped package names for aliases

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
@@ -56,7 +56,7 @@ import wrap from '@vue/web-component-wrapper'
 // runtime shared by every component chunk
 import '${resolveImportPath('css-loader/dist/runtime/api.js')}'
 import '${resolveImportPath('vue-style-loader/lib/addStylesShadow')}'
-import '${resolveImportPath('@vue/loader-v15/lib/runtime/componentNormalizer')}'
+import '${resolveImportPath('@vue/vue-loader-v15/lib/runtime/componentNormalizer')}'
 
 ${elements}`.trim()
 

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
@@ -56,7 +56,7 @@ import wrap from '@vue/web-component-wrapper'
 // runtime shared by every component chunk
 import '${resolveImportPath('css-loader/dist/runtime/api.js')}'
 import '${resolveImportPath('vue-style-loader/lib/addStylesShadow')}'
-import '${resolveImportPath('vue-loader-v15/lib/runtime/componentNormalizer')}'
+import '${resolveImportPath('@vue/loader-v15/lib/runtime/componentNormalizer')}'
 
 ${elements}`.trim()
 

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -58,7 +58,7 @@ module.exports = (api, options) => {
     if (vueMajor === 2) {
       // for Vue 2 projects
       const vueLoaderCacheConfig = api.genCacheConfig('vue-loader', {
-        'vue-loader': require('vue-loader-v15/package.json').version,
+        'vue-loader': require('@vue/loader-v15/package.json').version,
         '@vue/component-compiler-utils': require('@vue/component-compiler-utils/package.json').version,
         'vue-template-compiler': require('vue-template-compiler/package.json').version
       })
@@ -80,7 +80,7 @@ module.exports = (api, options) => {
             .options(vueLoaderCacheConfig)
             .end()
           .use('vue-loader')
-            .loader(require.resolve('vue-loader-v15'))
+            .loader(require.resolve('@vue/loader-v15'))
             .options(Object.assign({
               compilerOptions: {
                 whitespace: 'condense'
@@ -89,7 +89,7 @@ module.exports = (api, options) => {
 
       webpackConfig
         .plugin('vue-loader')
-          .use(require('vue-loader-v15').VueLoaderPlugin)
+          .use(require('@vue/loader-v15').VueLoaderPlugin)
 
       // some plugins may implicitly relies on the `vue-loader` dependency path name
       // such as vue-cli-plugin-apollo

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -58,7 +58,7 @@ module.exports = (api, options) => {
     if (vueMajor === 2) {
       // for Vue 2 projects
       const vueLoaderCacheConfig = api.genCacheConfig('vue-loader', {
-        'vue-loader': require('@vue/loader-v15/package.json').version,
+        'vue-loader': require('@vue/vue-loader-v15/package.json').version,
         '@vue/component-compiler-utils': require('@vue/component-compiler-utils/package.json').version,
         'vue-template-compiler': require('vue-template-compiler/package.json').version
       })
@@ -80,7 +80,7 @@ module.exports = (api, options) => {
             .options(vueLoaderCacheConfig)
             .end()
           .use('vue-loader')
-            .loader(require.resolve('@vue/loader-v15'))
+            .loader(require.resolve('@vue/vue-loader-v15'))
             .options(Object.assign({
               compilerOptions: {
                 whitespace: 'condense'
@@ -89,7 +89,7 @@ module.exports = (api, options) => {
 
       webpackConfig
         .plugin('vue-loader')
-          .use(require('@vue/loader-v15').VueLoaderPlugin)
+          .use(require('@vue/vue-loader-v15').VueLoaderPlugin)
 
       // some plugins may implicitly relies on the `vue-loader` dependency path name
       // such as vue-cli-plugin-apollo

--- a/packages/@vue/cli-service/lib/config/vue-loader-v15-resolve-compat/vue-loader.js
+++ b/packages/@vue/cli-service/lib/config/vue-loader-v15-resolve-compat/vue-loader.js
@@ -1,1 +1,1 @@
-module.exports = require('@vue/loader-v15')
+module.exports = require('@vue/vue-loader-v15')

--- a/packages/@vue/cli-service/lib/config/vue-loader-v15-resolve-compat/vue-loader.js
+++ b/packages/@vue/cli-service/lib/config/vue-loader-v15-resolve-compat/vue-loader.js
@@ -1,1 +1,1 @@
-module.exports = require('vue-loader-v15')
+module.exports = require('@vue/loader-v15')

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -72,7 +72,7 @@
     "thread-loader": "^3.0.0",
     "url-loader": "^4.1.1",
     "vue-loader": "^16.1.2",
-    "@vue/loader-v15": "npm:vue-loader@^15.9.7",
+    "@vue/vue-loader-v15": "npm:vue-loader@^15.9.7",
     "vue-style-loader": "^4.1.3",
     "webpack": "^5.22.0",
     "webpack-bundle-analyzer": "^4.4.0",

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -72,7 +72,7 @@
     "thread-loader": "^3.0.0",
     "url-loader": "^4.1.1",
     "vue-loader": "^16.1.2",
-    "vue-loader-v15": "npm:vue-loader@^15.9.6",
+    "@vue/loader-v15": "npm:vue-loader@^15.9.7",
     "vue-style-loader": "^4.1.3",
     "webpack": "^5.22.0",
     "webpack-bundle-analyzer": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,17 +4149,6 @@
   dependencies:
     vue-eslint-parser "^7.0.0"
 
-"@vue/loader-v15@npm:vue-loader@^15.9.7", vue-loader@^15.7.1:
-  version "15.9.7"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.7.tgz#15b05775c3e0c38407679393c2ce6df673b01044"
-  integrity sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==
-  dependencies:
-    "@vue/component-compiler-utils" "^3.1.0"
-    hash-sum "^1.0.2"
-    loader-utils "^1.1.0"
-    vue-hot-reload-api "^2.3.0"
-    vue-style-loader "^4.1.0"
-
 "@vue/shared@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.11.tgz#20d22dd0da7d358bb21c17f9bde8628152642c77"
@@ -4182,6 +4171,17 @@
     focus-visible "^5.2.0"
     v-tooltip "^3.0.0-alpha.20"
     vue-resize "^1.0.0"
+
+"@vue/vue-loader-v15@npm:vue-loader@^15.9.7", vue-loader@^15.7.1:
+  version "15.9.7"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.7.tgz#15b05775c3e0c38407679393c2ce6df673b01044"
+  integrity sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==
+  dependencies:
+    "@vue/component-compiler-utils" "^3.1.0"
+    hash-sum "^1.0.2"
+    loader-utils "^1.1.0"
+    vue-hot-reload-api "^2.3.0"
+    vue-style-loader "^4.1.0"
 
 "@vue/web-component-wrapper@^1.3.0":
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,6 +4149,17 @@
   dependencies:
     vue-eslint-parser "^7.0.0"
 
+"@vue/loader-v15@npm:vue-loader@^15.9.7", vue-loader@^15.7.1:
+  version "15.9.7"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.7.tgz#15b05775c3e0c38407679393c2ce6df673b01044"
+  integrity sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==
+  dependencies:
+    "@vue/component-compiler-utils" "^3.1.0"
+    hash-sum "^1.0.2"
+    loader-utils "^1.1.0"
+    vue-hot-reload-api "^2.3.0"
+    vue-style-loader "^4.1.0"
+
 "@vue/shared@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.11.tgz#20d22dd0da7d358bb21c17f9bde8628152642c77"
@@ -22194,17 +22205,6 @@ vue-jest@^4.0.1:
     chalk "^2.1.0"
     extract-from-css "^0.4.4"
     source-map "0.5.6"
-
-"vue-loader-v15@npm:vue-loader@^15.9.6", vue-loader@^15.7.1:
-  version "15.9.6"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.6.tgz#f4bb9ae20c3a8370af3ecf09b8126d38ffdb6b8b"
-  integrity sha512-j0cqiLzwbeImIC6nVIby2o/ABAWhlppyL/m5oJ67R5MloP0hj/DtFgb0Zmq3J9CG7AJ+AXIvHVnJAPBvrLyuDg==
-  dependencies:
-    "@vue/component-compiler-utils" "^3.1.0"
-    hash-sum "^1.0.2"
-    loader-utils "^1.1.0"
-    vue-hot-reload-api "^2.3.0"
-    vue-style-loader "^4.1.0"
 
 vue-loader@^16.1.2:
   version "16.2.0"


### PR DESCRIPTION
So that users won't refer to random third-party packages when they see
error messages from the aliased package.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
