### PR TITLE
fix(cli-service): wrong property name (typo)

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveAppConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveAppConfig.js
@@ -27,7 +27,7 @@ module.exports = (api, args, options) => {
         .plugin('modern-mode-legacy')
         .use(ModernModePlugin, [{
           targetDir,
-          isModernBuild: false
+          isModuleBuild: false
         }])
     } else {
       config


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe:

the value of `isModuleBuild` is false here, so you can write anything for the property, but it's better to write it correctly.

```js
config
    .plugin('modern-mode-legacy')
    .use(ModernModePlugin, [{
      targetDir,
      TYPO_PROP: false
    }])

class ModernModePlugin {
  constructor ({ targetDir, isModuleBuild }) {
    this.targetDir = targetDir
    this.isModuleBuild = isModuleBuild
  }
  // ...
}
```
<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
