### PR TITLE
fix: set css-minimizer-webpack-plugin to v3.0.2

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -47,7 +47,7 @@
     "cliui": "^7.0.4",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^5.1.1",
-    "css-minimizer-webpack-plugin": "^3.0.2",
+    "css-minimizer-webpack-plugin": "~3.0.2",
     "cssnano": "^5.0.0",
     "debug": "^4.1.1",
     "default-gateway": "^6.0.3",


### PR DESCRIPTION

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Previously we allowed installing v3.1.0, but it turns out this breaks new applications created with CLI beta.4.
This commit sets the version to v3.0.2 to unblock new applications.

Fixes #6723
