### PR TITLE
Update deployment.md

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -134,6 +134,7 @@ pages: # the job must be named pages
     - mv dist public # rename the dist folder (result of npm run build)
     # optionally, you can activate gzip support with the following line:
     - find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec gzip -f -k {} \;
+    - cp public/index.html public/404.html # without this, reloading on a route other than root throws error 404
   artifacts:
     paths:
       - public # artifact path must be /public for GitLab Pages to pick it up


### PR DESCRIPTION
added a command to make a copy of index.html and name it 404.html. Without this, if a reload is done on a route other than the root throws a 404 error on GitLab

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
