### PR TITLE
fix(cli): do not remove empty file when use vue add command

### DIFF
--- a/packages/@vue/cli/lib/util/writeFileTree.js
+++ b/packages/@vue/cli/lib/util/writeFileTree.js
@@ -4,7 +4,7 @@ const path = require('path')
 function deleteRemovedFiles (directory, newFiles, previousFiles) {
   // get all files that are not in the new filesystem and are still existing
   const filesToDelete = Object.keys(previousFiles)
-    .filter(filename => !newFiles[filename])
+    .filter(filename => !newFiles[filename] && newFiles[filename] !== '')
 
   // delete each of these files
   return Promise.all(filesToDelete.map(filename => {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Once use vue-add command in other project, it will delete all empty file in the project.