### PR TITLE
fix(migrator): fix invalid semver

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/migrator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/migrator/index.js
@@ -13,7 +13,7 @@ module.exports = (api) => {
 
     if (!allDeps['vue-jest']) {
       // Likely a Vue 2 project, and uses the builtin preset.
-      newDevDeps['@vue/vue3-jest'] = '^27.0.0.alpha.1'
+      newDevDeps['@vue/vue3-jest'] = '^27.0.0-alpha.1'
     }
 
     if (allDeps['@vue/cli-plugin-typescript'] && !allDeps['ts-jest']) {


### PR DESCRIPTION
small fix for invalid semver, as indicated when running migrator:

🚀  Running migrator of @vue/cli-plugin-unit-jest
 WARN  invalid version range for dependency "@vue/vue3-jest":

- ^27.0.0.alpha.1 injected by generator "@vue/cli-plugin-unit-jest"
📦  Installing additional dependencies...

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
