### PR TITLE
docs: update vue create --help output in "Basics/Creating a Project"

### DIFF
--- a/docs/guide/creating-a-project.md
+++ b/docs/guide/creating-a-project.md
@@ -53,9 +53,11 @@ Options:
   -g, --git [message|false]       Force / skip git initialization, optionally specify initial commit message
   -n, --no-git                    Skip git initialization
   -f, --force                     Overwrite target directory if it exists
+  --merge                         Merge target directory if it exists
   -c, --clone                     Use git clone when fetching remote preset
   -x, --proxy                     Use specified proxy when creating project
   -b, --bare                      Scaffold project without beginner instructions
+  --skipGetStarted                Skip displaying "Get started" instructions
   -h, --help                      Output usage information
 ```
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
The command output section was not up to date with the current `vue create --help` output missing `--merge` and `--skipGetStarted`.

Unfortunately, I can't provide zh and ru translations 🥲
If someone could provide the translations I could add them too