### PR TITLE
fix: add "devServer.server.type" to "useHttps" judgement

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -108,7 +108,8 @@ module.exports = (api, options) => {
     const modesUseHttps = ['https', 'http2']
     const serversUseHttps = ['https', 'spdy']
     const optionsUseHttps = modesUseHttps.some(modeName => !!projectDevServerOptions[modeName]) ||
-      (typeof projectDevServerOptions.server === 'string' && serversUseHttps.includes(projectDevServerOptions.server))
+      (typeof projectDevServerOptions.server === 'string' && serversUseHttps.includes(projectDevServerOptions.server)) ||
+      (typeof projectDevServerOptions.server === 'object' && projectDevServerOptions.server !== null && serversUseHttps.includes(projectDevServerOptions.server.type))
     const useHttps = args.https || optionsUseHttps || defaults.https
     const protocol = useHttps ? 'https' : 'http'
     const host = args.host || process.env.HOST || projectDevServerOptions.host || defaults.host


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

In the recent merged Pull Request #7202 which authored by me, the fixed judgement expression is not perfect, it should also consider the `devServer.server.type` because it can be an `object`.

This patch add another judgement expression to cover this case, if user set `devServer.server.type` to `https` or `spdy`, the `protocol` will be `https`.