### PR TITLE
Update docs for css-loader > 4.0.0

### DIFF
--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -6,6 +6,10 @@ Vue CLI projects come with support for [PostCSS](http://postcss.org/), [CSS Modu
 
 All compiled CSS are processed by [css-loader](https://github.com/webpack-contrib/css-loader), which parses `url()` and resolves them as module requests. This means you can refer to assets using relative paths based on the local file structure. Note if you want to reference a file inside an npm dependency or via webpack alias, the path must be prefixed with `~` to avoid ambiguity. See [Static Asset Handling](./html-and-static-assets.md#static-assets-handling) for more details.
 
+::: tip Note on Vue CLI 5
+The way css-loader handles absolute paths was changed in v4.0.0. Previously, absolute paths were left as-is; now they are resolved based on the server root. If you get a Webpack module resolution error for an absolute path inside your CSS, change it to use a relative path instead, or use `css.loaderOptions` below to pass an override for that file. The [css-loader docs](https://github.com/webpack-contrib/css-loader#url) have more information about passing url options.
+:::
+
 ## Pre-Processors
 
 You can select pre-processors (Sass/Less/Stylus) when creating the project. If you did not do so, the internal webpack config is still pre-configured to handle all of them. You just need to manually install the corresponding webpack loaders:


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

I ran into this problem when updating from Vue CLI v4 to v5, where some of my project's dependencies included absolute paths in the css.