### PR TITLE
Update installation.md to warn user about using CLI v5 with Vue v3

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -5,6 +5,10 @@ The package name changed from `vue-cli` to `@vue/cli`.
 If you have the previous `vue-cli` (1.x or 2.x) package installed globally, you need to uninstall it first with `npm uninstall vue-cli -g` or `yarn global remove vue-cli`.
 :::
 
+::: warning Warning regarding Next Version
+If you're using Vue 3, you need to use Vue CLI 5 for it to produce Vue 3 compatible demos when building. Use `@vue/cli@next` instead of `@vue/cli`.
+:::
+
 ::: tip Node Version Requirement
 Vue CLI 4.x requires [Node.js](https://nodejs.org/) version 8.9 or above (v10+ recommended). You can manage multiple versions of Node on the same machine with [n](https://github.com/tj/n), [nvm](https://github.com/creationix/nvm) or [nvm-windows](https://github.com/coreybutler/nvm-windows).
 :::


### PR DESCRIPTION
Vue CLI 4.x.x does not create Vue 3 compatible demos.  I had to install Vue CLI 5 (next) to make it work.

Having a notice about this in the documentation would help future users the same mistake I did.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
