### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/@vue/cli-ui-addon-widgets/src/components/NewsItem.vue
+++ b/packages/@vue/cli-ui-addon-widgets/src/components/NewsItem.vue
@@ -32,7 +32,7 @@ export default {
     snippet () {
       const text = this.item.contentSnippet
       if (text.length > 200) {
-        return text.substr(0, 197) + '...'
+        return text.slice(0, 197) + '...'
       }
       return text
     }

--- a/packages/@vue/cli-ui/apollo-server/connectors/configurations.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/configurations.js
@@ -225,7 +225,7 @@ async function save (id, context) {
               let field = key
               const dotIndex = key.indexOf('.')
               if (dotIndex !== -1) {
-                field = key.substr(0, dotIndex)
+                field = key.slice(0, dotIndex)
               }
               getChangedFields(fileId).push(field)
 

--- a/packages/@vue/cli-ui/apollo-server/connectors/cwd.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/cwd.js
@@ -8,7 +8,7 @@ function normalize (value) {
   if (value.length === 1) return value
   const lastChar = value.charAt(value.length - 1)
   if (lastChar === path.sep) {
-    value = value.substr(0, value.length - 1)
+    value = value.slice(0, -1)
   }
   return value
 }

--- a/packages/@vue/cli-ui/apollo-server/connectors/dependencies.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/dependencies.js
@@ -152,7 +152,7 @@ function getLocalPath (id, context) {
   )
   const range = deps[id]
   if (range && range.match(/^file:/)) {
-    const localPath = range.substr('file:'.length)
+    const localPath = range.slice('file:'.length)
     return path.resolve(cwd.get(), localPath)
   }
   return null

--- a/packages/@vue/cli-ui/apollo-server/connectors/locales.js
+++ b/packages/@vue/cli-ui/apollo-server/connectors/locales.js
@@ -39,7 +39,7 @@ function _loadFolder (root, context) {
   const paths = globby.sync(['./locales/*.json'], { cwd: root, absolute: true })
   paths.forEach(file => {
     const basename = path.basename(file)
-    const lang = basename.substr(0, basename.indexOf('.'))
+    const lang = basename.substring(0, basename.indexOf('.'))
     const strings = fs.readJsonSync(file)
     add({ lang, strings }, context)
   })

--- a/packages/@vue/cli-ui/apollo-server/util/highlight.js
+++ b/packages/@vue/cli-ui/apollo-server/util/highlight.js
@@ -30,7 +30,7 @@ export function highlightCode (filename, content, lang = null) {
     language = languages.find(l => l.test.test(filename))
   }
   if (!language) {
-    const ext = path.extname(filename).substr(1)
+    const ext = path.extname(filename).slice(1)
     if (Prism.languages[ext]) {
       language = { lang: ext }
     }

--- a/packages/@vue/cli-ui/apollo-server/util/parse-args.js
+++ b/packages/@vue/cli-ui/apollo-server/util/parse-args.js
@@ -9,11 +9,11 @@ exports.parseArgs = function (args) {
   for (const part of parts) {
     const l = part.length
     if (!arg && part.charAt(0) === '"') {
-      arg = part.substr(1)
+      arg = part.slice(1)
     } else if (part.charAt(l - 1) === '"' && (
       l === 1 || part.charAt(l - 2) !== '\\'
     )) {
-      arg += args.charAt(index - 1) + part.substr(0, l - 1)
+      arg += args.charAt(index - 1) + part.slice(0, -1)
       result.push(arg)
       arg = null
     } else if (arg) {

--- a/packages/@vue/cli-ui/apollo-server/util/parse-diff.js
+++ b/packages/@vue/cli-ui/apollo-server/util/parse-diff.js
@@ -169,7 +169,7 @@ function parseFileFallback (s) {
   const t = (/\t.*|\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d(.\d+)?\s(\+|-)\d\d\d\d/).exec(s)
   if (t) { s = s.substring(0, t.index).trim() }
   // ignore git prefixes a/ or b/
-  if (s.match((/^(a|b)\//))) { return s.substr(2) } else { return s }
+  if (s.match((/^(a|b)\//))) { return s.slice(2) } else { return s }
 }
 
 function ltrim (s, chars) {

--- a/packages/@vue/cli-ui/apollo-server/util/resolve-path.js
+++ b/packages/@vue/cli-ui/apollo-server/util/resolve-path.js
@@ -4,7 +4,7 @@ exports.resolveModuleRoot = function (filePath, id = null) {
   {
     const index = filePath.lastIndexOf(path.sep + 'index.js')
     if (index !== -1) {
-      filePath = filePath.substr(0, index)
+      filePath = filePath.slice(0, index)
     }
   }
   if (id) {
@@ -21,13 +21,13 @@ exports.resolveModuleRoot = function (filePath, id = null) {
       // Scoped (in dev env)
       index = id.lastIndexOf('/')
       if (index !== -1) {
-        search = id.substr(index + 1)
+        search = id.slice(index + 1)
         index = filePath.lastIndexOf(search)
       }
     }
 
     if (index !== -1) {
-      filePath = filePath.substr(0, index + search.length)
+      filePath = filePath.slice(0, index + search.length)
     }
   }
   return filePath

--- a/packages/@vue/cli-ui/src/components/prompt/PromptsList.vue
+++ b/packages/@vue/cli-ui/src/components/prompt/PromptsList.vue
@@ -66,7 +66,7 @@ export default {
       if (types[type]) {
         type = types[type]
       }
-      type = type.charAt(0).toUpperCase() + type.substr(1)
+      type = type.charAt(0).toUpperCase() + type.slice(1)
       return require(`./Prompt${type}.vue`).default
     }
   }

--- a/packages/@vue/cli-ui/src/i18n.js
+++ b/packages/@vue/cli-ui/src/i18n.js
@@ -15,7 +15,7 @@ function detectLanguage () {
     const lang = (window.navigator.languages && window.navigator.languages[0]) ||
       window.navigator.language ||
       window.navigator.userLanguage
-    return [lang, lang.toLowerCase(), lang.substr(0, 2)].map(lang => lang.replace('-', '_'))
+    return [lang, lang.toLowerCase(), lang.slice(0, 2)].map(lang => lang.replace('-', '_'))
   } catch (e) {
     return undefined
   }

--- a/packages/@vue/cli-ui/src/register-components.js
+++ b/packages/@vue/cli-ui/src/register-components.js
@@ -12,7 +12,7 @@ const requireComponent = require.context('./components', true, /[a-z0-9]+\.(jsx?
 requireComponent.keys().forEach(fileName => {
   const componentConfig = requireComponent(fileName)
   const componentName = fileName
-    .substr(fileName.lastIndexOf('/') + 1)
+    .slice(fileName.lastIndexOf('/') + 1)
     // Remove the file extension from the end
     .replace(/\.\w+$/, '')
   // Globally register the component

--- a/packages/@vue/cli-ui/ui-defaults/utils/audit.js
+++ b/packages/@vue/cli-ui/ui-defaults/utils/audit.js
@@ -24,7 +24,7 @@ exports.auditProject = async function (cwd) {
         const errLines = child.stderr.split('\n').map(l => l.trim()).filter(l => l)
         const error = errLines.find(l => l.startsWith('Error:'))
         if (error) {
-          throw new Error(error.substr('Error:'.length).trim())
+          throw new Error(error.slice('Error:'.length).trim())
         }
       }
 

--- a/packages/@vue/cli-ui/ui-defaults/utils/modules.js
+++ b/packages/@vue/cli-ui/ui-defaults/utils/modules.js
@@ -31,9 +31,9 @@ exports.buildDepModules = function (modules) {
       let name = pathParts[1]
       if (name.charAt(0) === '@') {
         // Scoped package
-        name = name.substr(0, name.indexOf('/', name.indexOf('/') + 1))
+        name = name.slice(0, name.indexOf('/', name.indexOf('/') + 1))
       } else {
-        name = name.substr(0, name.indexOf('/'))
+        name = name.slice(0, name.indexOf('/'))
       }
       let dep = deps.get(name)
       if (!dep) {

--- a/packages/@vue/cli/lib/util/executeCommand.js
+++ b/packages/@vue/cli/lib/util/executeCommand.js
@@ -84,7 +84,7 @@ exports.executeCommand = function executeCommand (command, args, cwd) {
         if (str && command === 'yarn' && str.indexOf('"type":') !== -1) {
           const newLineIndex = str.lastIndexOf('\n')
           if (newLineIndex !== -1) {
-            str = str.substr(newLineIndex)
+            str = str.slice(newLineIndex)
           }
           try {
             const data = JSON.parse(str)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.