### PR TITLE
feat: support multi-entry library build

### DIFF
--- a/packages/@vue/cli-service/__tests__/buildLibMultiEntry.spec.js
+++ b/packages/@vue/cli-service/__tests__/buildLibMultiEntry.spec.js
@@ -1,0 +1,54 @@
+jest.setTimeout(40000)
+
+const { defaultPreset } = require('@vue/cli/lib/options')
+const create = require('@vue/cli-test-utils/createTestProject')
+
+async function makeProjectMultiEntry (project) {
+  await project.write('vue.config.js', `
+    module.exports = {
+      chainWebpack: config => {
+        config.output.filename("testLib.[name].js");
+        config.entryPoints.clear();
+        config
+          .entry("foo")
+          .add("./src/foo.js")
+          .end();
+        config
+          .entry("bar")
+          .add("./src/bar.js")
+          .end();
+      }
+    }
+  `)
+  await project.write('src/foo.js', `
+    import Vue from 'vue'
+    new Vue({
+      el: '#app',
+      render: h => h('h1', 'Foo')
+    })
+  `)
+  await project.write('src/bar.js', `
+    import Vue from 'vue'
+    new Vue({
+      el: '#app',
+      render: h => h('h1', 'Bar')
+    })
+  `)
+}
+
+test('build as lib with multi-entry', async () => {
+  const project = await create('build-lib-multi-entry', defaultPreset)
+
+  await makeProjectMultiEntry(project)
+
+  const { stdout } = await project.run('vue-cli-service build --target lib')
+  expect(stdout).toMatch('Build complete.')
+
+  expect(project.has('dist/demo.html')).toBe(true)
+  expect(project.has('dist/testLib.foo.common.js')).toBe(true)
+  expect(project.has('dist/testLib.foo.umd.js')).toBe(true)
+  expect(project.has('dist/testLib.foo.umd.min.js')).toBe(true)
+  expect(project.has('dist/testLib.bar.common.js')).toBe(true)
+  expect(project.has('dist/testLib.bar.umd.js')).toBe(true)
+  expect(project.has('dist/testLib.bar.umd.min.js')).toBe(true)
+})

--- a/packages/@vue/cli-service/lib/commands/build/index.js
+++ b/packages/@vue/cli-service/lib/commands/build/index.js
@@ -46,7 +46,7 @@ module.exports = (api, options) => {
       }
     }
     args.entry = args.entry || args._[0]
-    if (args.target !== 'app') {
+    if (!['app', 'lib'].includes(args.target)) {
       args.entry = args.entry || 'src/App.vue'
     }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

This PR adds support to multi-entry library builds.
It does so by looking at Webpack's [Entry Points](https://webpack.js.org/concepts/entry-points/) config and processing the last file in each entry point in [resolveLibConfig](https://github.com/semiaddict/vue-cli/blob/multi-entry-lib/packages/%40vue/cli-service/lib/commands/build/resolveLibConfig.js).

Example usage with vue.config.js:
```js
module.exports = {
    config.output.filename("MyLibrary.[name].js");
    chainWebpack: (config) => {
        config.entryPoints.clear();
        config.entry("EntryOne").add("./src/my-polyfill.js").add("./src/entry-one/main.js").end();
        config.entry("EntryTwo").add("./src/entry-two/main.js").end();
    }
}
```

Related issue: #3922