### PR TITLE
fix(migrator): be aware of the project's vue version

### DIFF
--- a/packages/@vue/cli-plugin-unit-jest/migrator/index.js
+++ b/packages/@vue/cli-plugin-unit-jest/migrator/index.js
@@ -1,6 +1,5 @@
 /** @param {import('@vue/cli/lib/MigratorAPI')} api MigratorAPI */
 module.exports = (api, options, rootOptions) => {
-
   const isVue3 = rootOptions && rootOptions.vueVersion === '3'
 
   api.extendPackage(pkg => {


### PR DESCRIPTION
Make migrator smarter, or at least vue2-vue3 aware before adding the right @vue/vue-jest package

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
