### PR TITLE
Added maskIconColor option to html-pwa-plugin

### DIFF
--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -73,6 +73,7 @@ module.exports = class HtmlPwaPlugin {
           name,
           themeColor,
           msTileColor,
+          maskIconColor,
           appleMobileWebAppCapable,
           appleMobileWebAppStatusBarStyle,
           assetsVersion,
@@ -158,7 +159,7 @@ module.exports = class HtmlPwaPlugin {
           data.headTags.push(makeTag('link', {
             rel: 'mask-icon',
             href: getTagHref(publicPath, iconPaths.maskIcon, assetsVersionStr),
-            color: themeColor
+            color: maskIconColor || themeColor
           }))
         }
 


### PR DESCRIPTION
`maskIconColor` allows set color for mask-icon. `themeColor` will be used if `maskIconColor` is not defined.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Replaced by #6768