### PR TITLE
fix: add XMLSerializer to the global scope

### DIFF
--- a/packages/@vue/cli-plugin-unit-mocha/setup.js
+++ b/packages/@vue/cli-plugin-unit-mocha/setup.js
@@ -6,3 +6,6 @@ window.Date = Date
 global.ShadowRoot = window.ShadowRoot
 
 global.SVGElement = window.SVGElement
+
+// https://github.com/vuejs/test-utils/issues/1253
+global.XMLSerializer = window.XMLSerializer


### PR DESCRIPTION
In @vue/test-utils 2.0.0rc18, The usage of `XMLSerializer` was introduced: https://github.com/vuejs/test-utils/blob/d86cbc333de7b2ec1208f5d3c65e0879671dd01e/src/utils/stringifyNode.ts#L4

`XMLSerializer` needs to be available as a global so `cli-plugin-unit-mocha` will stay compatible with newer versions of @vue/test-utils.

See also: https://github.com/vuejs/test-utils/issues/1253


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**
