### PR TITLE
fix: vue build should allowUnknownOption

### DIFF
--- a/packages/@vue/cli/bin/vue.js
+++ b/packages/@vue/cli/bin/vue.js
@@ -110,6 +110,7 @@ program
 program
   .command('build')
   .description('alias of "npm run build" in the current project')
+  .allowUnknownOption()
   .action((cmd) => {
     require('../lib/util/runNpmScript')('build', process.argv.slice(3))
   })


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

![image](https://github.com/vuejs/vue-cli/assets/32624612/41527088-de9f-472c-9c4e-dcfebaf5ca6f)
The Command `vue build`, which is the alias of `vue-cli-service build`, should allowUnknownOption.