### PR TITLE
fix: set mini-css-extract-plugin to 2.4.5

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -61,7 +61,7 @@
     "launch-editor-middleware": "^2.2.1",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.mapvalues": "^4.6.0",
-    "mini-css-extract-plugin": "^2.4.3",
+    "mini-css-extract-plugin": "~2.4.3",
     "minimist": "^1.2.5",
     "module-alias": "^2.2.2",
     "portfinder": "^1.0.26",


### PR DESCRIPTION
Workaround for https://github.com/vuejs/vue-cli/discussions/6943

Source cause https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
