### PR TITLE
Detect cgroup v2 on "checkInContainer"

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -370,7 +370,9 @@ function checkInContainer () {
   }
   const fs = require('fs')
   // Detect cgroup v2 - https://unix.stackexchange.com/a/668244
-  if (fs.existsSync(`/sys/fs/cgroup/cgroup.controllers`)) { return true }
+  if (fs.existsSync(`/sys/fs/cgroup/cgroup.controllers`)) {
+    return fs.existsSync(`/.dockerenv`)
+  }
 
   // Detect cgroup v1
   if (fs.existsSync(`/proc/1/cgroup`)) {

--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -369,6 +369,10 @@ function checkInContainer () {
     return true
   }
   const fs = require('fs')
+  // Detect cgroup v2 - https://unix.stackexchange.com/a/668244
+  if (fs.existsSync(`/sys/fs/cgroup/cgroup.controllers`)) { return true }
+
+  // Detect cgroup v1
   if (fs.existsSync(`/proc/1/cgroup`)) {
     const content = fs.readFileSync(`/proc/1/cgroup`, 'utf-8')
     return /:\/(lxc|docker|kubepods(\.slice)?)\//.test(content)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**Problem:**
Updates from Ubuntu 20.xx to 22.xx break a frontend running inside a docker.

**Other information:**
Ubuntu 22.04 released April 21, 2022 use new config for systemd `systemd.unified_cgroup_hierarchy=1`. This config changes how docker use users group to v2: https://docs.docker.com/config/containers/runmetrics/#enumerate-cgroups

Right now, vue-cli does not detect cgroup v2, and this PR aims to detect a new cgroup config based on the existence of file `/sys/fs/cgroup/cgroup.controllers`.