### PR TITLE
fix: require webpack 5.54+

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "verdaccio": "^5.0.1",
     "vite-plugin-pwa": "^0.11.3",
     "vitepress": "^0.20.1",
-    "webpack": "^5.22.0",
+    "webpack": "^5.54.0",
     "yorkie": "^2.0.0"
   },
   "resolutions": {

--- a/packages/@vue/cli-plugin-babel/package.json
+++ b/packages/@vue/cli-plugin-babel/package.json
@@ -25,7 +25,7 @@
     "@vue/cli-shared-utils": "^5.0.0-rc.0",
     "babel-loader": "^8.2.2",
     "thread-loader": "^3.0.0",
-    "webpack": "^5.22.0"
+    "webpack": "^5.54.0"
   },
   "peerDependencies": {
     "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0"

--- a/packages/@vue/cli-plugin-eslint/package.json
+++ b/packages/@vue/cli-plugin-eslint/package.json
@@ -26,7 +26,7 @@
     "@vue/cli-shared-utils": "^5.0.0-rc.0",
     "eslint-webpack-plugin": "^3.1.0",
     "globby": "^11.0.2",
-    "webpack": "^5.22.0",
+    "webpack": "^5.54.0",
     "yorkie": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/@vue/cli-plugin-pwa/package.json
+++ b/packages/@vue/cli-plugin-pwa/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@vue/cli-shared-utils": "^5.0.0-rc.0",
     "html-webpack-plugin": "^5.1.0",
-    "webpack": "^5.22.0",
+    "webpack": "^5.54.0",
     "workbox-webpack-plugin": "^6.1.0"
   },
   "devDependencies": {

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -32,7 +32,7 @@
     "globby": "^11.0.2",
     "thread-loader": "^3.0.0",
     "ts-loader": "^9.2.5",
-    "webpack": "^5.22.0",
+    "webpack": "^5.54.0",
     "yorkie": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -73,7 +73,7 @@
     "thread-loader": "^3.0.0",
     "vue-loader": "^16.8.2",
     "vue-style-loader": "^4.1.3",
-    "webpack": "^5.22.0",
+    "webpack": "^5.54.0",
     "webpack-bundle-analyzer": "^4.4.0",
     "webpack-chain": "^6.5.1",
     "webpack-dev-server": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20379,10 +20379,10 @@ webpack-virtual-modules@^0.4.2:
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.3.tgz#cd597c6d51d5a5ecb473eea1983a58fa8a17ded9"
   integrity sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==
 
-webpack@*, webpack@^5.22.0, webpack@^5.38.1:
-  version "5.58.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.58.1.tgz#df8aad72b617a9d0db8c89d4f410784ee93320d7"
-  integrity sha512-4Z/dmbTU+VmkCb2XNgW7wkE5TfEcSooclprn/UEuVeAkwHhn07OcgUsyaKHGtCY/VobjnsYBlyhKeMLiSoOqPg==
+webpack@*, webpack@^5.38.1, webpack@^5.54.0:
+  version "5.63.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.63.0.tgz#4b074115800e0526d85112985e46c64b95e04aaf"
+  integrity sha512-HYrw6bkj/MDmphAXvqLEvn2fVoDZsYu6O638WjK6lSNgIpjb5jl/KtOrqJyU9EC/ZV9mLUmZW5h4mASB+CVA4A==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"


### PR DESCRIPTION
Because `xxhash64` is only supported in 5.54+

Fixes issues like https://github.com/vuejs/vue-cli/issues/6806#issuecomment-963375201

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
