### PR TITLE
Added maskIconColor option to html-pwa-pluginq

### DIFF
--- a/docs/core-plugins/pwa.md
+++ b/docs/core-plugins/pwa.md
@@ -49,6 +49,12 @@ file, or the `"vue"` field in `package.json`.
 
   - Default: `'#000000'`
 
+- **pwa.maskIconColor**
+
+  - Default: `undefined`
+
+    For compatibility uses `pwa.themeColor` if value not passed.
+
 - **pwa.appleMobileWebAppCapable**
 
   - Default: `'no'`

--- a/docs/ru/core-plugins/pwa.md
+++ b/docs/ru/core-plugins/pwa.md
@@ -47,6 +47,12 @@
 
   - По умолчанию: `'#000000'`
 
+- **pwa.maskIconColor**
+
+  - По умолчанию: `undefined`
+
+    Для совместимости использует `pwa.themeColor` если не было передано значение.
+
 - **pwa.appleMobileWebAppCapable**
 
   - По умолчанию: `'no'`

--- a/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
+++ b/packages/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js
@@ -6,6 +6,7 @@ const defaults = {
   name: 'PWA app',
   themeColor: '#4DBA87', // The Vue color
   msTileColor: '#000000',
+  maskIconColor: undefined,
   appleMobileWebAppCapable: 'no',
   appleMobileWebAppStatusBarStyle: 'default',
   assetsVersion: '',
@@ -73,6 +74,7 @@ module.exports = class HtmlPwaPlugin {
           name,
           themeColor,
           msTileColor,
+          maskIconColor,
           appleMobileWebAppCapable,
           appleMobileWebAppStatusBarStyle,
           assetsVersion,
@@ -158,7 +160,7 @@ module.exports = class HtmlPwaPlugin {
           data.headTags.push(makeTag('link', {
             rel: 'mask-icon',
             href: getTagHref(publicPath, iconPaths.maskIcon, assetsVersionStr),
-            color: themeColor
+            color: maskIconColor || themeColor
           }))
         }
 


### PR DESCRIPTION
`maskIconColor` allows set color for mask-icon. `themeColor` will be used if `maskIconColor` is not defined.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Fixes #6765