### PR TITLE
fix: remove non standard rel=shortcut

### DIFF
--- a/packages/@vue/cli-ui/public/index.html
+++ b/packages/@vue/cli-ui/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="shortcut icon" href="<%= webpackConfig.output.publicPath %>favicon.ico">
+    <link rel="icon" href="<%= webpackConfig.output.publicPath %>favicon.ico">
     <title>Vue CLI</title>
   </head>
   <body>


### PR DESCRIPTION
`shortcut` is used by IE6 which is dead and not supported anymore https://github.com/vuejs/vue-cli/issues/5232

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
