### PR TITLE
feat(unit-jest): add jest as a peer dependency

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/generator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/generator/index.js
@@ -12,6 +12,7 @@ module.exports = (api, options, rootOptions, invoking) => {
       'test:unit': 'vue-cli-service test:unit'
     },
     devDependencies: {
+      'jest': '^26.6.3',
       'vue-jest': isVue3 ? '^5.0.0-0' : '^4.0.1',
       '@vue/test-utils': isVue3 ? '^2.0.0-0' : '^1.1.3'
     },

--- a/packages/@vue/cli-plugin-unit-jest/migrator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/migrator/index.js
@@ -1,7 +1,9 @@
 /** @param {import('@vue/cli/lib/MigratorAPI')} api MigratorAPI */
 module.exports = (api) => {
   api.extendPackage(pkg => {
-    const newDevDeps = {}
+    const newDevDeps = {
+      'jest': '^26.6.3'
+    }
 
     const allDeps = {
       ...pkg.dependencies,

--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -41,6 +41,7 @@
   },
   "peerDependencies": {
     "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
+    "jest": "^26.3.3",
     "ts-jest": "^26.5.3",
     "vue-jest": "^4.0.1 || ^5.0.0-0"
   },


### PR DESCRIPTION
Eventually, we need to update to Jest 27 + vue2-jest / vue3-jest
So let's make it a peer dependency to ease the pain of breaking changes.

To not surprise existing beta users, jest 26 is still listed as a direct
dependency in the next release.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
