### PR TITLE
Doc fixes to @vue/babel preset app

### DIFF
--- a/packages/@vue/babel-preset-app/README.md
+++ b/packages/@vue/babel-preset-app/README.md
@@ -72,7 +72,7 @@ Note that the usage detection does not apply to your dependencies (which are exc
 
 2. **If the dependency ships ES5 code and explicitly lists the polyfills needed:** you can pre-include the needed polyfills using the [polyfills](#polyfills) option for this preset.
 
-3. **If the dependency ships ES5 code, but uses ES6+ features without explicitly listing polyfill requirements (e.g. Vuetify):** Use `useBuiltIns: 'entry'` and then add `import '@babel/polyfill'` to your entry file. This will import **ALL** polyfills based on your `browserslist` targets so that you don't need to worry about dependency polyfills anymore, but will likely increase your final bundle size with some unused polyfills.
+3. **If the dependency ships ES5 code, but uses ES6+ features without explicitly listing polyfill requirements (e.g. Vuetify):** Use `useBuiltIns: 'entry'` and then add `import 'core-js/stable';` `import 'regenerator-runtime/runtime';` to your entry file. This will import **ALL** polyfills based on your `browserslist` targets so that you don't need to worry about dependency polyfills anymore, but will likely increase your final bundle size with some unused polyfills.
 
 See [@babel/preset-env docs](https://new.babeljs.io/docs/en/next/babel-preset-env.html#usebuiltins-usage) for more details.
 


### PR DESCRIPTION
Update babel-preset-app README.md with cli.vuejs.org browser-compatibility section

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Updates the babel-preset-app README.md file to match the documentation from [Vue CLI Browser Compatibility](https://cli.vuejs.org/guide/browser-compatibility.html).

In addition, using `import "@babel/polyfill";` is deprecated and building shows the following message:
![image](https://user-images.githubusercontent.com/42522864/123248656-77107300-d4e8-11eb-983c-57a25a8c6c06.png)
Updating the docs should help.

