### PR TITLE
refactor: remove redundant Webpack version checks

### DIFF
--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -1,5 +1,4 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const { semver } = require('@vue/cli-shared-utils')
 
 const ID = 'vue-cli:pwa-html-plugin'
 
@@ -203,24 +202,12 @@ module.exports = class HtmlPwaPlugin {
         size: () => outputManifest.length
       }
 
-      let webpackMajor = 4
-      if (compiler.webpack) {
-        webpackMajor = semver.major(compiler.webpack.version)
-      }
-
-      if (webpackMajor === 4) {
-        compiler.hooks.emit.tapAsync(ID, (data, cb) => {
-          data.assets[manifestPath] = manifestAsset
-          cb(null, data)
-        })
-      } else {
-        compiler.hooks.compilation.tap(ID, compilation => {
-          compilation.hooks.processAssets.tap(
-            { name: ID, stage: 'PROCESS_ASSETS_STAGE_ADDITIONS' },
-            assets => { assets[manifestPath] = manifestAsset }
-          )
-        })
-      }
+      compiler.hooks.compilation.tap(ID, compilation => {
+        compilation.hooks.processAssets.tap(
+          { name: ID, stage: 'PROCESS_ASSETS_STAGE_ADDITIONS' },
+          assets => { assets[manifestPath] = manifestAsset }
+        )
+      })
     }
   }
 }

--- a/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcConfig.js
@@ -5,7 +5,7 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
   // Disable CSS extraction and turn on CSS shadow mode for vue-style-loader
   process.env.VUE_CLI_CSS_SHADOW_MODE = true
 
-  const { log, error, semver } = require('@vue/cli-shared-utils')
+  const { log, error } = require('@vue/cli-shared-utils')
   const abort = msg => {
     log()
     error(msg)
@@ -14,7 +14,6 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
 
   const cwd = api.getCwd()
   const webpack = require('webpack')
-  const webpackMajor = semver.major(webpack.version)
   const vueMajor = require('../../util/getVueMajor')(cwd)
   if (vueMajor === 3) {
     abort(`Vue 3 support of the web component target is still under development.`)
@@ -131,11 +130,7 @@ module.exports = (api, { target, entry, name, 'inline-vue': inlineVue }) => {
 
     // to ensure that multiple copies of async wc bundles can co-exist
     // on the same page.
-    if (webpackMajor === 4) {
-      rawConfig.output.jsonpFunction = libName.replace(/-\w/g, c => c.charAt(1).toUpperCase()) + '_jsonp'
-    } else {
-      rawConfig.output.uniqueName = `vue-lib-${libName}`
-    }
+    rawConfig.output.uniqueName = `vue-lib-${libName}`
 
     return rawConfig
   }

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -33,15 +33,10 @@ module.exports = (api, options) => {
         .filename(outputFilename)
         .chunkFilename(outputFilename)
 
-    const webpack = require('webpack')
-    const { semver } = require('@vue/cli-shared-utils')
-    const webpackMajor = semver.major(webpack.version)
-    if (webpackMajor !== 4) {
-      // FIXME: a temporary workaround to get accurate contenthash in `applyLegacy`
-      // Should use a better fix per discussions at <https://github.com/jantimon/html-webpack-plugin/issues/1554#issuecomment-753653580>
-      webpackConfig.optimization
-        .set('realContentHash', false)
-    }
+    // FIXME: a temporary workaround to get accurate contenthash in `applyLegacy`
+    // Should use a better fix per discussions at <https://github.com/jantimon/html-webpack-plugin/issues/1554#issuecomment-753653580>
+    webpackConfig.optimization
+      .set('realContentHash', false)
 
     // code splitting
     if (process.env.NODE_ENV !== 'test') {

--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -67,13 +67,7 @@ module.exports = (api, options) => {
       scriptLoading: 'defer',
       templateParameters: (compilation, assets, assetTags, pluginOptions) => {
         // enhance html-webpack-plugin's built in template params
-        let stats
         return Object.assign({
-          // make stats lazy as it is expensive
-          // TODO: not sure if it's still needed as of <https://github.com/jantimon/html-webpack-plugin/issues/780#issuecomment-390651831>
-          get webpack () {
-            return stats || (stats = compilation.getStats().toJson())
-          },
           compilation: compilation,
           webpackConfig: compilation.options,
           htmlWebpackPlugin: {

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -1,11 +1,9 @@
 const path = require('path')
-const { semver } = require('@vue/cli-shared-utils')
 
 /** @type {import('@vue/cli-service').ServicePlugin} */
 module.exports = (api, options) => {
   const cwd = api.getCwd()
   const webpack = require('webpack')
-  const webpackMajor = semver.major(webpack.version)
   const vueMajor = require('../util/getVueMajor')(cwd)
 
   api.chainWebpack(webpackConfig => {
@@ -13,12 +11,10 @@ module.exports = (api, options) => {
     const resolveLocal = require('../util/resolveLocal')
 
     // https://github.com/webpack/webpack/issues/11467#issuecomment-691873586
-    if (webpackMajor !== 4) {
-      webpackConfig.module
-        .rule('esm')
-          .test(/\.m?jsx?$/)
-          .resolve.set('fullySpecified', false)
-    }
+    webpackConfig.module
+      .rule('esm')
+        .test(/\.m?jsx?$/)
+        .resolve.set('fullySpecified', false)
 
     webpackConfig
       .mode('development')


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Since Webpack 4 support was dropped and Webpack 5 became the only supported version, there is no longer a need to check Webpack version for version-specific code. The code to support the older version has been removed.

This PR removes the Webpack version checks and older version-specific code.