### PR TITLE
feat: use eslint v8

### DIFF
--- a/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
+++ b/packages/@vue/cli-plugin-eslint/__tests__/eslintPlugin.spec.js
@@ -300,3 +300,88 @@ foo=42
   const resultForMain = resultsContents.find(({ filePath }) => filePath.endsWith(path.join('src', 'main.js')))
   expect(resultForMain.messages.length).toBe(0)
 })
+
+test('should work with prettier config', async () => {
+  const project = await create('eslint-prettier-config', {
+    plugins: {
+      '@vue/cli-plugin-eslint': {
+        config: 'prettier',
+        lintOn: 'save'
+      }
+    }
+  })
+
+  let done
+  const donePromise = new Promise(resolve => {
+    done = resolve
+  })
+  const { run } = project
+  const server = run('vue-cli-service serve')
+
+  server.stdout.on('data', data => {
+    data = data.toString()
+    if (data.match(/Compiled successfully/)) {
+      server.stdin.write('close')
+      done()
+    }
+  })
+
+  await donePromise
+})
+
+test('should work with standard config', async () => {
+  const project = await create('eslint-standard-config', {
+    plugins: {
+      '@vue/cli-plugin-eslint': {
+        config: 'standard',
+        lintOn: 'save'
+      }
+    }
+  })
+
+  let done
+  const donePromise = new Promise(resolve => {
+    done = resolve
+  })
+  const { run } = project
+  const server = run('vue-cli-service serve')
+
+  server.stdout.on('data', data => {
+    data = data.toString()
+    if (data.match(/Compiled successfully/)) {
+      server.stdin.write('close')
+      done()
+    }
+  })
+
+  await donePromise
+})
+
+test('should work with typescript config', async () => {
+  const project = await create('eslint-typescript-config', {
+    plugins: {
+      '@vue/cli-plugin-typescript': {},
+      '@vue/cli-plugin-eslint': {
+        config: 'typescript',
+        lintOn: 'save'
+      }
+    }
+  })
+
+  let done
+  const donePromise = new Promise(resolve => {
+    done = resolve
+  })
+  const { run } = project
+  const server = run('vue-cli-service serve')
+
+  server.stdout.on('data', data => {
+    data = data.toString()
+    if (data.match(/Compiled successfully/)) {
+      server.stdin.write('close')
+      done()
+    }
+  })
+
+  await donePromise
+})

--- a/packages/@vue/cli-plugin-eslint/eslintDeps.js
+++ b/packages/@vue/cli-plugin-eslint/eslintDeps.js
@@ -16,8 +16,9 @@ const DEPS_MAP = {
   standard: {
     '@vue/eslint-config-standard': '^6.1.0',
     'eslint-plugin-import': '^2.25.3',
+    // https://github.com/mysticatea/eslint-plugin-node/issues/294 to track eslint v8 support
     'eslint-plugin-node': '^11.1.0',
-    'eslint-plugin-promise': '^5.1.0'
+    'eslint-plugin-promise': '^6.0.0'
   },
   typescript: {
     '@vue/eslint-config-typescript': '^9.1.0',
@@ -37,8 +38,8 @@ exports.getDeps = function (api, preset, rootOptions = {}) {
 
   if (api.hasPlugin('babel') && !api.hasPlugin('typescript')) {
     Object.assign(deps, {
-      '@babel/eslint-parser': '^7.12.16',
-      '@babel/core': '^7.12.16'
+      '@babel/eslint-parser': '^7.16.0',
+      '@babel/core': '^7.16.0'
     })
   }
 


### PR DESCRIPTION
Updates the dependencies installed by `@vue/cli-plugin-eslint` to use eslint v8.
Plugins are alo updated (when possible) to support eslint v8. Some are not yet updated, and a comment with relevant issue has been added in that case.
Tests have been added to check each configuration, and they all succeed, despite some plugins not yet updated.

Fixes #6740

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
