### PR TITLE
Add a top-level `terser` option to allow users to customize the minifier

### DIFF
--- a/packages/@vue/cli-service/lib/config/terserOptions.js
+++ b/packages/@vue/cli-service/lib/config/terserOptions.js
@@ -96,10 +96,10 @@ const uglifyJsMinify = (options) => ({
 
 // Currently we do not allow custom minify function
 const getMinify = (options) => {
-  const { minify = 'default' } = options.terser || {}
+  const { minify = 'terser' } = options.terser || {}
 
   const minifyMap = {
-    default: terserMinify,
+    terser: terserMinify,
     esbuild: esbuildMinify,
     swc: swcMinify,
     uglifyJs: uglifyJsMinify

--- a/packages/@vue/cli-service/lib/options.js
+++ b/packages/@vue/cli-service/lib/options.js
@@ -61,7 +61,7 @@ const schema = createSchema(joi => joi.object({
 
   // terser
   terser: joi.object({
-    minify: joi.string().valid('default', 'esbuild', 'swc', 'uglifyJs'),
+    minify: joi.string().valid('terser', 'esbuild', 'swc', 'uglifyJs'),
     terserOptions: joi.object()
   }),
 

--- a/packages/@vue/cli-service/types/ProjectOptions.d.ts
+++ b/packages/@vue/cli-service/types/ProjectOptions.d.ts
@@ -160,12 +160,12 @@ interface ProjectOptions {
    */
   terser?: {
     /**
-     * Supported minify: [default(terser)](https://github.com/webpack-contrib/terser-webpack-plugin#minify), [esbuild](https://github.com/webpack-contrib/terser-webpack-plugin#esbuild), [swc](https://github.com/webpack-contrib/terser-webpack-plugin#swc), [uglifyJs](https://github.com/webpack-contrib/terser-webpack-plugin#uglify-js). currently we do not allow custom minify function
+     * Supported minify: [terser](https://github.com/webpack-contrib/terser-webpack-plugin#minify), [esbuild](https://github.com/webpack-contrib/terser-webpack-plugin#esbuild), [swc](https://github.com/webpack-contrib/terser-webpack-plugin#swc), [uglifyJs](https://github.com/webpack-contrib/terser-webpack-plugin#uglify-js). currently we do not allow custom minify function
      *
-     * In the non-default case, you should install the corresponding package (eg. `npm i esbuild -D`)
+     * In the non-terser case, you should install the corresponding package (eg. `npm i esbuild -D`)
      *
      */
-    minify: 'default' | 'esbuild' | 'swc' | 'uglifyJs';
+    minify: 'terser' | 'esbuild' | 'swc' | 'uglifyJs';
     /**
      * `terserOptions` options will be passed to minify
      *


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

### Other information

#### background

- Form [`terser-webpack-plugin@5.2`](https://github.com/webpack-contrib/terser-webpack-plugin/blob/master/CHANGELOG.md#520-2021-08-31) we can custom minify
- So Vue CLI 5 can support user to custom terser-webpack-plugin minify as `esbuild`, `swc` or `uglifyJs` 👇


<img src="https://user-images.githubusercontent.com/22092110/137356692-968e3cee-7d28-4b72-8b1a-10db0cbf58de.png" height="350px">


<img src="https://user-images.githubusercontent.com/22092110/137362454-254c16e6-a9d9-41c8-b8ce-f01cd5a7787c.png" height="320px">



<br>

#### Some data
``` shell
// delete .cache before each build
yarn build --no-module
```

##### Vue CLI 5 demo

- Generally, projects with more files will be more effective
- I just tested the speed briefly,  we have used it in the company’s project, and the build time can be reduced by about **20%**

> no cache,  minify with default options


<img src="https://user-images.githubusercontent.com/22092110/137263243-cd5edd35-57e6-4b10-8377-3f914381278d.png" height="200px">


<img src="https://user-images.githubusercontent.com/22092110/137264323-1df90de2-9ed9-47d2-a88f-633efd9ef9fb.png" height="300px">




<br>
<br>
<br>

