### PR TITLE
fix: change merge webpack priority rawconfig

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -114,7 +114,7 @@ module.exports = (api, { entry, name, formats, filename, 'inline-vue': inlineVue
       [entryName]: realEntry
     }
 
-    rawConfig.output = Object.assign({
+    rawConfig.output = Object.assign(rawConfig.output, {
       library: libName,
       libraryExport: isVueEntry ? 'default' : undefined,
       libraryTarget: format,
@@ -123,7 +123,7 @@ module.exports = (api, { entry, name, formats, filename, 'inline-vue': inlineVue
       // https://github.com/webpack/webpack/issues/6522
       // https://github.com/webpack/webpack/issues/6525
       globalObject: `(typeof self !== 'undefined' ? self : this)`
-    }, rawConfig.output, {
+    }, {
       filename: `${entryName}.js`,
       chunkFilename: `${entryName}.[name].js`,
       // use dynamic publicPath so this can be deployed anywhere


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
when I will use command:
vue-cli-service build --target lib --name myLib [entry]

entry is *.vue

and vue.config.js has webpack config：

config.output.set('library', 'otherLib')

now: the webpack output library will priority myLib

expected result：Command priority webpack config library