### PR TITLE
fix: [ext] in asset modules already contains a leading dot

### DIFF
--- a/packages/@vue/cli-service/lib/config/assets.js
+++ b/packages/@vue/cli-service/lib/config/assets.js
@@ -5,7 +5,7 @@ module.exports = (api, options) => {
   const genAssetSubPath = dir => {
     return getAssetPath(
       options,
-      `${dir}/[name]${options.filenameHashing ? '.[hash:8]' : ''}.[ext]`
+      `${dir}/[name]${options.filenameHashing ? '.[hash:8]' : ''}[ext]`
     )
   }
 


### PR DESCRIPTION
Fixes #6825

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
