### PR TITLE
refactor(webdriverio)!: don't include sync API support by default

### DIFF
--- a/packages/@vue/cli-plugin-e2e-webdriverio/generator/template/tests/e2e/pageobjects/app.page.js
+++ b/packages/@vue/cli-plugin-e2e-webdriverio/generator/template/tests/e2e/pageobjects/app.page.js
@@ -7,8 +7,8 @@ class App {
   /**
    * methods
    */
-  open (path = '/') {
-    browser.url(path)
+  async open (path = '/') {
+    await browser.url(path)
   }
 }
 

--- a/packages/@vue/cli-plugin-e2e-webdriverio/generator/template/tests/e2e/specs/app.spec.js
+++ b/packages/@vue/cli-plugin-e2e-webdriverio/generator/template/tests/e2e/specs/app.spec.js
@@ -1,8 +1,8 @@
 <%- hasTS ? 'import App from \'../pageobjects/app.page\'' : 'const App = require(\'../pageobjects/app.page\')' %>
 
 describe('Vue.js app', () => {
-  it('should open and render', () => {
-    App.open()
-    expect(App.heading).toHaveText('Welcome to Your Vue.js <%- hasTS ? '+ TypeScript ' : '' %>App')
+  it('should open and render', async () => {
+    await App.open()
+    await expect(App.heading).toHaveText('Welcome to Your Vue.js <%- hasTS ? '+ TypeScript ' : '' %>App')
   })
 })

--- a/packages/@vue/cli-plugin-e2e-webdriverio/index.js
+++ b/packages/@vue/cli-plugin-e2e-webdriverio/index.js
@@ -49,8 +49,8 @@ module.exports = (api, options) => {
       info(`Start WebdriverIO: $ wdio ${runArgs.join(' ')}`)
       const runner = execa(wdioBinPath, runArgs, { stdio: 'inherit' })
       if (server) {
-        runner.on('exit', () => server.close())
-        runner.on('error', () => server.close())
+        runner.on('exit', () => server.stop())
+        runner.on('error', () => server.stop())
       }
 
       if (process.env.VUE_CLI_TEST) {

--- a/packages/@vue/cli-plugin-e2e-webdriverio/migrator/index.js
+++ b/packages/@vue/cli-plugin-e2e-webdriverio/migrator/index.js
@@ -17,4 +17,12 @@ module.exports = (api) => {
       }
     })
   }
+
+  if (api.fromVersion('<= 5.0.0-beta.4')) {
+    api.extendPackage({
+      devDependencies: {
+        '@wdio/sync': '^7.0.7'
+      }
+    })
+  }
 }

--- a/packages/@vue/cli-plugin-e2e-webdriverio/package.json
+++ b/packages/@vue/cli-plugin-e2e-webdriverio/package.json
@@ -32,7 +32,6 @@
     "@wdio/mocha-framework": "^7.0.7",
     "@wdio/sauce-service": "^7.0.7",
     "@wdio/spec-reporter": "^7.0.7",
-    "@wdio/sync": "^7.0.7",
     "eslint-plugin-wdio": "^7.0.0",
     "webdriverio": "^7.0.7"
   },


### PR DESCRIPTION
[WebDriverIO's sync API has been deprecated](https://webdriver.io/blog/2021/07/28/sync-api-deprecation/) and doesn't work in Node.js v16.

If users still need it, they can install the dependency by themselves.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
