### PR TITLE
Add `getters:{}` to cli-plugin-vuex template

### DIFF
--- a/packages/@vue/cli-plugin-vuex/generator/template-vue3/src/store/index.js
+++ b/packages/@vue/cli-plugin-vuex/generator/template-vue3/src/store/index.js
@@ -3,6 +3,8 @@ import { createStore } from 'vuex'
 export default createStore({
   state: {
   },
+  getters: {
+  },
   mutations: {
   },
   actions: {

--- a/packages/@vue/cli-plugin-vuex/generator/template/src/store/index.js
+++ b/packages/@vue/cli-plugin-vuex/generator/template/src/store/index.js
@@ -6,6 +6,8 @@ Vue.use(Vuex)
 export default new Vuex.Store({
   state: {
   },
+  getters: {
+  },
   mutations: {
   },
   actions: {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [x] Other, please describe: modified cli-plugin-vuex template

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
null

