### PR TITLE
fix: eliminate calling deprecated function in cli-plugin-e2e-cypress and cli-plugin-e2e-nightwatch

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/index.js
@@ -36,8 +36,8 @@ module.exports = (api, options) => {
       resolveModule('cypress/bin/cypress', __dirname)
     const runner = execa(cypressBinPath, cyArgs, { stdio: 'inherit' })
     if (server) {
-      runner.on('exit', () => server.close())
-      runner.on('error', () => server.close())
+      runner.on('exit', () => server.stop())
+      runner.on('error', () => server.stop())
     }
 
     if (process.env.VUE_CLI_TEST) {

--- a/packages/@vue/cli-plugin-e2e-nightwatch/index.js
+++ b/packages/@vue/cli-plugin-e2e-nightwatch/index.js
@@ -80,8 +80,8 @@ module.exports = (api, options) => {
       const nightWatchBinPath = require.resolve('nightwatch/bin/nightwatch')
       const runner = execa(nightWatchBinPath, rawArgs, { stdio: 'inherit' })
       if (server) {
-        runner.on('exit', () => server.close())
-        runner.on('error', () => server.close())
+        runner.on('exit', () => server.stop())
+        runner.on('error', () => server.stop())
       }
 
       if (process.env.VUE_CLI_TEST) {


### PR DESCRIPTION
Due to webpack-dev-server's close() method became deprecated in version v4.0.0, currently vue-cli
is using version ^4.7.3, everytime when cli-plugin-e2e-cypress or cli-plugin-e2e-nightwatch ran any
tests a deprecation warning appeared. From now on method stop() is called instead of close() as
advised by the deprecation warning.

close #7157

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
