### PR TITLE
fix: update mini-css-extract-plugin to ^2.5.3

### DIFF
--- a/packages/@vue/cli-service/package.json
+++ b/packages/@vue/cli-service/package.json
@@ -59,7 +59,7 @@
     "launch-editor-middleware": "^2.2.1",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.mapvalues": "^4.6.0",
-    "mini-css-extract-plugin": "~2.4.3",
+    "mini-css-extract-plugin": "^2.5.3",
     "minimist": "^1.2.5",
     "module-alias": "^2.2.2",
     "portfinder": "^1.0.26",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Basically, just removing the temporary workaround introduced in https://github.com/vuejs/vue-cli/pull/6944 (`v5.0.0-rc.2`) due to an accidental breaking change added in `mini-css-extract-plugin v2.5.0`. This was fixed in `v2.5.1` https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896#issuecomment-1014458314.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**
