### PR TITLE
fix: Cypress plugin stop error

### DIFF
--- a/packages/@vue/cli-plugin-e2e-cypress/index.js
+++ b/packages/@vue/cli-plugin-e2e-cypress/index.js
@@ -46,8 +46,8 @@ module.exports = (api, options) => {
 
     const runner = execa(cypressBinPath, cyArgs, { stdio: 'inherit' })
     if (server) {
-      runner.on('exit', () => server.stop())
-      runner.on('error', () => server.stop())
+      runner.on('exit', () => server.close())
+      runner.on('error', () => server.close())
     }
 
     if (process.env.VUE_CLI_TEST) {


### PR DESCRIPTION
When running tests with cypress plugin and Cypress 10, an exception is thrown when the stop() function is called to stop the server.
Changing method to close() doesn't throw any exception or warning and the server gets closed correctly.
https://github.com/vuejs/vue-cli/issues/7230

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

