### PR TITLE
feat(cli-service):   Support webpack5 devServer.server configuration

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -9,7 +9,7 @@ const {
 const defaults = {
   host: '0.0.0.0',
   port: 8080,
-  https: false
+  server: 'http'
 }
 
 /** @type {import('@vue/cli-service').ServicePlugin} */
@@ -24,7 +24,7 @@ module.exports = (api, options) => {
       '--mode': `specify env mode (default: development)`,
       '--host': `specify host (default: ${defaults.host})`,
       '--port': `specify port (default: ${defaults.port})`,
-      '--https': `use https (default: ${defaults.https})`,
+      '--https': `use https (default: ${defaults.server ==='https' || defaults.server ==='spdy'})`,
       '--public': `specify the public network URL for the HMR client`,
       '--skip-plugins': `comma-separated list of plugin names to skip for this run`
     }
@@ -101,9 +101,10 @@ module.exports = (api, options) => {
     // Compatible with server in webpack5
     const projectDevServerType = typeof projectDevServerOptions.server === 'string' ? projectDevServerOptions.server : typeof (projectDevServerOptions.server || {}).type === 'string' ? projectDevServerOptions.server.type : 'http'
     const httpsTypes = ['https', 'spdy']
+    const serverSetting = args['server-type'] || (process.env.HTTPS === 'true' ? 'https' : 'http') || projectDevServerOptions.server || defaults.server
 
     // resolve server options
-    const useHttps = args.https || args.http2 || projectDevServerOptions.https || defaults.https || httpsTypes.includes(args['server-type']) || httpsTypes.includes(projectDevServerType)
+    const useHttps = args.https || args.http2 || process.env.HTTPS === 'true' || httpsTypes.includes(defaults.https) || httpsTypes.includes(args['server-type']) || httpsTypes.includes(projectDevServerType)
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
     portfinder.basePort = args.port || process.env.PORT || projectDevServerOptions.port || defaults.port
@@ -197,7 +198,7 @@ module.exports = (api, options) => {
     }, projectDevServerOptions, {
       host,
       port,
-      https: useHttps,
+      server: serverSetting,
       proxy: proxySettings,
 
       static: {

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -24,7 +24,7 @@ module.exports = (api, options) => {
       '--mode': `specify env mode (default: development)`,
       '--host': `specify host (default: ${defaults.host})`,
       '--port': `specify port (default: ${defaults.port})`,
-      '--https': `use https (default: ${defaults.server ==='https' || defaults.server ==='spdy'})`,
+      '--https': `use https (default: ${defaults.server === 'https' || defaults.server === 'spdy'})`,
       '--public': `specify the public network URL for the HMR client`,
       '--skip-plugins': `comma-separated list of plugin names to skip for this run`
     }

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -98,8 +98,12 @@ module.exports = (api, options) => {
       }
     }
 
+    // Compatible with server in webpack5
+    const projectDevServerType = typeof projectDevServerOptions.server === 'string' ? projectDevServerOptions.server : typeof (projectDevServerOptions.server || {}).type === 'string' ? projectDevServerOptions.server.type : 'http'
+    const httpsTypes = ['https', 'spdy']
+
     // resolve server options
-    const useHttps = args.https || projectDevServerOptions.https || defaults.https
+    const useHttps = args.https || args.http2 || projectDevServerOptions.https || defaults.https || httpsTypes.includes(args['server-type']) || httpsTypes.includes(projectDevServerType)
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
     portfinder.basePort = args.port || process.env.PORT || projectDevServerOptions.port || defaults.port


### PR DESCRIPTION
options 'https' is deprecated in favor of the devServer.server option.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
