### PR TITLE
fix: the match fails when the compile dependency option is regular

### DIFF
--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -2,7 +2,7 @@ const path = require('path')
 const babel = require('@babel/core')
 const { isWindows } = require('@vue/cli-shared-utils')
 
-function getDepPathRegex(dependencies) {
+function getDepPathRegex (dependencies) {
   const deps = dependencies.map(dep => {
     if (typeof dep === 'string') {
       const depPath = path.join('node_modules', dep, '/')
@@ -37,70 +37,70 @@ module.exports = (api, options) => {
 
     const jsRule = webpackConfig.module
       .rule('js')
-      .test(/\.m?jsx?$/)
-      .exclude
-      .add(filepath => {
-        const SHOULD_SKIP = true
-        const SHOULD_TRANSPILE = false
+        .test(/\.m?jsx?$/)
+        .exclude
+          .add(filepath => {
+            const SHOULD_SKIP = true
+            const SHOULD_TRANSPILE = false
 
-        // With data URI support in webpack 5, filepath could be undefined
-        if (!filepath) {
-          return SHOULD_SKIP
-        }
+            // With data URI support in webpack 5, filepath could be undefined
+            if (!filepath) {
+              return SHOULD_SKIP
+            }
 
-        // Always transpile js in vue files
-        if (/\.vue\.jsx?$/.test(filepath)) {
-          return SHOULD_TRANSPILE
-        }
-        // Exclude dynamic entries from cli-service
-        if (filepath.startsWith(cliServicePath)) {
-          return SHOULD_SKIP
-        }
+            // Always transpile js in vue files
+            if (/\.vue\.jsx?$/.test(filepath)) {
+              return SHOULD_TRANSPILE
+            }
+            // Exclude dynamic entries from cli-service
+            if (filepath.startsWith(cliServicePath)) {
+              return SHOULD_SKIP
+            }
 
-        // To transpile `@babel/runtime`, the config needs to be
-        // carefully adjusted to avoid infinite loops.
-        // So we only do the tranpilation when the special flag is on.
-        if (getDepPathRegex(['@babel/runtime']).test(filepath)) {
-          return process.env.VUE_CLI_TRANSPILE_BABEL_RUNTIME
-            ? SHOULD_TRANSPILE
-            : SHOULD_SKIP
-        }
+            // To transpile `@babel/runtime`, the config needs to be
+            // carefully adjusted to avoid infinite loops.
+            // So we only do the tranpilation when the special flag is on.
+            if (getDepPathRegex(['@babel/runtime']).test(filepath)) {
+              return process.env.VUE_CLI_TRANSPILE_BABEL_RUNTIME
+                ? SHOULD_TRANSPILE
+                : SHOULD_SKIP
+            }
 
-        // if `transpileDependencies` is set to true, transpile all deps
-        if (options.transpileDependencies === true) {
-          // Some of the deps cannot be transpiled, though
-          // https://stackoverflow.com/a/58517865/2302258
-          const NON_TRANSPILABLE_DEPS = [
-            'core-js',
-            'webpack',
-            'webpack-4',
-            'css-loader',
-            'mini-css-extract-plugin',
-            'promise-polyfill',
-            'html-webpack-plugin',
-            'whatwg-fetch'
-          ]
-          const nonTranspilableDepsRegex = getDepPathRegex(NON_TRANSPILABLE_DEPS)
-          return nonTranspilableDepsRegex.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
-        }
+            // if `transpileDependencies` is set to true, transpile all deps
+            if (options.transpileDependencies === true) {
+              // Some of the deps cannot be transpiled, though
+              // https://stackoverflow.com/a/58517865/2302258
+              const NON_TRANSPILABLE_DEPS = [
+                'core-js',
+                'webpack',
+                'webpack-4',
+                'css-loader',
+                'mini-css-extract-plugin',
+                'promise-polyfill',
+                'html-webpack-plugin',
+                'whatwg-fetch'
+              ]
+              const nonTranspilableDepsRegex = getDepPathRegex(NON_TRANSPILABLE_DEPS)
+              return nonTranspilableDepsRegex.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
+            }
 
-        // Otherwise, check if this is something the user explicitly wants to transpile
-        if (Array.isArray(options.transpileDependencies)) {
-          const transpileDepRegex = getDepPathRegex(options.transpileDependencies)
-          if (transpileDepRegex && transpileDepRegex.test(filepath)) {
-            return SHOULD_TRANSPILE
-          }
-        }
+            // Otherwise, check if this is something the user explicitly wants to transpile
+            if (Array.isArray(options.transpileDependencies)) {
+              const transpileDepRegex = getDepPathRegex(options.transpileDependencies)
+              if (transpileDepRegex && transpileDepRegex.test(filepath)) {
+                return SHOULD_TRANSPILE
+              }
+            }
 
-        // Don't transpile node_modules
-        return /node_modules/.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
-      })
-      .end()
+            // Don't transpile node_modules
+            return /node_modules/.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
+          })
+          .end()
 
     if (useThreads) {
       const threadLoaderConfig = jsRule
         .use('thread-loader')
-        .loader(require.resolve('thread-loader'))
+          .loader(require.resolve('thread-loader'))
 
       if (typeof options.parallel === 'number') {
         threadLoaderConfig.options({ workers: options.parallel })
@@ -109,19 +109,19 @@ module.exports = (api, options) => {
 
     jsRule
       .use('babel-loader')
-      .loader(require.resolve('babel-loader'))
-      .options({
-        cacheCompression: false,
-        ...api.genCacheConfig('babel-loader', {
-          '@babel/core': require('@babel/core/package.json').version,
-          '@vue/babel-preset-app': require('@vue/babel-preset-app/package.json').version,
-          'babel-loader': require('babel-loader/package.json').version,
-          modern: !!process.env.VUE_CLI_MODERN_BUILD,
-          browserslist: api.service.pkg.browserslist
-        }, [
-          'babel.config.js',
-          '.browserslistrc'
-        ])
-      })
+        .loader(require.resolve('babel-loader'))
+        .options({
+          cacheCompression: false,
+          ...api.genCacheConfig('babel-loader', {
+            '@babel/core': require('@babel/core/package.json').version,
+            '@vue/babel-preset-app': require('@vue/babel-preset-app/package.json').version,
+            'babel-loader': require('babel-loader/package.json').version,
+            modern: !!process.env.VUE_CLI_MODERN_BUILD,
+            browserslist: api.service.pkg.browserslist
+          }, [
+            'babel.config.js',
+            '.browserslistrc'
+          ])
+        })
   })
 }

--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -2,7 +2,7 @@ const path = require('path')
 const babel = require('@babel/core')
 const { isWindows } = require('@vue/cli-shared-utils')
 
-function getDepPathRegex (dependencies) {
+function getDepPathRegex(dependencies) {
   const deps = dependencies.map(dep => {
     if (typeof dep === 'string') {
       const depPath = path.join('node_modules', dep, '/')
@@ -10,7 +10,9 @@ function getDepPathRegex (dependencies) {
         ? depPath.replace(/\\/g, '\\\\') // double escape for windows style path
         : depPath
     } else if (dep instanceof RegExp) {
-      return dep.source
+      return isWindows
+        ? dep.source.replace(/\\\//g, '\\\\') // /@scope\/external-(dep1|dep2)/ >>> /@scope\\external-(dep1|dep2)/
+        : dep.source
     }
 
     throw new Error('transpileDependencies only accepts an array of string or regular expressions')
@@ -35,70 +37,70 @@ module.exports = (api, options) => {
 
     const jsRule = webpackConfig.module
       .rule('js')
-        .test(/\.m?jsx?$/)
-        .exclude
-          .add(filepath => {
-            const SHOULD_SKIP = true
-            const SHOULD_TRANSPILE = false
+      .test(/\.m?jsx?$/)
+      .exclude
+      .add(filepath => {
+        const SHOULD_SKIP = true
+        const SHOULD_TRANSPILE = false
 
-            // With data URI support in webpack 5, filepath could be undefined
-            if (!filepath) {
-              return SHOULD_SKIP
-            }
+        // With data URI support in webpack 5, filepath could be undefined
+        if (!filepath) {
+          return SHOULD_SKIP
+        }
 
-            // Always transpile js in vue files
-            if (/\.vue\.jsx?$/.test(filepath)) {
-              return SHOULD_TRANSPILE
-            }
-            // Exclude dynamic entries from cli-service
-            if (filepath.startsWith(cliServicePath)) {
-              return SHOULD_SKIP
-            }
+        // Always transpile js in vue files
+        if (/\.vue\.jsx?$/.test(filepath)) {
+          return SHOULD_TRANSPILE
+        }
+        // Exclude dynamic entries from cli-service
+        if (filepath.startsWith(cliServicePath)) {
+          return SHOULD_SKIP
+        }
 
-            // To transpile `@babel/runtime`, the config needs to be
-            // carefully adjusted to avoid infinite loops.
-            // So we only do the tranpilation when the special flag is on.
-            if (getDepPathRegex(['@babel/runtime']).test(filepath)) {
-              return process.env.VUE_CLI_TRANSPILE_BABEL_RUNTIME
-                ? SHOULD_TRANSPILE
-                : SHOULD_SKIP
-            }
+        // To transpile `@babel/runtime`, the config needs to be
+        // carefully adjusted to avoid infinite loops.
+        // So we only do the tranpilation when the special flag is on.
+        if (getDepPathRegex(['@babel/runtime']).test(filepath)) {
+          return process.env.VUE_CLI_TRANSPILE_BABEL_RUNTIME
+            ? SHOULD_TRANSPILE
+            : SHOULD_SKIP
+        }
 
-            // if `transpileDependencies` is set to true, transpile all deps
-            if (options.transpileDependencies === true) {
-              // Some of the deps cannot be transpiled, though
-              // https://stackoverflow.com/a/58517865/2302258
-              const NON_TRANSPILABLE_DEPS = [
-                'core-js',
-                'webpack',
-                'webpack-4',
-                'css-loader',
-                'mini-css-extract-plugin',
-                'promise-polyfill',
-                'html-webpack-plugin',
-                'whatwg-fetch'
-              ]
-              const nonTranspilableDepsRegex = getDepPathRegex(NON_TRANSPILABLE_DEPS)
-              return nonTranspilableDepsRegex.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
-            }
+        // if `transpileDependencies` is set to true, transpile all deps
+        if (options.transpileDependencies === true) {
+          // Some of the deps cannot be transpiled, though
+          // https://stackoverflow.com/a/58517865/2302258
+          const NON_TRANSPILABLE_DEPS = [
+            'core-js',
+            'webpack',
+            'webpack-4',
+            'css-loader',
+            'mini-css-extract-plugin',
+            'promise-polyfill',
+            'html-webpack-plugin',
+            'whatwg-fetch'
+          ]
+          const nonTranspilableDepsRegex = getDepPathRegex(NON_TRANSPILABLE_DEPS)
+          return nonTranspilableDepsRegex.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
+        }
 
-            // Otherwise, check if this is something the user explicitly wants to transpile
-            if (Array.isArray(options.transpileDependencies)) {
-              const transpileDepRegex = getDepPathRegex(options.transpileDependencies)
-              if (transpileDepRegex && transpileDepRegex.test(filepath)) {
-                return SHOULD_TRANSPILE
-              }
-            }
+        // Otherwise, check if this is something the user explicitly wants to transpile
+        if (Array.isArray(options.transpileDependencies)) {
+          const transpileDepRegex = getDepPathRegex(options.transpileDependencies)
+          if (transpileDepRegex && transpileDepRegex.test(filepath)) {
+            return SHOULD_TRANSPILE
+          }
+        }
 
-            // Don't transpile node_modules
-            return /node_modules/.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
-          })
-          .end()
+        // Don't transpile node_modules
+        return /node_modules/.test(filepath) ? SHOULD_SKIP : SHOULD_TRANSPILE
+      })
+      .end()
 
     if (useThreads) {
       const threadLoaderConfig = jsRule
         .use('thread-loader')
-          .loader(require.resolve('thread-loader'))
+        .loader(require.resolve('thread-loader'))
 
       if (typeof options.parallel === 'number') {
         threadLoaderConfig.options({ workers: options.parallel })
@@ -107,19 +109,19 @@ module.exports = (api, options) => {
 
     jsRule
       .use('babel-loader')
-        .loader(require.resolve('babel-loader'))
-        .options({
-          cacheCompression: false,
-          ...api.genCacheConfig('babel-loader', {
-            '@babel/core': require('@babel/core/package.json').version,
-            '@vue/babel-preset-app': require('@vue/babel-preset-app/package.json').version,
-            'babel-loader': require('babel-loader/package.json').version,
-            modern: !!process.env.VUE_CLI_MODERN_BUILD,
-            browserslist: api.service.pkg.browserslist
-          }, [
-            'babel.config.js',
-            '.browserslistrc'
-          ])
-        })
+      .loader(require.resolve('babel-loader'))
+      .options({
+        cacheCompression: false,
+        ...api.genCacheConfig('babel-loader', {
+          '@babel/core': require('@babel/core/package.json').version,
+          '@vue/babel-preset-app': require('@vue/babel-preset-app/package.json').version,
+          'babel-loader': require('babel-loader/package.json').version,
+          modern: !!process.env.VUE_CLI_MODERN_BUILD,
+          browserslist: api.service.pkg.browserslist
+        }, [
+          'babel.config.js',
+          '.browserslistrc'
+        ])
+      })
   })
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
When the `transpileDependencies` option is regular, it will be written like this according to the developer's convention: `/@scope\/external-dep/` . However, the matching fails due to the windows style path, and must be `/@scope\\external-dep/` to be matched. This commit fixes this bug and escapes the regex again.
