### PR TITLE
fix(SafariNomoduleFixPlugin):to solve the publicPath with the protocol missing a "/" character

### DIFF
--- a/packages/@vue/cli-service/__tests__/safeJoinPublicPath.spec.js
+++ b/packages/@vue/cli-service/__tests__/safeJoinPublicPath.spec.js
@@ -1,0 +1,19 @@
+jest.setTimeout(10000)
+
+test('test safeJoinPublicPath', () => {
+  const safeJoinPublicPath = require('../lib/util/safeJoinPublicPath')
+
+  expect(safeJoinPublicPath('./', '/js/safari-nomodule-fix.js')).toBe('js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('./relative', '/js/safari-nomodule-fix.js')).toBe('relative/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('./relative/path/to', '/js/safari-nomodule-fix.js')).toBe('relative/path/to/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('relative', '/js/safari-nomodule-fix.js')).toBe('relative/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('relative/path/to', '/js/safari-nomodule-fix.js')).toBe('relative/path/to/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('/relative', '/js/safari-nomodule-fix.js')).toBe('/relative/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('/relative/path/to', '/js/safari-nomodule-fix.js')).toBe('/relative/path/to/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('http://example.com', '/js/safari-nomodule-fix.js')).toBe('http://example.com/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('http://example.com/relative', '/js/safari-nomodule-fix.js')).toBe('http://example.com/relative/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('http://example.com/relative/path/to', '/js/safari-nomodule-fix.js')).toBe('http://example.com/relative/path/to/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('//example.com', '/js/safari-nomodule-fix.js')).toBe('//example.com/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('//example.com/relative', '/js/safari-nomodule-fix.js')).toBe('//example.com/relative/js/safari-nomodule-fix.js')
+  expect(safeJoinPublicPath('//example.com/relative/path/to', '/js/safari-nomodule-fix.js')).toBe('//example.com/relative/path/to/js/safari-nomodule-fix.js')
+})

--- a/packages/@vue/cli-service/lib/util/safeJoinPublicPath.js
+++ b/packages/@vue/cli-service/lib/util/safeJoinPublicPath.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('path').posix
 
 module.exports = function safeJoinPublicPath (publicPath, joinPath) {
   let urlPath = publicPath

--- a/packages/@vue/cli-service/lib/util/safeJoinPublicPath.js
+++ b/packages/@vue/cli-service/lib/util/safeJoinPublicPath.js
@@ -1,0 +1,15 @@
+const path = require('path')
+
+module.exports = function safeJoinPublicPath (publicPath, joinPath) {
+  let urlPath = publicPath
+  let pathPrefix = ''
+  if (/:\/\//.test(urlPath)) {
+  // publicPath like http://example.com/path/to/
+    [pathPrefix, urlPath] = urlPath.split('://')
+    pathPrefix = `${pathPrefix}://`
+  } else if (/^\/\//.test(urlPath)) {
+  // publicPath like //example.com/path/to/
+    pathPrefix = '/'
+  }
+  return `${pathPrefix}${path.join(urlPath, joinPath)}`
+}

--- a/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
@@ -41,8 +41,14 @@ class SafariNomoduleFixPlugin {
           }
         } else {
           // inject the fix as an external script
+          let urlPath = compilation.options.output.publicPath
+          let protocol = ''
+          if (/:\/\//.test(urlPath)) {
+            [protocol, urlPath] = urlPath.split('://')
+            protocol = `${protocol}://`
+          }
           const safariFixPath = path.join(this.jsDirectory, 'safari-nomodule-fix.js')
-          const fullSafariFixPath = path.join(compilation.options.output.publicPath, safariFixPath)
+          const fullSafariFixPath = `${protocol}${path.join(urlPath, safariFixPath)}`
           compilation.assets[safariFixPath] = new RawSource(safariFix)
           scriptTag = {
             tagName: 'script',

--- a/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
+++ b/packages/@vue/cli-service/lib/webpack/SafariNomoduleFixPlugin.js
@@ -5,6 +5,7 @@ const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const { semver } = require('@vue/cli-shared-utils')
 const { projectModuleTargets } = require('../util/targets')
+const safeJoinPublicPath = require('../util/safeJoinPublicPath')
 
 const minSafariVersion = projectModuleTargets.safari
 const minIOSVersion = projectModuleTargets.ios
@@ -41,14 +42,8 @@ class SafariNomoduleFixPlugin {
           }
         } else {
           // inject the fix as an external script
-          let urlPath = compilation.options.output.publicPath
-          let protocol = ''
-          if (/:\/\//.test(urlPath)) {
-            [protocol, urlPath] = urlPath.split('://')
-            protocol = `${protocol}://`
-          }
           const safariFixPath = path.join(this.jsDirectory, 'safari-nomodule-fix.js')
-          const fullSafariFixPath = `${protocol}${path.join(urlPath, safariFixPath)}`
+          const fullSafariFixPath = safeJoinPublicPath(compilation.options.output.publicPath, safariFixPath)
           compilation.assets[safariFixPath] = new RawSource(safariFix)
           scriptTag = {
             tagName: 'script',


### PR DESCRIPTION
When using the publicPath option, if you use https:// or http://, the resulting fullSafariFixPath will be missing a /character (e.g. `http://example.com/...` will become `http:/example.com...`) This is commit to fix this issue.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
To solve https://github.com/vuejs/vue-cli/issues/6594