### PR TITLE
feat!: remove `@vue/compiler-sfc` from peer dependencies

### DIFF
--- a/packages/@vue/babel-preset-app/package.json
+++ b/packages/@vue/babel-preset-app/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@babel/core": "*",
     "core-js": "^3",
-    "vue": "^2 || ^3.0.0-0"
+    "vue": "^2 || ^3.2.13"
   },
   "peerDependenciesMeta": {
     "core-js": {

--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -85,7 +85,7 @@ module.exports = (api, projectOptions) => {
             extensions: {
               vue: {
                 enabled: true,
-                compiler: isVue3 ? require.resolve('@vue/compiler-sfc') : require.resolve('vue-template-compiler')
+                compiler: isVue3 ? require.resolve('vue/compiler-sfc') : require.resolve('vue-template-compiler')
               }
             },
             diagnosticOptions: {

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -37,14 +37,11 @@
   },
   "peerDependencies": {
     "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
-    "@vue/compiler-sfc": "^3.0.0-beta.14",
     "typescript": ">=2",
-    "vue-template-compiler": "^2.0.0"
+    "vue-template-compiler": "^2.0.0",
+    "vue": "^2 || ^3.2.13"
   },
   "peerDependenciesMeta": {
-    "@vue/compiler-sfc": {
-      "optional": true
-    },
     "vue-template-compiler": {
       "optional": true
     }

--- a/packages/@vue/cli-service/__tests__/generator.spec.js
+++ b/packages/@vue/cli-service/__tests__/generator.spec.js
@@ -34,7 +34,6 @@ test('Vue 3', async () => {
   })
 
   expect(pkg.dependencies.vue).toMatch('^3')
-  expect(pkg).toHaveProperty(['devDependencies', '@vue/compiler-sfc'])
 
   expect(files['src/main.js']).toMatch(`import { createApp } from 'vue'`)
 

--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -7,10 +7,7 @@ module.exports = (api, options) => {
   if (options.vueVersion === '3') {
     api.extendPackage({
       dependencies: {
-        'vue': '^3.2.6'
-      },
-      devDependencies: {
-        '@vue/compiler-sfc': '^3.2.6'
+        'vue': '^3.2.13'
       }
     })
   } else {

--- a/packages/@vue/cli-service/lib/config/base.js
+++ b/packages/@vue/cli-service/lib/config/base.js
@@ -101,8 +101,7 @@ module.exports = (api, options) => {
     } else if (vueMajor === 3) {
       // for Vue 3 projects
       const vueLoaderCacheConfig = api.genCacheConfig('vue-loader', {
-        'vue-loader': require('vue-loader/package.json').version,
-        '@vue/compiler-sfc': require('@vue/compiler-sfc/package.json').version
+        'vue-loader': require('vue-loader/package.json').version
       })
 
       webpackConfig.resolve

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -82,14 +82,10 @@
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
-    "@vue/compiler-sfc": "^3.0.0-beta.14",
     "vue-template-compiler": "^2.0.0",
     "webpack-sources": "*"
   },
   "peerDependenciesMeta": {
-    "@vue/compiler-sfc": {
-      "optional": true
-    },
     "less-loader": {
       "optional": true
     },


### PR DESCRIPTION
Starting from vue 3.2.13, it's bundled into the main vue package,
accessible via `vue/compiler-sfc`

This commit is incompatible with Vue >= 3.0.0-alpha.0 < 3.2.13

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Other information:**
