### PR TITLE
fix: avoid copy-webpack plugin errors in module mode

### DIFF
--- a/packages/@vue/cli-service/lib/config/app.js
+++ b/packages/@vue/cli-service/lib/config/app.js
@@ -240,20 +240,27 @@ module.exports = (api, options) => {
 
     // copy static assets in public/
     const publicDir = api.resolve('public')
-    if (!isLegacyBundle && fs.existsSync(publicDir)) {
-      webpackConfig
-        .plugin('copy')
-          .use(require('copy-webpack-plugin'), [{
-            patterns: [{
-              from: publicDir,
-              to: outputDir,
-              toType: 'dir',
-              noErrorOnMissing: true,
-              globOptions: {
-                ignore: publicCopyIgnore
-              }
-            }]
-          }])
+    const CopyWebpackPlugin = require('copy-webpack-plugin')
+    const PlaceholderPlugin = class PlaceholderPlugin { apply () {} }
+
+    const copyOptions = {
+      patterns: [{
+        from: publicDir,
+        to: outputDir,
+        toType: 'dir',
+        noErrorOnMissing: true,
+        globOptions: {
+          ignore: publicCopyIgnore
+        }
+      }]
+    }
+
+    if (fs.existsSync(publicDir)) {
+      if (isLegacyBundle) {
+        webpackConfig.plugin('copy').use(PlaceholderPlugin, [copyOptions])
+      } else {
+        webpackConfig.plugin('copy').use(CopyWebpackPlugin, [copyOptions])
+      }
     }
   })
 }


### PR DESCRIPTION
By adding a placeholder plugin with the same name and options as
copy-webpack-plugin.

Fixes #6648
Addresses the concern raised by @tomica at https://github.com/vuejs/vue-cli/commit/cd783766755fcb6b7e8c558984c58e2b8b305c09#commitcomment-52141775

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
