### PR TITLE
fix: default baseUrl when publicPath is auto

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -116,7 +116,7 @@ module.exports = (api, options) => {
       protocol,
       host,
       port,
-      isAbsoluteUrl(options.publicPath) ? '/' : options.publicPath
+      isAbsoluteUrl(options.publicPath) || options.publicPath === 'auto' ? '/' : options.publicPath
     )
     const localUrlForBrowser = publicUrl || urls.localUrlForBrowser
 

--- a/packages/@vue/cli-service/lib/util/resolveClientEnv.js
+++ b/packages/@vue/cli-service/lib/util/resolveClientEnv.js
@@ -7,7 +7,7 @@ module.exports = function resolveClientEnv (options, raw) {
       env[key] = process.env[key]
     }
   })
-  env.BASE_URL = options.publicPath
+  env.BASE_URL = options.publicPath !== 'auto' ? options.publicPath : '/'
 
   if (raw) {
     return env


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Fixed incorrect `env.BASE_URL` assignment and serve command urls output, when `publicPath: auto`.