### PR TITLE
fix: webpack-dev-server doesn't exit on Ctrl+C

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -261,7 +261,7 @@ module.exports = (api, options) => {
 
     // fix: webpack-dev-server doesn't exit on Ctrl+C
     ;['SIGINT', 'SIGTERM'].forEach(signal => {
-      process.on(signal, () => exitProcess)
+      process.on(signal, exitProcess)
     })
 
     if (args.stdin) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

### Other information

#### 1.background
We need to execute `ctrl +c` twice to stop the `yarn serve`

**This is unbearable for developers**

![image](https://user-images.githubusercontent.com/22092110/136928191-c590f5bc-1ce5-4a79-84e9-474340178116.png)


#### 2.reproduction repo
[vue-cli-5-mini-repo](https://github.com/screetBloom/vue-cli-5-mini-repo)

<br>

#### 3.webpack-dev-server issue
- https://github.com/webpack/webpack-dev-server/issues/2168
- https://github.com/webpack/webpack-dev-server/issues/1479
- and so on

<br>

#### 4.solutions
Usually Ctrl-C is interpreted as a `SIGINT` signal, And the termination of a process is interpreted as a `SIGTERM` signal

So we need to **exit the child process when these two signals are thrown**

![image](https://user-images.githubusercontent.com/22092110/136931025-7efe58e4-a447-4bc6-8448-cc1adc82f99e.png)



<br>
<br>
<br>



