### PR TITLE
fix: support non-alpha cli-service@v5 peer deps

### DIFF
--- a/packages/@vue/cli-plugin-babel/package.json
+++ b/packages/@vue/cli-plugin-babel/package.json
@@ -28,7 +28,7 @@
     "webpack": "^5.54.0"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.16",

--- a/packages/@vue/cli-plugin-e2e-cypress/package.json
+++ b/packages/@vue/cli-plugin-e2e-cypress/package.json
@@ -30,7 +30,7 @@
     "cypress": "^8.3.0"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "cypress": "*"
   }
 }

--- a/packages/@vue/cli-plugin-e2e-nightwatch/package.json
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/package.json
@@ -33,7 +33,7 @@
     "selenium-server": "^3.141.59"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "chromedriver": "*",
     "geckodriver": "*",
     "selenium-server": "^3.141.59"

--- a/packages/@vue/cli-plugin-eslint/package.json
+++ b/packages/@vue/cli-plugin-eslint/package.json
@@ -30,7 +30,7 @@
     "yorkie": "^2.0.0"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "eslint": ">=7.5.0"
   }
 }

--- a/packages/@vue/cli-plugin-pwa/package.json
+++ b/packages/@vue/cli-plugin-pwa/package.json
@@ -32,6 +32,6 @@
     "register-service-worker": "^1.7.2"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0"
   }
 }

--- a/packages/@vue/cli-plugin-router/package.json
+++ b/packages/@vue/cli-plugin-router/package.json
@@ -29,6 +29,6 @@
     "@vue/cli-test-utils": "^5.0.1"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0"
   }
 }

--- a/packages/@vue/cli-plugin-typescript/package.json
+++ b/packages/@vue/cli-plugin-typescript/package.json
@@ -35,7 +35,7 @@
     "yorkie": "^2.0.0"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "cache-loader": "^4.1.0",
     "typescript": ">=2",
     "vue": "^2 || ^3.2.13",

--- a/packages/@vue/cli-plugin-unit-jest/package.json
+++ b/packages/@vue/cli-plugin-unit-jest/package.json
@@ -41,7 +41,7 @@
     "ts-jest": "^27.0.4"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "@vue/vue2-jest": "^27.0.0-alpha.3",
     "@vue/vue3-jest": "^27.0.0-alpha.3",
     "jest": "^27.1.0",

--- a/packages/@vue/cli-plugin-unit-mocha/package.json
+++ b/packages/@vue/cli-plugin-unit-mocha/package.json
@@ -35,7 +35,7 @@
     "chai": "^4.3.0"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vue/cli-plugin-vuex/package.json
+++ b/packages/@vue/cli-plugin-vuex/package.json
@@ -26,6 +26,6 @@
     "@vue/cli-test-utils": "^5.0.1"
   },
   "peerDependencies": {
-    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+    "@vue/cli-service": "^3.0.0 || ^4.0.0 || ^5.0.0"
   }
 }

--- a/packages/@vue/cli-ui/ui-defaults/tasks.js
+++ b/packages/@vue/cli-ui/ui-defaults/tasks.js
@@ -330,7 +330,7 @@ module.exports = api => {
 
       // the flag is different between v3/4 and v5 projects
       const servicePkg = loadModule('@vue/cli-service/package.json', api.getCwd())
-      const isV5Project = servicePkg && semver.satisfies(servicePkg.version, '^5.0.0-0')
+      const isV5Project = servicePkg && semver.satisfies(servicePkg.version, '^5.0.0')
 
       if (answers.modern) {
         args.push(isV5Project ? '--module' : '--modern')


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
Many cli plugins expect a peer dependency of `^5.0.0-0` which means that the new `v5.0.1` conflicts with it. This PR updates the cli plugins to have an allowed peer dependency of `^5.0.0` so that alpha _and_ non-alpha v5 of cli-service are acceptable dependency peers.

Additionally, the `build` command switches alternates between different flags depending on if the service is v3/v4 or v5. I updated that check to also toggle the flag for non-alpha v5 cli-service. 

**Example error from bad peer dependency:**
```
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: @vue/cli-plugin-router@5.0.1
npm WARN Found: @vue/cli-service@5.0.1
npm WARN node_modules/@vue/cli-service
npm WARN   dev @vue/cli-service@"^5.0.1" from the root project
npm WARN   2 more (@vue/cli-plugin-router, @vue/cli-plugin-vuex)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer @vue/cli-service@"^3.0.0 || ^4.0.0 || ^5.0.0-0" from @vue/cli-plugin-router@5.0.1
npm WARN node_modules/@vue/cli-plugin-router
npm WARN   @vue/cli-plugin-router@"^5.0.1" from @vue/cli-service@5.0.1
npm WARN   node_modules/@vue/cli-service
```

Installing these new versions that have adjusted peer dependencies return no errors.