### PR TITLE
fix: optimize the judgment on whether HTTPS has been set in options

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -103,8 +103,8 @@ module.exports = (api, options) => {
     // resolve server options
     const modesUseHttps = ['https', 'http2']
     const serversUseHttps = ['https', 'spdy']
-    const optionsUseHttps = modesUseHttps.some(modeName => !!projectDevServerOptions[modeName])
-      || (typeof projectDevServerOptions.server === 'string' && serversUseHttps.includes(projectDevServerOptions.server))
+    const optionsUseHttps = modesUseHttps.some(modeName => !!projectDevServerOptions[modeName]) ||
+      (typeof projectDevServerOptions.server === 'string' && serversUseHttps.includes(projectDevServerOptions.server))
     const useHttps = args.https || optionsUseHttps || defaults.https
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -101,7 +101,11 @@ module.exports = (api, options) => {
     }
 
     // resolve server options
-    const useHttps = args.https || projectDevServerOptions.https || defaults.https
+    const modesUseHttps = ['https', 'http2']
+    const serversUseHttps = ['https', 'spdy']
+    const optionsUseHttps = modesUseHttps.some(modeName => !!projectDevServerOptions[modeName])
+      || (typeof projectDevServerOptions.server === 'string' && serversUseHttps.includes(projectDevServerOptions.server))
+    const useHttps = args.https || optionsUseHttps || defaults.https
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host
     portfinder.basePort = args.port || process.env.PORT || projectDevServerOptions.port || defaults.port


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Webpack also provides two configuration items named `http2` and `devServer.server`, if `http2` is set to `true`, the dev server will also start with HTTPS, and it's the same for `devServer.server` is set to `https` or `spdy`.

The current code only judgement whether `projectDevServerOptions.https` is a truthy value, this is an inaccurate judgement.

This patch contains changes that cover more cases than the existing code, allowing users to get correct URLs after executing `vue-cli-service serve`.