### PR TITLE
fix: vue config set a char+number value got null

### DIFF
--- a/packages/@vue/cli/lib/config.js
+++ b/packages/@vue/cli/lib/config.js
@@ -53,7 +53,7 @@ async function configure (value, options) {
   if (options.set && value) {
     set(config, options.set, value)
 
-    if (value.match('[0-9]')) {
+    if (/^\d+$/.test(value)) {
       set(config, options.set, parseInt(value))
     }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
![123](https://user-images.githubusercontent.com/18263998/147808338-5d831ecf-f901-48f7-aa38-94fee3e7b669.png)

