### PR TITLE
Add text-align center to the template CSS

### DIFF
--- a/packages/@vue/cli-plugin-router/generator/template-vue3/src/App.vue
+++ b/packages/@vue/cli-plugin-router/generator/template-vue3/src/App.vue
@@ -4,7 +4,7 @@ replace:
   - !!js/regexp /<template>[^]*?<\/template>/
   - !!js/regexp /\n<script>[^]*?<\/script>\n/
   - !!js/regexp /  margin-top[^]*?<\/style>/
-  - !!js/regext /text-align: center;/
+  - !!js/regexp /text-align: center;/
 ---
 
 <%# REPLACE %>
@@ -25,6 +25,10 @@ replace:
 
 <%_ if (rootOptions.cssPreprocessor !== 'stylus') { _%>
   <%_ if (!rootOptions.cssPreprocessor) { _%>
+.home {
+  text-align: center;
+}
+
 #nav {
   padding: 30px;
   text-align: center;
@@ -39,6 +43,10 @@ replace:
   color: #42b983;
 }
   <%_ } else { _%>
+.home {
+  text-align: center;
+}
+
 #nav {
   padding: 30px;
   text-align: center;
@@ -54,6 +62,10 @@ replace:
 }
   <%_ } _%>
 <%_ } else { _%>
+
+.home
+  text-align center
+  
 #nav
   padding 30px
   text-align center

--- a/packages/@vue/cli-plugin-router/generator/template-vue3/src/App.vue
+++ b/packages/@vue/cli-plugin-router/generator/template-vue3/src/App.vue
@@ -4,6 +4,7 @@ replace:
   - !!js/regexp /<template>[^]*?<\/template>/
   - !!js/regexp /\n<script>[^]*?<\/script>\n/
   - !!js/regexp /  margin-top[^]*?<\/style>/
+  - !!js/regext /text-align: center;/
 ---
 
 <%# REPLACE %>
@@ -26,6 +27,7 @@ replace:
   <%_ if (!rootOptions.cssPreprocessor) { _%>
 #nav {
   padding: 30px;
+  text-align: center;
 }
 
 #nav a {
@@ -39,6 +41,7 @@ replace:
   <%_ } else { _%>
 #nav {
   padding: 30px;
+  text-align: center;
 
   a {
     font-weight: bold;
@@ -53,6 +56,7 @@ replace:
 <%_ } else { _%>
 #nav
   padding 30px
+  text-align center
   a
     font-weight bold
     color #2c3e50

--- a/packages/@vue/cli-plugin-router/generator/template/src/App.vue
+++ b/packages/@vue/cli-plugin-router/generator/template/src/App.vue
@@ -4,6 +4,7 @@ replace:
   - !!js/regexp /<template>[^]*?<\/template>/
   - !!js/regexp /\n<script>[^]*?<\/script>\n/
   - !!js/regexp /  margin-top[^]*?<\/style>/
+  - !!js/regexp /text-align: center;/
 ---
 
 <%# REPLACE %>
@@ -26,8 +27,13 @@ replace:
 
 <%_ if (rootOptions.cssPreprocessor !== 'stylus') { _%>
   <%_ if (!rootOptions.cssPreprocessor) { _%>
+  
+.home {
+  text-align: center;
+}
 #nav {
   padding: 30px;
+  text-align: center;
 }
 
 #nav a {
@@ -39,8 +45,12 @@ replace:
   color: #42b983;
 }
   <%_ } else { _%>
+.home {
+  text-align: center;
+}
 #nav {
   padding: 30px;
+  text-align: center;
 
   a {
     font-weight: bold;
@@ -53,8 +63,12 @@ replace:
 }
   <%_ } _%>
 <%_ } else { _%>
+.home
+  text-align center
+
 #nav
   padding 30px
+  text-align center
   a
     font-weight bold
     color #2c3e50


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe: Quality improvement: originally a bug, I think.

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Not really a breaking change, just a quality update. After creating a project and adding the router plugin, anything you code after that will have the text-align: center CSS trait. This patch removes the `text-align: center trait` from the #app and shifts it to the #nav section, making following code useful and keeping the current navbar functionality.