### PR TITLE
Update version of webpack documentation links

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -330,7 +330,7 @@ In v3 this means the opposite of `css.requireModuleExtension`.
 
 - Type: `Object`
 
-  [All options for `webpack-dev-server`](https://webpack.js.org/configuration/dev-server/) are supported. Note that:
+  [All options for `webpack-dev-server`](https://v4.webpack.js.org/configuration/dev-server/) are supported. Note that:
 
   - Some values like `host`, `port` and `https` may be overwritten by command line flags.
 
@@ -382,7 +382,7 @@ In v3 this means the opposite of `css.requireModuleExtension`.
 - Type: `boolean`
 - Default: `true`
 
-  Toggle between the dev-server's two different modes. See [devServer.inline](https://webpack.js.org/configuration/dev-server/#devserverinline) for more details. Note that:
+  Toggle between the dev-server's two different modes. See [devServer.inline](https://v4.webpack.js.org/configuration/dev-server/#devserverinline) for more details. Note that:
 
   - To use the `iframe mode` no additional configuration is needed. Just navigate the browser to `http://<host>:<port>/webpack-dev-server/<path>` to debug your app. A notification bar with messages will appear at the top of your app.
   - To use the `inline mode`, just navigate to `http://<host>:<port>/<path>` to debug your app. The build messages will appear in the browser console.


### PR DESCRIPTION
Change all references to https://webpack.js.org/ to https://v4.webpack.js.org/

The latest version of @vue/cli-service relies on webpack-dev-server ^3.11.0, but the webpack documentation links now point to v5 by default, and there are some differences in the config format. Webpack documentation for v3 appears not to be available, but at least v4 is closer than v5. (I was unable to spot any inconsistencies of the vue.js documentation of devServer vs the webpack v4 documentation, after a cursory look at the latter.)

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
