### PR TITLE
docs(next): fix algolia search

### DIFF
--- a/docs/.vitepress/theme/AlgoliaSearchBox.vue
+++ b/docs/.vitepress/theme/AlgoliaSearchBox.vue
@@ -1,0 +1,325 @@
+<script setup lang="ts">
+import 'docsearch.js/dist/cdn/docsearch.min.css'
+import docsearch from 'docsearch.js/dist/cdn/docsearch.min.js'
+import { useRoute, useRouter, useData } from 'vitepress'
+import { getCurrentInstance, onMounted, watch } from 'vue'
+const props = defineProps<{
+  options: any
+}>()
+
+const vm = getCurrentInstance()
+const route = useRoute()
+const router = useRouter()
+watch(
+  () => props.options,
+  (value) => {
+    update(value)
+  }
+)
+onMounted(() => {
+  initialize(props.options)
+})
+function isSpecialClick(event: MouseEvent) {
+  return (
+    event.button === 1 ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey
+  )
+}
+function getRelativePath(absoluteUrl: string) {
+  const { pathname, hash } = new URL(absoluteUrl)
+  return pathname + hash
+}
+function update(options: any) {
+  if (vm && vm.vnode.el) {
+    vm.vnode.el.innerHTML =
+      '<input id="algolia-search-input" class="search-query">'
+    initialize(options)
+  }
+}
+const { lang, site } = useData()
+// the search results should be filtered based on the language
+const facetFilters: string[] = ['language:' + lang.value]
+if (props.options.searchParameters?.facetFilters) {
+  facetFilters.push(...props.options.searchParameters.facetFilters)
+}
+watch(
+  lang,
+  (newLang, oldLang) => {
+    const index = facetFilters.findIndex(
+      (filter) => filter === 'language:' + oldLang
+    )
+    if (index > -1) {
+      facetFilters.splice(index, 1, 'language:' + newLang)
+    }
+  }
+)
+function initialize(userOptions: any) {
+  const { algoliaOptions = {}} = userOptions
+  docsearch(Object.assign(
+    {},
+    userOptions,
+    {
+      inputSelector: '#algolia-search-input',
+      // #697 Make docsearch work well at i18n mode.
+      algoliaOptions: {
+        ...algoliaOptions,
+        facetFilters: [`lang:${lang.value}`].concat(algoliaOptions.facetFilters || [])
+      },
+      handleSelected: (input, event, suggestion) => {
+        const { pathname, hash } = new URL(suggestion.url)
+
+        // Router doesn't handle same-page navigation so we use the native
+        // browser location API for anchor navigation
+        if (route.path === pathname) {
+          window.location.assign(suggestion.url)
+        } else {
+          const routepath = pathname.replace(site.base, '/')
+          const _hash = decodeURIComponent(hash)
+          router.go(`${routepath}${_hash}`)
+        }
+      }
+    })
+  )
+}
+</script>
+
+<template>
+  <form
+    id="search-form"
+    class="algolia-search-wrapper search-box"
+    role="search"
+  >
+    <input id="algolia-search-input" class="search-query">
+  </form>
+</template>
+
+<style>
+.search-box {
+  flex: 0 0 auto;
+  vertical-align: top;
+}
+.algolia-search-wrapper {
+  --border-color: #eaecef;
+  --text-color: #2c3e50;
+  --accent-color: #3eaf7c;
+}
+
+.algolia-search-wrapper > span {
+  vertical-align: middle;
+}
+.algolia-search-wrapper .algolia-autocomplete {
+  line-height: normal;
+}
+.algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu {
+  background-color: #fff;
+  border: 1px solid #999;
+  border-radius: 4px;
+  font-size: 16px;
+  margin: 6px 0 0;
+  padding: 4px;
+  text-align: left;
+}
+.algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu:before {
+  border-color: #999;
+}
+.algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu [class*=ds-dataset-] {
+  border: none;
+  padding: 0;
+}
+.algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu .ds-suggestions {
+  margin-top: 0;
+}
+.algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu .ds-suggestion {
+  border-bottom: 1px solid var(--border-color);
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: #2c815b;
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion {
+  border-color: var(--border-color);
+  padding: 0;
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--category-header {
+  padding: 5px 10px;
+  margin-top: 0;
+  background: var(--accent-color);
+  color: #fff;
+  font-weight: 600;
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight {
+  background: rgba(255,255,255,0.6);
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--wrapper {
+  padding: 0;
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--title {
+  font-weight: 600;
+  margin-bottom: 0;
+  color: var(--text-color);
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column {
+  vertical-align: top;
+  padding: 5px 7px 5px 5px;
+  border-color: var(--border-color);
+  background: #f1f3f5;
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column:after {
+  display: none;
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column-text {
+  color: #555;
+}
+.algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-footer {
+  border-color: var(--border-color);
+}
+.algolia-search-wrapper .algolia-autocomplete .ds-cursor .algolia-docsearch-suggestion--content {
+  background-color: #e7edf3 !important;
+  color: var(--text-color);
+}
+@media (min-width: 719px) {
+  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column {
+    float: none;
+    width: 150px;
+    min-width: 150px;
+    display: table-cell;
+  }
+  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content {
+    float: none;
+    display: table-cell;
+    width: 100%;
+    vertical-align: top;
+  }
+  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .ds-dropdown-menu {
+    min-width: 515px !important;
+  }
+}
+@media (max-width: 719px) {
+  .algolia-search-wrapper .ds-dropdown-menu {
+    min-width: calc(100vw - 4rem) !important;
+    max-width: calc(100vw - 4rem) !important;
+  }
+  .algolia-search-wrapper .algolia-docsearch-suggestion--wrapper {
+    padding: 5px 7px 5px 5px !important;
+  }
+  .algolia-search-wrapper .algolia-docsearch-suggestion--subcategory-column {
+    padding: 0 !important;
+    background: #fff !important;
+  }
+  .algolia-search-wrapper .algolia-docsearch-suggestion--subcategory-column-text:after {
+    content: " > ";
+    font-size: 10px;
+    line-height: 14.4px;
+    display: inline-block;
+    width: 5px;
+    margin: -3px 3px 0;
+    vertical-align: middle;
+  }
+}
+
+.search-box {
+  display: inline-block;
+  position: relative;
+  margin-left: 1rem;
+}
+.search-box input {
+  cursor: text;
+  width: 10rem;
+  height: 2rem;
+  color: #4e6e8e;
+  display: inline-block;
+  border: 1px solid #cfd4db;
+  border-radius: 2rem;
+  font-size: 0.9rem;
+  line-height: 2rem;
+  padding: 0 0.5rem 0 2rem;
+  outline: none;
+  transition: all 0.2s ease;
+  background: #fff url("./search.svg") 0.6rem 0.5rem no-repeat;
+  background-size: 1rem;
+}
+.search-box input:focus {
+  cursor: auto;
+  border-color: #3eaf7c;
+}
+.search-box .suggestions {
+  background: #fff;
+  width: 20rem;
+  position: absolute;
+  top: 2rem;
+  border: 1px solid #cfd4db;
+  border-radius: 6px;
+  padding: 0.4rem;
+  list-style-type: none;
+}
+.search-box .suggestions.align-right {
+  right: 0;
+}
+.search-box .suggestion {
+  line-height: 1.4;
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.search-box .suggestion a {
+  white-space: normal;
+  color: #5d82a6;
+}
+.search-box .suggestion a .page-title {
+  font-weight: 600;
+}
+.search-box .suggestion a .header {
+  font-size: 0.9em;
+  margin-left: 0.25em;
+}
+.search-box .suggestion.focused {
+  background-color: #f3f4f5;
+}
+.search-box .suggestion.focused a {
+  color: #3eaf7c;
+}
+@media (max-width: 959px) {
+  .search-box input {
+    cursor: pointer;
+    width: 0;
+    border-color: transparent;
+    position: relative;
+  }
+  .search-box input:focus {
+    cursor: text;
+    left: 0;
+    width: 10rem;
+  }
+}
+@media all and (-ms-high-contrast: none) {
+  .search-box input {
+    height: 2rem;
+  }
+}
+@media (max-width: 959px) and (min-width: 719px) {
+  .search-box .suggestions {
+    left: 0;
+  }
+}
+@media (max-width: 719px) {
+  .search-box {
+    margin-right: 0;
+  }
+  .search-box input {
+    left: 1rem;
+  }
+  .search-box .suggestions {
+    right: 0;
+  }
+}
+@media (max-width: 419px) {
+  .search-box .suggestions {
+    width: calc(100vw - 4rem);
+  }
+  .search-box input:focus {
+    width: 8rem;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,4 +1,20 @@
+import { h } from 'vue'
 import DefaultTheme from 'vitepress/dist/client/theme-default'
+import AlgoliaSearchBox from './AlgoliaSearchBox.vue'
 import './custom.css'
 
-export default DefaultTheme
+export default {
+  ...DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'navbar-search': () => {
+        return h(AlgoliaSearchBox, {
+          options: {
+            indexName: 'cli_vuejs',
+            apiKey: 'f6df220f7d246aff64a56300b7f19f21',
+          }
+        })
+      }
+    })
+  }
+}

--- a/docs/.vitepress/theme/search.svg
+++ b/docs/.vitepress/theme/search.svg
@@ -1,0 +1,2 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="13"><g stroke-width="2" stroke="#aaa" fill="none"><path d="M11.29 11.71l-4-4"/><circle cx="5" cy="5" r="4"/></g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-jest": "^27.0.6",
     "chromedriver": "^94.0.0",
     "debug": "^4.1.0",
+    "docsearch.js": "^2.6.3",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-graphql": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4751,7 +4751,7 @@ algoliasearch-helper@^2.26.0:
     lodash "^4.17.5"
     qs "^6.5.1"
 
-algoliasearch@^3.27.0:
+algoliasearch@^3.24.5, algoliasearch@^3.27.0:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
   integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
@@ -5625,6 +5625,13 @@ atomic-sleep@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
+autocomplete.js@0.36.0:
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.36.0.tgz#94fe775fe64b6cd42e622d076dc7fd26bedd837b"
+  integrity sha512-jEwUXnVMeCHHutUt10i/8ZiRaCb0Wo+ZyKxeGsYwBDtw6EJHqEeDrq4UwZRD8YBSvp3g6klP678il2eeiVXN2Q==
+  dependencies:
+    immediate "^3.2.3"
 
 autoprefixer@^10.2.4:
   version "10.3.7"
@@ -8205,6 +8212,19 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+docsearch.js@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/docsearch.js/-/docsearch.js-2.6.3.tgz#57cb4600d3b6553c677e7cbbe6a734593e38625d"
+  integrity sha512-GN+MBozuyz664ycpZY0ecdQE0ND/LSgJKhTLA0/v3arIS3S1Rpf2OJz6A35ReMsm91V5apcmzr5/kM84cvUg+A==
+  dependencies:
+    algoliasearch "^3.24.5"
+    autocomplete.js "0.36.0"
+    hogan.js "^3.0.2"
+    request "^2.87.0"
+    stack-utils "^1.0.1"
+    to-factory "^1.0.0"
+    zepto "^1.2.0"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -10981,6 +11001,14 @@ highlight.js@^10.7.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
+hogan.js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
+  integrity sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=
+  dependencies:
+    mkdirp "0.3.0"
+    nopt "1.0.10"
+
 hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -11324,6 +11352,11 @@ ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+immediate@^3.2.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
+  integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
 
 immutable@~3.7.6:
   version "3.7.6"
@@ -14348,6 +14381,11 @@ mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
+mkdirp@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
+  integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
+
 mkdirp@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
@@ -14841,6 +14879,13 @@ nodent-runtime@^3.2.1:
   resolved "https://registry.yarnpkg.com/nodent-runtime/-/nodent-runtime-3.2.1.tgz#9e2755d85e39f764288f0d4752ebcfe3e541e00e"
   integrity sha512-7Ws63oC+215smeKJQCxzrK21VFVlCFBkwl0MOObt0HOpVQXs3u483sAmtkF33nNqZ5rSOQjB76fgyPBmAUrtCA==
 
+nopt@1.0.10, nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
+  dependencies:
+    abbrev "1"
+
 nopt@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
@@ -14853,13 +14898,6 @@ nopt@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
   integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
-  dependencies:
-    abbrev "1"
-
-nopt@~1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
   dependencies:
     abbrev "1"
 
@@ -17146,7 +17184,7 @@ request@2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-request@^2.67.0, request@^2.88.0, request@^2.88.2:
+request@^2.67.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -18156,6 +18194,13 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stack-utils@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.5.tgz#a19b0b01947e0029c8e451d5d61a498f5bb1471b"
+  integrity sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
 stack-utils@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
@@ -18952,6 +18997,11 @@ to-buffer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
   integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
+
+to-factory@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-factory/-/to-factory-1.0.0.tgz#8738af8bd97120ad1d4047972ada5563bf9479b1"
+  integrity sha1-hzivi9lxIK0dQEeXKtpVY7+UebE=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -21216,6 +21266,11 @@ zen-observable@0.8.15, zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zepto@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/zepto/-/zepto-1.2.0.tgz#e127bd9e66fd846be5eab48c1394882f7c0e4f98"
+  integrity sha1-4Se9nmb9hGvl6rSME5SIL3wOT5g=
 
 zip-stream@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
the CLI documentation search index hasn't been updated to the new version of docsearch (which vitepress requires).
So I migrated some of the code from the vuepress version to use docsearch.js 2.x instead.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
