### PR TITLE
feat(docs): Add Layer0 deployment guide

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -325,6 +325,18 @@ You can deploy a fresh Vue project, with a Git repository set up for you, with t
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/git?s=https%3A%2F%2Fgithub.com%2Fvercel%2Fvercel%2Ftree%2Fmaster%2Fexamples%2Fvue)
 
+### Layer0
+
+[Layer0](https://layer0.co) is the powerful CDN platform that integrates edge logic into your application code & extends the edge to the browser.
+
+See the official guide on [how to deploy a Vue.js application on Layer0]((https://docs.layer0.co/guides/vue)).
+
+#### Deploying a fresh Vue project on Layer0
+
+You can deploy a fresh Vue project on Layer0 with the following Deploy Button:
+
+[Deploy to Layer0](https://app.layer0.co/deploy?button&deploy&repo=https://github.com/layer0-docs/layer0-static-vuejs-example)
+
 ## References:
 
 - [Example Source](https://github.com/vercel/vercel/tree/master/examples/vue)

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -325,11 +325,18 @@ You can deploy a fresh Vue project, with a Git repository set up for you, with t
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/git?s=https%3A%2F%2Fgithub.com%2Fvercel%2Fvercel%2Ftree%2Fmaster%2Fexamples%2Fvue)
 
+## References:
+
+- [Example Source](https://github.com/vercel/vercel/tree/master/examples/vue)
+- [Official Vercel Guide](https://vercel.com/guides/deploying-vuejs-to-vercel)
+- [Vercel Deployment Docs](https://vercel.com/docs)
+- [Vercel Custom Domain Docs](https://vercel.com/docs/custom-domains)
+
 ### Layer0
 
 [Layer0](https://layer0.co) is the powerful CDN platform that integrates edge logic into your application code & extends the edge to the browser.
 
-See the official guide on [how to deploy a Vue.js application on Layer0]((https://docs.layer0.co/guides/vue)).
+See the official guide on [how to deploy a Vue.js application on Layer0](https://docs.layer0.co/guides/vue).
 
 #### Deploying a fresh Vue project on Layer0
 
@@ -337,12 +344,9 @@ You can deploy a fresh Vue project on Layer0 with the following Deploy Button:
 
 [Deploy to Layer0](https://app.layer0.co/deploy?button&deploy&repo=https://github.com/layer0-docs/layer0-static-vuejs-example)
 
-## References:
-
-- [Example Source](https://github.com/vercel/vercel/tree/master/examples/vue)
-- [Official Vercel Guide](https://vercel.com/guides/deploying-vuejs-to-vercel)
-- [Vercel Deployment Docs](https://vercel.com/docs)
-- [Vercel Custom Domain Docs](https://vercel.com/docs/custom-domains)
+## References
+- [Example Site](https://layer0-docs-layer0-static-vuejs-example-default.layer0-limelight.link)
+- [Example Source](https://github.com/layer0-docs/layer0-static-vuejs-example)
 
 ### Stdlib
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update
- [ ] Refactor
- [ x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

**Other information:**
Vue.js apps can be deployed to Layer0 alongside [other frameworks](https://docs.layer0.co/guides/jamstack_getting_started). I've updated the docs to reference the official docs guide for users looking to deploy on Layer0
